### PR TITLE
fix!: update the format of conflic name from `{name}$0` to `{name}_1`

### DIFF
--- a/packages/ast-utils/src/identifier.ts
+++ b/packages/ast-utils/src/identifier.ts
@@ -69,9 +69,9 @@ function getUniqueName(name: string, scope: Scope | null = null, existedNames: s
         return name
     }
 
-    let i = 0
-    while (isConflict(`${name}$${i}`)) {
+    let i = 1
+    while (isConflict(`${name}_${i}`)) {
         i++
     }
-    return `${name}$${i}`
+    return `${name}_${i}`
 }

--- a/packages/unminify/src/transformations/__tests__/smart-inline.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/smart-inline.spec.ts
@@ -180,11 +180,11 @@ const {
 } = e;
 
 const {
-  size: size$0,
-  color: color$0
+  size: size_1,
+  color: color_1
 } = f;
 
-console.log(size, color, size$0, color$0);
+console.log(size, color, size_1, color_1);
 `,
 )
 
@@ -207,9 +207,9 @@ var {
 if (3 === tag) {
   for (tag = r.return; null !== tag; ) {
     var {
-      tag: tag$0
+      tag: tag_1
     } = tag;
-    if (3 === tag$0) {
+    if (3 === tag_1) {
       tag = tag.return;
     }
   }
@@ -239,9 +239,9 @@ function foo() {
   if (3 === tag) {
     for (tag = r.return; null !== tag; ) {
       var {
-        tag: tag$0
+        tag: tag_1
       } = tag;
-      if (3 === tag$0) {
+      if (3 === tag_1) {
         tag = tag.return;
       }
     }

--- a/packages/unminify/src/transformations/__tests__/smart-rename.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/smart-rename.spec.ts
@@ -153,15 +153,15 @@ function foo({
 const gql = 1;
 
 function foo({
-  gql: gql$0,
+  gql: gql_1,
   dispatchers,
   listener
 }, {
-  gql: gql$1,
-  dispatchers: dispatchers$0,
-  listener: listener$0
+  gql: gql_2,
+  dispatchers: dispatchers_1,
+  listener: listener_1
 }) {
-  dispatchers.delete(gql$0, listener, gql$1, dispatchers$0, listener$0);
+  dispatchers.delete(gql_1, listener, gql_2, dispatchers_1, listener_1);
 }
 `,
 )

--- a/packages/unminify/src/transformations/__tests__/un-esm.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-esm.spec.ts
@@ -191,8 +191,8 @@ var bar = 1;
 console.log(bar);
 `,
   `
-import { bar as bar$0 } from "foo";
-var { baz } = bar$0;
+import { bar as bar_1 } from "foo";
+var { baz } = bar_1;
 var bar = 1;
 console.log(bar);
 `,
@@ -282,10 +282,10 @@ function fn() {
 }
 `,
   `
-import { bar as bar$0 } from "foo";
+import { bar as bar_1 } from "foo";
 function fn() {
   var bar = 1;
-  var { baz } = bar$0;
+  var { baz } = bar_1;
   return baz;
 }
 `,
@@ -301,10 +301,10 @@ function fn() {
 }
 `,
   `
-import { bar as bar$0 } from "foo";
+import { bar as bar_1 } from "foo";
 var bar = 1;
 function fn() {
-  var { baz } = bar$0;
+  var { baz } = bar_1;
   return baz;
 }
 `,
@@ -330,9 +330,9 @@ var foo = require("foo")("baz");
 var buz = require("foo").bar("baz");
 `,
   `
-import foo$0 from "foo";
-var foo = foo$0("baz");
-var buz = foo$0.bar("baz");
+import foo_1 from "foo";
+var foo = foo_1("baz");
+var buz = foo_1.bar("baz");
 `,
 )
 
@@ -505,21 +505,21 @@ console.log(foo);
 exports.foo = 2;
 
 const bar = 2;
-const bar$0 = 3;
-console.log(bar, bar$0);
+const bar_1 = 3;
+console.log(bar, bar_1);
 module.exports.bar = 4;
 `,
   `
 var foo = 1;
 console.log(foo);
-const foo$0 = 2;
-export { foo$0 as foo };
+const foo_1 = 2;
+export { foo_1 as foo };
 
 const bar = 2;
-const bar$0 = 3;
-console.log(bar, bar$0);
-const bar$1 = 4;
-export { bar$1 as bar };
+const bar_1 = 3;
+console.log(bar, bar_1);
+const bar_2 = 4;
+export { bar_2 as bar };
 `,
 )
 
@@ -712,9 +712,9 @@ var bar = 1;
 module.exports = require('bar');
 `,
   `
-import bar$0 from "bar";
+import bar_1 from "bar";
 var bar = 1;
-export default bar$0;
+export default bar_1;
 `,
 )
 

--- a/packages/unminify/src/transformations/__tests__/un-indirect-call.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-indirect-call.spec.ts
@@ -29,12 +29,12 @@ var thirdRef = (0, t.useRef)(0);
 `,
   `
 import { useRef } from "react";
-import { useRef as useRef$0 } from "another";
+import { useRef as useRef_1 } from "another";
 import randomUnusedImport from "third";
 
 var countRef = useRef(0);
