### PR TITLE
feat(un-es6-class): support extending super class

### DIFF
--- a/packages/unminify/src/transformations/__tests__/un-es6-class.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-es6-class.spec.ts
@@ -82,6 +82,88 @@ class C {
 }
 `)
 
+inlineTest('extend super class',
+`
+var BabelSuperClass = /*#__PURE__*/_createClass(function BabelSuperClass() {
+    _classCallCheck(this, BabelSuperClass);
+});
+var BabelSubClass = /*#__PURE__*/function (_BabelSuperClass) {
+    _inherits(BabelSubClass, _BabelSuperClass);
+    var _super = _createSuper(BabelSubClass);
+    function BabelSubClass() {
+        var _this;
+        _classCallCheck(this, BabelSubClass);
+        return _possibleConstructorReturn(_this);
+    }
+    return _createClass(BabelSubClass);
+}(BabelSuperClass);
+
+var SwcSuperClass = function SwcSuperClass() {
+    "use strict";
+    _class_call_check(this, SwcSuperClass);
+};
+var SwcSubClass = /*#__PURE__*/ function(SwcSuperClass) {
+    "use strict";
+    _inherits(SwcSubClass, SwcSuperClass);
+    var _super = _create_super(SwcSubClass);
+    function SwcSubClass() {
+        _class_call_check(this, SwcSubClass);
+        var _this;
+        return _possible_constructor_return(_this);
+    }
+    return SwcSubClass;
+}(SwcSuperClass);
+
+var TsSuperClass = /** @class */ (function () {
+    function TsSuperClass() {
+    }
+    return TsSuperClass;
+}());
+var TsSubClass = /** @class */ (function (_super) {
+    __extends(TsSubClass, _super);
+    function TsSubClass() {
+        var _this = this;
+        return _this;
+    }
+    return TsSubClass;
+}(TsSuperClass));
+`,
+`
+var BabelSuperClass = /*#__PURE__*/_createClass(function BabelSuperClass() {
+    _classCallCheck(this, BabelSuperClass);
+});
+
+class BabelSubClass extends BabelSuperClass {
+    constructor() {
+        var _this;
+        _classCallCheck(this, BabelSubClass);
+        return _possibleConstructorReturn(_this);
+    }
+}
+
+var SwcSuperClass = function SwcSuperClass() {
+    "use strict";
+    _class_call_check(this, SwcSuperClass);
+};
+
+class SwcSubClass extends SwcSuperClass {
+    constructor() {
+        _class_call_check(this, SwcSubClass);
+        var _this;
+        return _possible_constructor_return(_this);
+    }
+}
+
+class TsSuperClass {}
+
+class TsSubClass extends TsSuperClass {
+    constructor() {
+        var _this = this;
+        return _this;
+    }
+}
+`)
+
 inlineTest.todo('ultimate class declaration',
 `
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/packages/unminify/src/transformations/__tests__/un-es6-class.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-es6-class.spec.ts
@@ -84,6 +84,8 @@ class C {
 
 inlineTest('extend super class',
 `
+import babelInherits from "@babel/runtime/helpers/inherits";
+
 var BabelSuperClass = /*#__PURE__*/_createClass(function BabelSuperClass() {
     _classCallCheck(this, BabelSuperClass);
 });
@@ -97,6 +99,20 @@ var BabelSubClass = /*#__PURE__*/function (_BabelSuperClass) {
     }
     return _createClass(BabelSubClass);
 }(BabelSuperClass);
+
+var BabelSuperClass2 = /*#__PURE__*/_createClass(function BabelSuperClass2() {
+    _classCallCheck(this, BabelSuperClass2);
+});
+var BabelSubClass2 = /*#__PURE__*/function (_BabelSuperClass2) {
+    babelInherits(BabelSubClass2, _BabelSuperClass2);
+    var _super = _createSuper(BabelSubClass2);
+    function BabelSubClass2() {
+        var _this;
+        _classCallCheck(this, BabelSubClass2);
+        return _possibleConstructorReturn(_this);
+    }
+    return _createClass(BabelSubClass2);
+}(BabelSuperClass2);
 
 var SwcSuperClass = function SwcSuperClass() {
     "use strict";
@@ -137,6 +153,18 @@ class BabelSubClass extends BabelSuperClass {
     constructor() {
         var _this;
         _classCallCheck(this, BabelSubClass);
+        return _possibleConstructorReturn(_this);
+    }
+}
+
+var BabelSuperClass2 = /*#__PURE__*/_createClass(function BabelSuperClass2() {
+    _classCallCheck(this, BabelSuperClass2);
+});
+
+class BabelSubClass2 extends BabelSuperClass2 {
+    constructor() {
+        var _this;
+        _classCallCheck(this, BabelSubClass2);
         return _possibleConstructorReturn(_this);
     }
 }

--- a/packages/unminify/src/transformations/un-es6-class.ts
+++ b/packages/unminify/src/transformations/un-es6-class.ts
@@ -1,10 +1,10 @@
 import { findReferences } from '@wakaru/ast-utils'
+import { findHelperLocals, removeHelperImport } from '../utils/import'
 import wrap from '../wrapAstTransformation'
 import type { ASTTransformation } from '../wrapAstTransformation'
 import type { ExpressionKind } from 'ast-types/lib/gen/kinds'
 import type { Scope } from 'ast-types/lib/scope'
 import type { AssignmentExpression, CallExpression, ExpressionStatement, FunctionExpression, Identifier, MemberExpression, VariableDeclarator } from 'jscodeshift'
-import { findHelperLocals, removeHelperImport } from '../utils/import'
 
 const inheritsModuleName = '@babel/runtime/helpers/inherits'
 const inheritsModuleEsmName = '@babel/runtime/helpers/esm/inherits'
@@ -356,7 +356,7 @@ export const transformAST: ASTTransformation = (context, params) => {
 
     inheritsHelpers
         .filter(helperLocal => findReferences(j, rootScope, helperLocal).length === 1)
-        .forEach(helperLocal => {
+        .forEach((helperLocal) => {
             removeHelperImport(j, rootScope, helperLocal)
         })
 }


### PR DESCRIPTION
This PR only handles extending class (`class C extends B {}`) but doesn't handle `super()` call. `super()` call should be solved in separated PR.