### PR TITLE
feat(un-es6-class): support methods in Babel loose mode

### DIFF
--- a/packages/unminify/src/transformations/__tests__/un-es6-class.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-es6-class.spec.ts
@@ -57,6 +57,31 @@ class Foo {
 `,
 )
 
+inlineTest('Babel loose class declaration',
+`
+var C = /*#__PURE__*/function () {
+  function C() {
+    this.field = 1;
+  }
+  var _proto = C.prototype;
+  _proto.doSomething = function doSomething() {
+    console.log(this.field);
+  };
+  return C;
+}();
+`,
+`
+class C {
+  constructor() {
+    this.field = 1;
+  }
+
+  doSomething() {
+    console.log(this.field);
+  }
+}
+`)
+
 inlineTest.todo('ultimate class declaration',
 `
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {


### PR DESCRIPTION
Input:

```js
var C = /*#__PURE__*/function () {
  function C() {
    this.field = 1;
  }
  var _proto = C.prototype;
  _proto.doSomething = function doSomething() {
    console.log(this.field);
  };
  return C;
}();
```

Output:

```js
class C {
  constructor() {
    this.field = 1;
  }

  doSomething() {
    console.log(this.field);
  }
}
```

Getters/setters compilation result is different from class methods, so this PR is only for class methods.