### PR TITLE
feat: integrate `ast-grep`

### DIFF
--- a/benches/un-undefined.ts
+++ b/benches/un-undefined.ts
@@ -16,10 +16,16 @@ void 99;
 const main = async () => {
     await suite(
         title,
+        ...([10, 100, 1000].map((count) => {
+            const source = snippet.repeat(count)
+            return add(`jscodeshift=${count}`, async () => {
+                await runTransformationRules({ path: '', source }, [title])
+            })
+        })),
         ...([10, 100, 1000, 5000].map((count) => {
             const source = snippet.repeat(count)
-            return add(`items=${count}`, async () => {
-                await runTransformationRules({ path: '', source }, [title])
+            return add(`ast-grep=${count}`, async () => {
+                await runTransformationRules({ path: '', source }, [`${title}.grep`])
             })
         })),
         cycle(),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "lint:fix": "eslint src --fix"
   },
   "dependencies": {
+    "@ast-grep/napi": "^0.18.1",
     "fs-extra": "^11.2.0",
     "globby": "^11.1.0",
     "picocolors": "^1.0.0",

--- a/packages/cli/src/unminify.worker.ts
+++ b/packages/cli/src/unminify.worker.ts
@@ -1,9 +1,11 @@
 /* eslint-disable no-console */
-import { runDefaultTransformationRules } from '@wakaru/unminify'
+import { runTransformationRules, transformationRulesForCLI } from '@wakaru/unminify'
 import fsa from 'fs-extra'
 import { ThreadWorker } from 'poolifier'
 import type { UnminifyWorkerParams } from './types'
 import type { Timing } from '@wakaru/shared/timing'
+
+const ruleIds = transformationRulesForCLI.map(rule => rule.id)
 
 export async function unminify(data?: UnminifyWorkerParams) {
     if (!data) throw new Error('No data received')
@@ -13,7 +15,7 @@ export async function unminify(data?: UnminifyWorkerParams) {
         const source = await fsa.readFile(inputPath, 'utf-8')
         const fileInfo = { path: inputPath, source }
 
-        const { code, timing } = await runDefaultTransformationRules(fileInfo, { moduleMeta, moduleMapping })
+        const { code, timing } = await runTransformationRules(fileInfo, ruleIds, { moduleMeta, moduleMapping })
         await fsa.ensureFile(outputPath)
         await fsa.writeFile(outputPath, code, 'utf-8')
 

--- a/packages/cli/src/unminify.worker.ts
+++ b/packages/cli/src/unminify.worker.ts
@@ -1,11 +1,9 @@
 /* eslint-disable no-console */
-import { runTransformationRules, transformationRulesForCLI } from '@wakaru/unminify'
+import { runTransformationRules, transformationRuleIds } from '@wakaru/unminify/nodejs'
 import fsa from 'fs-extra'
 import { ThreadWorker } from 'poolifier'
 import type { UnminifyWorkerParams } from './types'
 import type { Timing } from '@wakaru/shared/timing'
-
-const ruleIds = transformationRulesForCLI.map(rule => rule.id)
 
 export async function unminify(data?: UnminifyWorkerParams) {
     if (!data) throw new Error('No data received')
@@ -15,7 +13,7 @@ export async function unminify(data?: UnminifyWorkerParams) {
         const source = await fsa.readFile(inputPath, 'utf-8')
         const fileInfo = { path: inputPath, source }
 
-        const { code, timing } = await runTransformationRules(fileInfo, ruleIds, { moduleMeta, moduleMapping })
+        const { code, timing } = await runTransformationRules(fileInfo, transformationRuleIds, { moduleMeta, moduleMapping })
         await fsa.ensureFile(outputPath)
         await fsa.writeFile(outputPath, code, 'utf-8')
 

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
         'process.env.NODE_DEBUG': 'undefined',
     },
     minify: true,
+    external: [
+        '@ast-grep/napi',
+    ],
     noExternal: [
         'jscodeshift',
         'ast-types',

--- a/packages/playground/src/atoms/rule.ts
+++ b/packages/playground/src/atoms/rule.ts
@@ -1,4 +1,4 @@
-import { transformationRules } from '@wakaru/unminify'
+import { transformationRuleIds, transformationRules } from '@wakaru/unminify'
 import { atom } from 'jotai/vanilla'
 import { atomWithStorage } from 'jotai/vanilla/utils'
 import { KEY_DISABLED_RULES, KEY_RULE_ORDER } from '../const'
@@ -11,7 +11,7 @@ export const prettifyRules = [
 
 export const allRulesAtom = atom(() => transformationRules)
 
-export const ruleOrderAtom = atomWithStorage<string[]>(KEY_RULE_ORDER, transformationRules.map(rule => rule.id))
+export const ruleOrderAtom = atomWithStorage<string[]>(KEY_RULE_ORDER, transformationRuleIds)
 
 export const orderedRulesAtom = atom((get) => {
     const ruleOrder = get(ruleOrderAtom)
@@ -57,5 +57,5 @@ export const toggleRuleAtom = atom(null, (get, set, ruleId: string) => {
 
 export const resetRulesAtom = atom(null, (_get, set) => {
     set(disabledRuleIdsAtom, [])
-    set(ruleOrderAtom, transformationRules.map(rule => rule.id))
+    set(ruleOrderAtom, transformationRuleIds)
 })

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "exports": {
     "./array": "./src/array.ts",
+    "./astGrepRule": "./src/astGrepRule.ts",
     "./jscodeshift": "./src/jscodeshift.ts",
     "./rule": "./src/rule.ts",
     "./runner": "./src/runner.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -37,8 +37,8 @@
     "@types/jscodeshift": "^0.11.11",
     "ast-types": "^0.16.1",
     "jscodeshift": "^0.15.2",
-    "typescript": "^5.3.3",
     "magic-string": "^0.30.5",
+    "typescript": "^5.3.3",
     "zod": "^3.22.4"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,10 +33,12 @@
     "pathe": "^1.1.2"
   },
   "devDependencies": {
+    "@ast-grep/napi": "^0.18.1",
     "@types/jscodeshift": "^0.11.11",
     "ast-types": "^0.16.1",
     "jscodeshift": "^0.15.2",
     "typescript": "^5.3.3",
+    "magic-string": "^0.30.5",
     "zod": "^3.22.4"
   }
 }

--- a/packages/shared/src/astGrepRule.ts
+++ b/packages/shared/src/astGrepRule.ts
@@ -1,0 +1,102 @@
+import { type SgNode, js } from '@ast-grep/napi'
+import MagicString from 'magic-string'
+import type { BaseTransformationRule } from './rule'
+import type { Transform } from 'jscodeshift'
+import type { ZodSchema, z } from 'zod'
+
+export type AstGrepTransformation<Schema extends ZodSchema = ZodSchema> = (root: SgNode, s: MagicString, params: z.infer<Schema>) => MagicString | void
+
+export class AstGrepTransformationRule<Schema extends ZodSchema = ZodSchema> implements BaseTransformationRule {
+    type = 'ast-grep' as const
+
+    id: string
+
+    name: string
+
+    tags: string[]
+
+    schema?: ZodSchema
+
+    transform: AstGrepTransformation<Schema>
+
+    constructor({
+        name, tags = [], transform, schema,
+    }: {
+        name: string
+        tags?: string[]
+        transform: AstGrepTransformation<Schema>
+        schema?: ZodSchema
+    },
+    ) {
+        this.id = name
+        this.name = name
+        this.tags = tags
+        this.transform = transform
+        this.schema = schema
+    }
+
+    execute({
+        source, filename, params,
+    }: {
+        source: string
+        filename: string
+        params: z.infer<Schema>
+    }) {
+        try {
+            const ast = js.parse(source)
+            const root = ast.root()
+            const s = new MagicString(source)
+            const resultS = this.transform(root, s, params)
+            return resultS ? resultS.toString() : source
+        }
+        catch (err: any) {
+            console.error(`\nError running rule ${this.name} on ${filename}`, err)
+            return source
+        }
+    }
+
+    toJSCodeshiftTransform(): Transform {
+        const transform: Transform = (file, _api, options) => {
+            const { source } = file
+            const params = options as z.infer<Schema>
+            return this.execute({ source, filename: file.path, params })
+        }
+        return transform
+    }
+
+    withId(id: string) {
+        const rule = this.clone()
+        rule.id = id
+        return rule
+    }
+
+    private clone() {
+        return new AstGrepTransformationRule({
+            name: this.name,
+            tags: this.tags,
+            transform: this.transform,
+            schema: this.schema,
+        })
+    }
+}
+
+export const createAstGrepTransformationRule = <Schema extends ZodSchema = ZodSchema>(
+    {
+        name,
+        tags = [],
+        transform,
+        schema,
+    }: {
+        name: string
+        tags?: string[]
+        transform: AstGrepTransformation<Schema>
+        schema?: ZodSchema
+    },
+): AstGrepTransformationRule<Schema> => {
+    return new AstGrepTransformationRule({
+        name,
+        tags,
+        transform,
+        schema,
+    })
+}

--- a/packages/shared/src/rule.ts
+++ b/packages/shared/src/rule.ts
@@ -5,7 +5,6 @@ import type { ModuleMapping, ModuleMeta } from './types'
 import type { API, FileInfo, Options } from 'jscodeshift'
 import type { ZodSchema } from 'zod'
 
-export * from './astGrepRule'
 export * from './jscodeshiftRule'
 export * from './stringRule'
 

--- a/packages/shared/src/rule.ts
+++ b/packages/shared/src/rule.ts
@@ -1,9 +1,11 @@
+import type { AstGrepTransformationRule } from './astGrepRule'
 import type { JSCodeshiftTransformationRule } from './jscodeshiftRule'
 import type { StringTransformationRule } from './stringRule'
 import type { ModuleMapping, ModuleMeta } from './types'
 import type { API, FileInfo, Options } from 'jscodeshift'
 import type { ZodSchema } from 'zod'
 
+export * from './astGrepRule'
 export * from './jscodeshiftRule'
 export * from './stringRule'
 
@@ -28,7 +30,7 @@ export interface JSCodeshiftTransform {
 }
 
 export interface BaseTransformationRule {
-    type: 'jscodeshift' | 'string' | 'rule-set'
+    type: 'jscodeshift' | 'string' | 'ast-grep' | 'rule-set'
     /**
      * The unique id of the rule
      */
@@ -55,6 +57,7 @@ export interface BaseTransformationRule {
 export type TransformationRule<Schema extends ZodSchema = ZodSchema> =
     | JSCodeshiftTransformationRule<Schema>
     | StringTransformationRule<Schema>
+    | AstGrepTransformationRule<Schema>
     | MergedTransformationRule
 
 export class MergedTransformationRule implements BaseTransformationRule {

--- a/packages/shared/src/runner.ts
+++ b/packages/shared/src/runner.ts
@@ -79,6 +79,26 @@ export async function executeTransformationRules<P extends Record<string, any>>(
                 currentRoot = null
                 break
             }
+            case 'ast-grep': {
+                const stopMeasure1 = timing.startMeasure(filePath, 'jscodeshift-print')
+                currentSource ??= currentRoot?.toSource() ?? source
+                stopMeasure1()
+
+                try {
+                    const stopMeasure2 = timing.startMeasure(filePath, rule.id)
+                    currentSource = rule.execute({
+                        source: currentSource,
+                        filename: filePath,
+                        params,
+                    }) ?? currentSource
+                    stopMeasure2()
+                }
+                catch (err: any) {
+                    console.error(`\nError running rule ${rule.id} on ${filePath}`, err)
+                }
+                currentRoot = null
+                break
+            }
             default: {
                 throw new Error(`Unsupported rule type ${rule.type} from ${rule.id}`)
             }

--- a/packages/unminify/package.json
+++ b/packages/unminify/package.json
@@ -6,6 +6,10 @@
   "author": "Pionxzh",
   "license": "MIT",
   "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./nodejs": "./src/nodejs.ts"
+  },
   "main": "src/index.ts",
   "bin": "dist/cli.cjs",
   "files": [

--- a/packages/unminify/src/nodejs.ts
+++ b/packages/unminify/src/nodejs.ts
@@ -1,6 +1,6 @@
 import { nonNullable } from '@wakaru/shared/array'
 import { executeTransformationRules } from '@wakaru/shared/runner'
-import { transformationRules } from './transformations'
+import { transformationRules } from './transformations/node'
 import type { FileInfo } from 'jscodeshift'
 
 export { transformationRules, transformationRuleIds } from './transformations'

--- a/packages/unminify/src/transformations/__tests__/un-boolean.grep.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-boolean.grep.spec.ts
@@ -1,0 +1,23 @@
+import { defineInlineTest } from '@wakaru/test-utils'
+import transform from '../un-boolean.grep'
+
+const inlineTest = defineInlineTest(transform)
+
+inlineTest('transform !0 to true and !1 to false',
+  `
+let a = !1;
+const b = !0;
+
+var obj = {
+  value: !0
+};
+`,
+  `
+let a = false;
+const b = true;
+
+var obj = {
+  value: true
+};
+`,
+)

--- a/packages/unminify/src/transformations/__tests__/un-esmodule-flag.grep.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-esmodule-flag.grep.spec.ts
@@ -1,0 +1,30 @@
+import { defineInlineTest } from '@wakaru/test-utils'
+import transform from '../un-esmodule-flag.grep'
+
+const inlineTest = defineInlineTest(transform)
+
+inlineTest('remove es module helper from ES5+',
+  `
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+Object.defineProperty(module.exports, "__esModule", {
+  value: !0
+});
+`,
+  `
+`,
+)
+
+inlineTest('remove es module helper from ES3',
+  `
+exports.__esModule = !0;
+exports.__esModule = true;
+exports["__esModule"] = true;
+module.exports.__esModule = !0;
+module.exports.__esModule = true;
+module.exports["__esModule"] = true;
+`,
+  `
+`,
+)

--- a/packages/unminify/src/transformations/__tests__/un-infinity.grep.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-infinity.grep.spec.ts
@@ -1,0 +1,37 @@
+import { defineInlineTest } from '@wakaru/test-utils'
+import transform from '../un-infinity.grep'
+
+const inlineTest = defineInlineTest(transform)
+
+inlineTest('transform {number} / 0 to Infinity',
+  `
+0 / 0;
+1 / 0;
+-1 / 0;
+99 / 0;
+
+'0' / 0;
+'1' / 0;
+'-1' / 0;
+'99' / 0;
+
+x / 0;
+
+[0 / 0, 1 / 0]
+`,
+  `
+0 / 0;
+Infinity;
+-Infinity;
+99 / 0;
+
+'0' / 0;
+'1' / 0;
+'-1' / 0;
+'99' / 0;
+
+x / 0;
+
+[0 / 0, Infinity]
+`,
+)

--- a/packages/unminify/src/transformations/__tests__/un-undefined.grep.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-undefined.grep.spec.ts
@@ -1,0 +1,66 @@
+import { defineInlineTest } from '@wakaru/test-utils'
+import transform from '../un-undefined.grep'
+
+const inlineTest = defineInlineTest(transform)
+
+inlineTest('transform void 0 to undefined',
+  `
+if(void 0 !== a) {
+  console.log('a')
+}
+`,
+  `
+if(undefined !== a) {
+  console.log('a')
+}
+`,
+)
+
+inlineTest('transform void literal to undefined',
+  `
+void 0
+void 99
+void(0)
+`,
+  `
+undefined
+undefined
+undefined
+`,
+)
+
+inlineTest('should not transform void function call',
+  `
+void function() {
+  console.log('a')
+  return void a()
+}
+`,
+  `
+void function() {
+  console.log('a')
+  return void a()
+}
+`,
+)
+
+inlineTest.fixme('should not transform when undefined is declared in scope',
+  `
+var undefined = 42;
+
+console.log(void 0);
+
+if (undefined !== a) {
+  console.log('a', void 0);
+}
+`,
+  `
+var undefined = 42;
+
+console.log(void 0);
+
+if (undefined !== a) {
+  console.log('a', void 0);
+}
+`,
+)

--- a/packages/unminify/src/transformations/__tests__/un-use-stict.grep.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-use-stict.grep.spec.ts
@@ -1,0 +1,33 @@
+import { defineInlineTest } from '@wakaru/test-utils'
+import transform from '../un-use-strict.grep'
+
+const inlineTest = defineInlineTest(transform)
+
+inlineTest('remove \'use strict\'',
+  `
+'use strict'
+`,
+  `
+`,
+)
+
+inlineTest('remove \'use strict\' with comments',
+  `
+// comment
+// another comment
+'use strict'
+function foo(str) {
+  'use strict'
+  return str === 'use strict'
+}
+`,
+  `
+// comment
+// another comment
+
+function foo(str) {
+
+  return str === 'use strict'
+}
+`,
+)

--- a/packages/unminify/src/transformations/index.ts
+++ b/packages/unminify/src/transformations/index.ts
@@ -17,6 +17,7 @@ import unEnum from './un-enum'
 import unES6Class from './un-es6-class'
 import unEsm from './un-esm'
 import unEsModuleFlag from './un-esmodule-flag'
+import unEsmoduleFlagGrep from './un-esmodule-flag.grep'
 import unExportRename from './un-export-rename'
 import unFlipComparisons from './un-flip-comparisons'
 import unIife from './un-iife'
@@ -46,7 +47,7 @@ import type { TransformationRule } from '@wakaru/shared/rule'
 export const transformationRules: TransformationRule[] = [
     // first stage - basically prettify the code
     prettier.withId('prettier'),
-    moduleMapping,
+    moduleMapping, // grep
     unCurlyBraces, // add curly braces so that other transformations can works easier, but generally this is not required
     unSequenceExpression, // curly braces can bring out return sequence expression, so it runs before this
     unVariableMerging,
@@ -59,12 +60,12 @@ export const transformationRules: TransformationRule[] = [
 
     // third stage - mostly one-to-one transformation
     lebab,
+    unUseStrict, // grep
+    unBoolean, // grep
+    unUndefined, // grep
+    unInfinity, // grep
+    unEsModuleFlag, // grep
     unExportRename, // relies on `un-esm` to give us the export statements, and this can break some rules from `lebab`
-    unUseStrict,
-    unEsModuleFlag,
-    unBoolean,
-    unUndefined,
-    unInfinity,
     unTypeof,
     unNumericLiteral,
     unTemplateLiteral,
@@ -97,11 +98,12 @@ export const transformationRules: TransformationRule[] = [
 ]
 
 const astGrepRules: TransformationRule[] = [
-    unUseStrictGrep,
-    unUndefinedGrep,
     moduleMappingGrep,
-    unInfinityGrep,
+    unUseStrictGrep,
+    unEsmoduleFlagGrep,
     unBooleanGrep,
+    unUndefinedGrep,
+    unInfinityGrep,
 ]
 
 // replace the transform function in transformationRules with the one from astGrepRules

--- a/packages/unminify/src/transformations/index.ts
+++ b/packages/unminify/src/transformations/index.ts
@@ -1,6 +1,5 @@
 import lebab from './lebab'
 import moduleMapping from './module-mapping'
-import moduleMappingGrep from './module-mapping.grep'
 import prettier from './prettier'
 import smartInline from './smart-inline'
 import smartRename from './smart-rename'
@@ -8,7 +7,6 @@ import unArgumentSpread from './un-argument-spread'
 import unAssignmentMerging from './un-assignment-merging'
 import unAsyncAwait from './un-async-await'
 import unBoolean from './un-boolean'
-import unBooleanGrep from './un-boolean.grep'
 import unBracketNotation from './un-bracket-notation'
 import unBuiltinPrototype from './un-builtin-prototype'
 import unConditionals from './un-conditionals'
@@ -17,14 +15,12 @@ import unEnum from './un-enum'
 import unES6Class from './un-es6-class'
 import unEsm from './un-esm'
 import unEsModuleFlag from './un-esmodule-flag'
-import unEsmoduleFlagGrep from './un-esmodule-flag.grep'
 import unExportRename from './un-export-rename'
 import unFlipComparisons from './un-flip-comparisons'
 import unIife from './un-iife'
 import unImportRename from './un-import-rename'
 import unIndirectCall from './un-indirect-call'
 import unInfinity from './un-infinity'
-import unInfinityGrep from './un-infinity.grep'
 import unJsx from './un-jsx'
 import unNullishCoalescing from './un-nullish-coalescing'
 import unNumericLiteral from './un-numeric-literal'
@@ -37,9 +33,7 @@ import unTemplateLiteral from './un-template-literal'
 import unTypeConstructor from './un-type-constructor'
 import unTypeof from './un-typeof'
 import unUndefined from './un-undefined'
-import unUndefinedGrep from './un-undefined.grep'
 import unUseStrict from './un-use-strict'
-import unUseStrictGrep from './un-use-strict.grep'
 import unVariableMerging from './un-variable-merging'
 import unWhileLoop from './un-while-loop'
 import type { TransformationRule } from '@wakaru/shared/rule'
@@ -47,6 +41,11 @@ import type { TransformationRule } from '@wakaru/shared/rule'
 export const transformationRules: TransformationRule[] = [
     // first stage - basically prettify the code
     prettier.withId('prettier'),
+    unUseStrict, // grep
+    unBoolean, // grep
+    unUndefined, // grep
+    unInfinity, // grep
+    unEsModuleFlag, // grep
     moduleMapping, // grep
     unCurlyBraces, // add curly braces so that other transformations can works easier, but generally this is not required
     unSequenceExpression, // curly braces can bring out return sequence expression, so it runs before this
@@ -60,11 +59,6 @@ export const transformationRules: TransformationRule[] = [
 
     // third stage - mostly one-to-one transformation
     lebab,
-    unUseStrict, // grep
-    unBoolean, // grep
-    unUndefined, // grep
-    unInfinity, // grep
-    unEsModuleFlag, // grep
     unExportRename, // relies on `un-esm` to give us the export statements, and this can break some rules from `lebab`
     unTypeof,
     unNumericLiteral,
@@ -97,17 +91,4 @@ export const transformationRules: TransformationRule[] = [
     prettier.withId('prettier-1'),
 ]
 
-const astGrepRules: TransformationRule[] = [
-    moduleMappingGrep,
-    unUseStrictGrep,
-    unEsmoduleFlagGrep,
-    unBooleanGrep,
-    unUndefinedGrep,
-    unInfinityGrep,
-]
-
-// replace the transform function in transformationRules with the one from astGrepRules
-export const transformationRulesForCLI: TransformationRule[] = transformationRules.map((rule) => {
-    const astGrepRule = astGrepRules.find(r => r.name === rule.name)
-    return astGrepRule ?? rule
-})
+export const transformationRuleIds = transformationRules.map(rule => rule.id)

--- a/packages/unminify/src/transformations/index.ts
+++ b/packages/unminify/src/transformations/index.ts
@@ -1,5 +1,6 @@
 import lebab from './lebab'
 import moduleMapping from './module-mapping'
+import moduleMappingGrep from './module-mapping.grep'
 import prettier from './prettier'
 import smartInline from './smart-inline'
 import smartRename from './smart-rename'
@@ -7,6 +8,7 @@ import unArgumentSpread from './un-argument-spread'
 import unAssignmentMerging from './un-assignment-merging'
 import unAsyncAwait from './un-async-await'
 import unBoolean from './un-boolean'
+import unBooleanGrep from './un-boolean.grep'
 import unBracketNotation from './un-bracket-notation'
 import unBuiltinPrototype from './un-builtin-prototype'
 import unConditionals from './un-conditionals'
@@ -21,6 +23,7 @@ import unIife from './un-iife'
 import unImportRename from './un-import-rename'
 import unIndirectCall from './un-indirect-call'
 import unInfinity from './un-infinity'
+import unInfinityGrep from './un-infinity.grep'
 import unJsx from './un-jsx'
 import unNullishCoalescing from './un-nullish-coalescing'
 import unNumericLiteral from './un-numeric-literal'
@@ -33,7 +36,9 @@ import unTemplateLiteral from './un-template-literal'
 import unTypeConstructor from './un-type-constructor'
 import unTypeof from './un-typeof'
 import unUndefined from './un-undefined'
+import unUndefinedGrep from './un-undefined.grep'
 import unUseStrict from './un-use-strict'
+import unUseStrictGrep from './un-use-strict.grep'
 import unVariableMerging from './un-variable-merging'
 import unWhileLoop from './un-while-loop'
 import type { TransformationRule } from '@wakaru/shared/rule'
@@ -90,3 +95,17 @@ export const transformationRules: TransformationRule[] = [
     // last stage - prettify the code again after we finish all the transformations
     prettier.withId('prettier-1'),
 ]
+
+const astGrepRules: TransformationRule[] = [
+    unUseStrictGrep,
+    unUndefinedGrep,
+    moduleMappingGrep,
+    unInfinityGrep,
+    unBooleanGrep,
+]
+
+// replace the transform function in transformationRules with the one from astGrepRules
+export const transformationRulesForCLI: TransformationRule[] = transformationRules.map((rule) => {
+    const astGrepRule = astGrepRules.find(r => r.name === rule.name)
+    return astGrepRule ?? rule
+})

--- a/packages/unminify/src/transformations/module-mapping.grep.ts
+++ b/packages/unminify/src/transformations/module-mapping.grep.ts
@@ -1,0 +1,36 @@
+import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+
+/**
+ * // params: { 29: 'index.js' }
+ * const a = require(29)
+ * ->
+ * const a = require('index.js')
+ */
+export default createAstGrepTransformationRule({
+    name: 'module-mapping',
+    transform(root, s, params) {
+        const { moduleMapping = {} } = params
+
+        root
+            .findAll({
+                rule: {
+                    pattern: 'require($SOURCE)',
+                },
+            })
+            .forEach((match) => {
+                const node = match.getMatch('SOURCE')
+                if (!node) return
+
+                // key can be a number or a string
+                // we want to remove the quotes from the string
+                const key = node.text().replace(/^['"]|['"]$/g, '')
+                const replacement = moduleMapping[key]
+                if (!replacement) return
+
+                const range = node.range()
+                s.update(range.start.index, range.end.index, `"${replacement}"`)
+            })
+
+        return s
+    },
+})

--- a/packages/unminify/src/transformations/module-mapping.grep.ts
+++ b/packages/unminify/src/transformations/module-mapping.grep.ts
@@ -1,4 +1,4 @@
-import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+import { createAstGrepTransformationRule } from '@wakaru/shared/astGrepRule'
 
 /**
  * // params: { 29: 'index.js' }

--- a/packages/unminify/src/transformations/node.ts
+++ b/packages/unminify/src/transformations/node.ts
@@ -1,0 +1,34 @@
+import moduleMapping from './module-mapping'
+import moduleMappingGrep from './module-mapping.grep'
+import unBoolean from './un-boolean'
+import unBooleanGrep from './un-boolean.grep'
+import unEsmoduleFlag from './un-esmodule-flag'
+import unEsmoduleFlagGrep from './un-esmodule-flag.grep'
+import unInfinity from './un-infinity'
+import unInfinityGrep from './un-infinity.grep'
+import unUndefined from './un-undefined'
+import unUndefinedGrep from './un-undefined.grep'
+import unUseStrict from './un-use-strict'
+import unUseStrictGrep from './un-use-strict.grep'
+import { transformationRules as _transformationRules, transformationRuleIds } from './index'
+import type { TransformationRule } from '@wakaru/shared/rule'
+
+const ruleAlternativesOnNodejs = new Map<TransformationRule, TransformationRule>([
+    [moduleMapping, moduleMappingGrep],
+    [unUseStrict, unUseStrictGrep],
+    [unEsmoduleFlag, unEsmoduleFlagGrep],
+    [unBoolean, unBooleanGrep],
+    [unUndefined, unUndefinedGrep],
+    [unInfinity, unInfinityGrep],
+])
+
+export const transformationRules = _transformationRules.map((rule) => {
+    if (ruleAlternativesOnNodejs.get(rule)) {
+        return ruleAlternativesOnNodejs.get(rule)!
+    }
+    return rule
+})
+
+export {
+    transformationRuleIds,
+}

--- a/packages/unminify/src/transformations/un-boolean.grep.ts
+++ b/packages/unminify/src/transformations/un-boolean.grep.ts
@@ -1,4 +1,4 @@
-import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+import { createAstGrepTransformationRule } from '@wakaru/shared/astGrepRule'
 
 /**
  * Converts minified `boolean` to simple `true`/`false`.

--- a/packages/unminify/src/transformations/un-boolean.grep.ts
+++ b/packages/unminify/src/transformations/un-boolean.grep.ts
@@ -1,0 +1,32 @@
+import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+
+/**
+ * Converts minified `boolean` to simple `true`/`false`.
+ *
+ * @example
+ * !0 -> true
+ * !1 -> false
+ *
+ * @see https://babeljs.io/docs/babel-plugin-transform-minify-booleans
+ * @see Terser: `booleans_as_integers`
+ */
+export default createAstGrepTransformationRule({
+    name: 'un-boolean',
+    transform(root, s) {
+        root
+            .findAll({ rule: { pattern: '!0' } })
+            .forEach((match) => {
+                const range = match.range()
+                s.update(range.start.index, range.end.index, 'true')
+            })
+
+        root
+            .findAll({ rule: { pattern: '!1' } })
+            .forEach((match) => {
+                const range = match.range()
+                s.update(range.start.index, range.end.index, 'false')
+            })
+
+        return s
+    },
+})

--- a/packages/unminify/src/transformations/un-esmodule-flag.grep.ts
+++ b/packages/unminify/src/transformations/un-esmodule-flag.grep.ts
@@ -1,0 +1,59 @@
+import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+
+/**
+ * Removes the `__esModule` flag from the module.
+ *
+ * @example
+ * ```diff
+ * - Object.defineProperty(exports, '__esModule', { value: true })
+ * - exports.__esModule = !0
+ * - module.exports.__esModule = true
+ * ```
+ */
+export default createAstGrepTransformationRule({
+    name: 'un-esmodule-flag',
+    transform(root, s) {
+        /**
+         * Target: ES5+
+         * Object.defineProperty(exports, '__esModule', { value: true })
+         * Object.defineProperty(module.exports, '__esModule', { value: true })
+         *
+         * Target: ES3
+         * exports.__esModule = true
+         * module.exports.__esModule = true
+         */
+        root
+            .findAll({
+                rule: {
+                    kind: 'expression_statement',
+                    has: {
+                        any: [
+                            { pattern: `Object.defineProperty(exports, '__esModule', { value: $BOOL })` },
+                            { pattern: `Object.defineProperty(exports, "__esModule", { value: $BOOL })` },
+
+                            { pattern: `Object.defineProperty(module.exports, '__esModule', { value: $BOOL })` },
+                            { pattern: `Object.defineProperty(module.exports, "__esModule", { value: $BOOL })` },
+
+                            { pattern: `exports.__esModule = $BOOL` },
+                            { pattern: `exports["__esModule"] = $BOOL` },
+                            { pattern: `module.exports.__esModule = $BOOL` },
+                            { pattern: `module.exports["__esModule"] = $BOOL` },
+                        ],
+                    },
+                    // strip the trailing semicolon if any
+                    regex: ';?$',
+                },
+                constraints: {
+                    BOOL: {
+                        regex: 'true|!0',
+                    },
+                },
+            })
+            .forEach((match) => {
+                const range = match.range()
+                s.remove(range.start.index, range.end.index)
+            })
+
+        return s
+    },
+})

--- a/packages/unminify/src/transformations/un-esmodule-flag.grep.ts
+++ b/packages/unminify/src/transformations/un-esmodule-flag.grep.ts
@@ -1,4 +1,4 @@
-import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+import { createAstGrepTransformationRule } from '@wakaru/shared/astGrepRule'
 
 /**
  * Removes the `__esModule` flag from the module.

--- a/packages/unminify/src/transformations/un-infinity.grep.ts
+++ b/packages/unminify/src/transformations/un-infinity.grep.ts
@@ -1,0 +1,32 @@
+import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+
+/**
+ * Converts `1 / 0` to `Infinity`.
+ *
+ * @example
+ * `1 / 0` -> `Infinity`
+ *
+ * @see https://babeljs.io/docs/babel-plugin-minify-infinity
+ * @see Terser: `keep_infinity`
+ * @see https://github.com/terser/terser/blob/931f8a5fd548795faae0da1fa9eafa3f2ad1647b/lib/compress/index.js#L2641
+ */
+export default createAstGrepTransformationRule({
+    name: 'un-infinity',
+    transform(root, s) {
+        root
+            .findAll({ rule: { pattern: '1/0' } })
+            .forEach((match) => {
+                const range = match.range()
+                s.update(range.start.index, range.end.index, 'Infinity')
+            })
+
+        root
+            .findAll({ rule: { pattern: '-1/0' } })
+            .forEach((match) => {
+                const range = match.range()
+                s.update(range.start.index, range.end.index, '-Infinity')
+            })
+
+        return s
+    },
+})

--- a/packages/unminify/src/transformations/un-infinity.grep.ts
+++ b/packages/unminify/src/transformations/un-infinity.grep.ts
@@ -1,4 +1,4 @@
-import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+import { createAstGrepTransformationRule } from '@wakaru/shared/astGrepRule'
 
 /**
  * Converts `1 / 0` to `Infinity`.

--- a/packages/unminify/src/transformations/un-undefined.grep.ts
+++ b/packages/unminify/src/transformations/un-undefined.grep.ts
@@ -1,4 +1,4 @@
-import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+import { createAstGrepTransformationRule } from '@wakaru/shared/astGrepRule'
 
 /**
  * Converts `void 0` to `undefined`.

--- a/packages/unminify/src/transformations/un-undefined.grep.ts
+++ b/packages/unminify/src/transformations/un-undefined.grep.ts
@@ -16,21 +16,10 @@ export default createAstGrepTransformationRule({
         root
             .findAll({
                 rule: {
-                    pattern: 'void $NUMBER',
-                },
-                constraints: {
-                    NUMBER: { kind: 'number' },
-                },
-            })
-            .forEach((match) => {
-                const range = match.range()
-                s.update(range.start.index, range.end.index, 'undefined')
-            })
-
-        root
-            .findAll({
-                rule: {
-                    pattern: 'void ($NUMBER)',
+                    any: [
+                        { pattern: 'void ($NUMBER)' },
+                        { pattern: 'void $NUMBER' },
+                    ],
                 },
                 constraints: {
                     NUMBER: { kind: 'number' },

--- a/packages/unminify/src/transformations/un-undefined.grep.ts
+++ b/packages/unminify/src/transformations/un-undefined.grep.ts
@@ -1,0 +1,46 @@
+import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+
+/**
+ * Converts `void 0` to `undefined`.
+ *
+ * @example
+ * void 0 -> undefined
+ * void 99 -> undefined
+ *
+ * @see https://babeljs.io/docs/babel-plugin-transform-undefined-to-void
+ * @see Terser: `unsafe_undefined`
+ */
+export default createAstGrepTransformationRule({
+    name: 'un-undefined',
+    transform(root, s) {
+        root
+            .findAll({
+                rule: {
+                    pattern: 'void $NUMBER',
+                },
+                constraints: {
+                    NUMBER: { kind: 'number' },
+                },
+            })
+            .forEach((match) => {
+                const range = match.range()
+                s.update(range.start.index, range.end.index, 'undefined')
+            })
+
+        root
+            .findAll({
+                rule: {
+                    pattern: 'void ($NUMBER)',
+                },
+                constraints: {
+                    NUMBER: { kind: 'number' },
+                },
+            })
+            .forEach((match) => {
+                const range = match.range()
+                s.update(range.start.index, range.end.index, 'undefined')
+            })
+
+        return s
+    },
+})

--- a/packages/unminify/src/transformations/un-use-strict.grep.ts
+++ b/packages/unminify/src/transformations/un-use-strict.grep.ts
@@ -1,4 +1,4 @@
-import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+import { createAstGrepTransformationRule } from '@wakaru/shared/astGrepRule'
 
 /**
  * Remove the 'use strict' directives

--- a/packages/unminify/src/transformations/un-use-strict.grep.ts
+++ b/packages/unminify/src/transformations/un-use-strict.grep.ts
@@ -20,6 +20,7 @@ export default createAstGrepTransformationRule({
             })
             .forEach((match) => {
                 const range = match.range()
+                // FIXME: use column to remove the leading whitespace is not safe
                 s.remove(range.start.index - range.start.column, range.end.index)
             })
 

--- a/packages/unminify/src/transformations/un-use-strict.grep.ts
+++ b/packages/unminify/src/transformations/un-use-strict.grep.ts
@@ -1,0 +1,28 @@
+import { createAstGrepTransformationRule } from '@wakaru/shared/rule'
+
+/**
+ * Remove the 'use strict' directives
+ *
+ * @see https://babeljs.io/docs/babel-plugin-transform-minify-booleans
+ */
+export default createAstGrepTransformationRule({
+    name: 'un-use-strict',
+    transform(root, s) {
+        root
+            .findAll({
+                rule: {
+                    regex: 'use strict',
+                    kind: 'string',
+                    inside: {
+                        kind: 'expression_statement',
+                    },
+                },
+            })
+            .forEach((match) => {
+                const range = match.range()
+                s.remove(range.start.index - range.start.column, range.end.index)
+            })
+
+        return s
+    },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@ast-grep/napi':
+        specifier: ^0.18.1
+        version: 0.18.1
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
@@ -570,7 +573,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@ast-grep/napi-darwin-x64@0.18.1:
@@ -579,7 +581,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@ast-grep/napi-linux-arm64-gnu@0.18.1:
@@ -588,7 +589,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@ast-grep/napi-linux-x64-gnu@0.18.1:
@@ -597,7 +597,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@ast-grep/napi-win32-arm64-msvc@0.18.1:
@@ -606,7 +605,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@ast-grep/napi-win32-ia32-msvc@0.18.1:
@@ -615,7 +613,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@ast-grep/napi-win32-x64-msvc@0.18.1:
@@ -624,7 +621,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@ast-grep/napi@0.18.1:
@@ -638,7 +634,6 @@ packages:
       '@ast-grep/napi-win32-arm64-msvc': 0.18.1
       '@ast-grep/napi-win32-ia32-msvc': 0.18.1
       '@ast-grep/napi-win32-x64-msvc': 0.18.1
-    dev: true
 
   /@babel/code-frame@7.23.5:
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,6 +375,9 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
     devDependencies:
+      '@ast-grep/napi':
+        specifier: ^0.18.1
+        version: 0.18.1
       '@types/jscodeshift':
         specifier: ^0.11.11
         version: 0.11.11
@@ -384,6 +387,9 @@ importers:
       jscodeshift:
         specifier: ^0.15.2
         version: 0.15.2(@babel/preset-env@7.23.9)
+      magic-string:
+        specifier: ^0.30.5
+        version: 0.30.8
       typescript:
         specifier: ^5.3.3
         version: 5.4.3
@@ -556,6 +562,82 @@ packages:
       '@arrows/composition': 1.2.2
       '@arrows/error': 1.0.2
       fast-deep-equal: 3.1.3
+    dev: true
+
+  /@ast-grep/napi-darwin-arm64@0.18.1:
+    resolution: {integrity: sha512-s7UVJrCPAyinlyvBea9+0LecnfxNJEjiUQYUqoNOt2OgDCsfSiSdsKfeouOsyyPKeE0qUh5ApXLbh2swkS47xw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@ast-grep/napi-darwin-x64@0.18.1:
+    resolution: {integrity: sha512-5wmPPdEnNpZdkDH6SBfjiUvHvQfMCbJ//OuFKCGK3sbt2/KHO+qE9O/s+PnHvre7Jq37ILPYJdjlCFkZW0aDoA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@ast-grep/napi-linux-arm64-gnu@0.18.1:
+    resolution: {integrity: sha512-Nsca7vGZCAElw9mAJyiudbh32mQx+O7YToibI4omw+Flo6CLONW4ks/6v+6USlKxO3zhHsyQr2EGWO4MAFekdg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@ast-grep/napi-linux-x64-gnu@0.18.1:
+    resolution: {integrity: sha512-xUxN7SLtCjibq1tm8ZeSFshgQjuw9RQQp8GGEc3awQiSlezGXo1mWNPFOXWoVfw1goT7zwzBGZRRmLTyXxb2Ug==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@ast-grep/napi-win32-arm64-msvc@0.18.1:
+    resolution: {integrity: sha512-i88Id7CNnh8TFYBGhcreozZO81c1QpLHXuhoGjaLfhqr7SozAl4tDKmMXJL2OQw5NCt7cqzfVXgrEzdxRToOFQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@ast-grep/napi-win32-ia32-msvc@0.18.1:
+    resolution: {integrity: sha512-jl9GODdH83ap6jVsKXEFyCKMFSqyNHSINvt1Z7DdyXmWy+rfUS9650zxBbdY9VN7vhgQCrNDDsLr5XZY+tXZcg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@ast-grep/napi-win32-x64-msvc@0.18.1:
+    resolution: {integrity: sha512-YaNi8hoXVgzuQtiJboH6YlLc+XVRHDJV8YorkXoB0EkEYhOHYW1pHQGLUmEulfHRhNtlLffv9ucEqwAG6HK3Zg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@ast-grep/napi@0.18.1:
+    resolution: {integrity: sha512-iIi/tkXixSzsdNlaswWPOY4RGzROcU65hKT0aScdM5MjkpTY3dJcXcVs4TPGfFaZD0wXiiLP7mI4jeNfuiC/Lg==}
+    engines: {node: '>= 10'}
+    optionalDependencies:
+      '@ast-grep/napi-darwin-arm64': 0.18.1
+      '@ast-grep/napi-darwin-x64': 0.18.1
+      '@ast-grep/napi-linux-arm64-gnu': 0.18.1
+      '@ast-grep/napi-linux-x64-gnu': 0.18.1
+      '@ast-grep/napi-win32-arm64-msvc': 0.18.1
+      '@ast-grep/napi-win32-ia32-msvc': 0.18.1
+      '@ast-grep/napi-win32-x64-msvc': 0.18.1
     dev: true
 
   /@babel/code-frame@7.23.5:


### PR DESCRIPTION
This PR introduces `ast-grep` as a new rule provider. We can implement some one-to-one rules with ast-grep, which brings better performance.

I'm not sure if this is a good move since the perf says JS is also fast on these one-to-one rules. The total execution time diff is not that obvious. I will have to do more tests with samples of different sizes.

Related: #35 