### PR TITLE
feat(playground): format decompiled output with biome

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -7,6 +7,7 @@
       "name": "wakaru-playground",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
+        "@wasm-fmt/biome_fmt": "^0.2.9",
         "allotment": "^1.20.2",
         "pako": "^2.1.0",
         "react": "^19.1.0",
@@ -53,7 +54,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1242,7 +1242,6 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1262,7 +1261,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1284,6 +1284,12 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@wasm-fmt/biome_fmt": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@wasm-fmt/biome_fmt/-/biome_fmt-0.2.9.tgz",
+      "integrity": "sha512-8V3RGOekqTtOINbgtBTZEPJuj/bGXM+jPqqDRj2/mtks1UXBpcfjs3MhMlrkBjMO/0/Kv3VGQmeP6IyPm7gLHQ==",
+      "license": "MIT"
     },
     "node_modules/allotment": {
       "version": "1.20.5",
@@ -1336,7 +1342,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1415,6 +1420,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -1593,6 +1599,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -1663,7 +1670,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1705,7 +1711,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1715,7 +1720,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -1893,7 +1897,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/playground/package.json
+++ b/playground/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@wasm-fmt/biome_fmt": "^0.2.9",
     "allotment": "^1.20.2",
     "pako": "^2.1.0",
     "react": "^19.1.0",

--- a/playground/src/wasm/worker.ts
+++ b/playground/src/wasm/worker.ts
@@ -1,5 +1,11 @@
-import init, { decompile } from "wakaru-wasm";
-import type { WorkerRequest, WorkerResponse } from "./types";
+import initWakaru, { decompile } from "wakaru-wasm";
+import * as biomeFormatter from "@wasm-fmt/biome_fmt/vite";
+import type { WakaruWarning, WorkerRequest, WorkerResponse } from "./types";
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
 
 let initialized = false;
 
@@ -8,13 +14,16 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
 
   if (msg.type === "init") {
     try {
-      await init();
+      await Promise.all([
+        initWakaru(),
+        initFormatter(), // Never rejects
+      ]);
       initialized = true;
       self.postMessage({ type: "init-done" } satisfies WorkerResponse);
     } catch (e) {
       self.postMessage({
         type: "init-error",
-        error: e instanceof Error ? e.message : String(e),
+        error: errorMessage(e),
       } satisfies WorkerResponse);
     }
     return;
@@ -36,18 +45,100 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
         undefined,
         msg.diagnostics
       );
+      const { code, warnings: formatWarnings } = formatDecompiledCode(
+        result.code
+      );
+
       self.postMessage({
         type: "decompile-result",
         id: msg.id,
-        code: result.code,
-        warnings: result.warnings,
+        code,
+        warnings: [...result.warnings, ...formatWarnings],
       } satisfies WorkerResponse);
     } catch (e) {
       self.postMessage({
         type: "decompile-error",
         id: msg.id,
-        error: e instanceof Error ? e.message : String(e),
+        error: errorMessage(e),
       } satisfies WorkerResponse);
     }
   }
 };
+
+
+const FORMAT_FILENAME = "decompiled.jsx";
+
+const { format: formatWithBiome } = biomeFormatter;
+const initBiomeFormatter = (
+  biomeFormatter as typeof biomeFormatter & {
+    default: () => Promise<unknown>;
+  }
+).default;
+
+function createFormatWarning(message: string): WakaruWarning {
+  return {
+    filename: FORMAT_FILENAME,
+    kind: "format",
+    message,
+  };
+}
+
+type FormatterState =
+  | { type: "initializing" }
+  | { type: "initialized" }
+  | { type: "failed"; error: string };
+
+
+let formatterState: FormatterState = { type: "initializing" };
+
+async function initFormatter() {
+  try {
+    await initBiomeFormatter();
+    formatterState = { type: "initialized" };
+  } catch (e) {
+    formatterState = { type: "failed", error: errorMessage(e) };
+  }
+}
+
+interface FormatDecompiledCodeResult {
+  code: string;
+  warnings: WakaruWarning[];
+}
+
+function formatDecompiledCode(code: string): FormatDecompiledCodeResult {
+  if (formatterState.type === "initialized") {
+    try {
+      return {
+        code: formatWithBiome(code, FORMAT_FILENAME),
+        warnings: [],
+      };
+    } catch (e) {
+      return {
+        code,
+        warnings: [
+          createFormatWarning(`Biome formatting failed: ${errorMessage(e)}`),
+        ],
+      };
+    }
+  }
+
+  if (formatterState.type === "failed") {
+    return {
+      code,
+      warnings: [
+        createFormatWarning(
+          `Biome formatter failed to initialize: ${formatterState.error}`
+        ),
+      ],
+    };
+  }
+
+  return {
+    code,
+    warnings: [
+      createFormatWarning(
+        "Biome formatter is still initializing; output was returned unformatted."
+      ),
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
Format decompile output with Biome in the playground.

## Notes
- Adds `@wasm-fmt/biome_fmt`.
- Falls back to unformatted output with a warning if formatter init or formatting fails.