-var secondRef = useRef$0(0);
-var thirdRef = useRef$0(0);
+var secondRef = useRef_1(0);
+var thirdRef = useRef_1(0);
 `,
 )
 
@@ -88,11 +88,11 @@ const { useRef } = s;
 const s = require("react");
 
 const {
-  useRef: useRef$0,
+  useRef: useRef_1,
   useMemo
 } = s;
 
-var countRef = useRef$0(0);
+var countRef = useRef_1(0);
 var secondRef = useMemo(() => {}, []);
 
 const { useRef } = s;
@@ -109,7 +109,7 @@ var countRef = (0, s.useRef)(0);
 var secondRef = (0, p.useRef)(0);
 `,
   `
-import { useRef as useRef$0 } from "r2";
+import { useRef as useRef_1 } from "r2";
 
 const s = require("react");
 
@@ -118,7 +118,7 @@ const {
 } = s;
 
 var countRef = useRef(0);
-var secondRef = useRef$0(0);
+var secondRef = useRef_1(0);
 `,
 )
 
@@ -141,12 +141,12 @@ const {
 const t = require(9527);
 
 const {
-  useRef: useRef$0
+  useRef: useRef_1
 } = t;
 
 var countRef = useRef(0);
-var secondRef = useRef$0(0);
-var thirdRef = useRef$0(0);
+var secondRef = useRef_1(0);
+var thirdRef = useRef_1(0);
 `,
 )
 
@@ -160,11 +160,11 @@ const fn = () => {
 }
 `,
   `
-import { useRef as useRef$0 } from "react";
+import { useRef as useRef_1 } from "react";
 
 const fn = () => {
   const useRef = 1;
-  useRef$0(0);
+  useRef_1(0);
 }
 `,
 )

--- a/packages/unminify/src/transformations/__tests__/un-jsx.spec.ts
+++ b/packages/unminify/src/transformations/__tests__/un-jsx.spec.ts
@@ -200,8 +200,8 @@ const Foo = () => {
   `
 const Foo = () => {
   const Component = g ? "p" : "div";
-  const Component$0 = r ? "a" : "div";
-  return <div><Component$0 key="b">bar</Component$0><Component key={c}>baz</Component></div>;
+  const Component_1 = r ? "a" : "div";
+  return <div><Component_1 key="b">bar</Component_1><Component key={c}>baz</Component></div>;
 };
 `,
 )

--- a/packages/unminify/src/transformations/un-esm.ts
+++ b/packages/unminify/src/transformations/un-esm.ts
@@ -580,8 +580,8 @@ function transformExport(context: Context) {
                  * module.exports.foo = 2
                  * ->
                  * const foo = 1
-                 * const foo$0 = 2
-                 * export { foo$0 as foo }
+                 * const foo_1 = 2
+                 * export { foo_1 as foo }
                  */
                 const oldName = name
                 const newName = generateName(oldName, path.scope)

--- a/packages/unminify/src/transformations/un-indirect-call.ts
+++ b/packages/unminify/src/transformations/un-indirect-call.ts
@@ -43,7 +43,7 @@ export const transformAST: ASTTransformation = (context) => {
      */
 
     /**
-     * `s.foo` (indirect call) -> `foo$0` (local specifiers)
+     * `s.foo` (indirect call) -> `foo_1` (local specifiers)
      */
     const replaceMapping = new Map<string, string>()
 
@@ -130,7 +130,7 @@ export const transformAST: ASTTransformation = (context) => {
                 },
             }).filter(path => isTopLevel(j, path))
             if (requireDecl.size() > 0) {
-                // find `const { useRef } = react` or `const { useRef: useRef$0 } = react`
+                // find `const { useRef } = react` or `const { useRef: useRef_1 } = react`
                 const propertyDecl = root.find(j.VariableDeclarator, {
                     id: {
                         type: 'ObjectPattern',
@@ -152,7 +152,7 @@ export const transformAST: ASTTransformation = (context) => {
                 })
 
                 if (propertyDecl.size() === 0) {
-                    // generate `const { useRef: useRef$0 } = react`
+                    // generate `const { useRef: useRef_1 } = react`
                     const key = j.identifier(property.name)
                     const valueName = generateName(property.name, rootScope, [...replaceMapping.values()])
                     replaceMapping.set(`${defaultSpecifierName}.${namedSpecifierName}`, valueName)
@@ -206,7 +206,7 @@ export const transformAST: ASTTransformation = (context) => {
                     return
                 }
 
-                // extract `useRef$0` from `const { useRef: useRef$0 } = react`
+                // extract `useRef_1` from `const { useRef: useRef_1 } = react`
                 const propertyNode = propertyDecl.get().node
                 const propertyValue = propertyNode.id as ObjectPattern
                 const targetProperty = propertyValue.properties.find((p) => {


### PR DESCRIPTION
The previous format was not friendly for reading and selecting on the editor. Double-clicking on `name$0` will only select `name` instead of the whole `name$0`. I would like to take this chance to update it to a different format. This might bring some unnecessary changes to downstream who need a consistent output. So I guess this will be the last time I adjust the naming rule.

Another format would be to follow what babel does: `_{name}1`. But I don't have a strong opinion on it.