### PR TITLE
fix(core): recover optional chaining from logical-and guards

### DIFF
--- a/crates/core/src/rules/un_optional_chaining.rs
+++ b/crates/core/src/rules/un_optional_chaining.rs
@@ -356,38 +356,31 @@ fn rewrite_logical_and_optional_chain_terms(
     uninitialized_bindings: &HashSet<BindingId>,
     binding_references: &HashMap<BindingId, usize>,
 ) -> Option<Expr> {
-    for end in (3..=terms.len()).rev() {
-        if let Some((chain, consumed)) = try_logical_and_optional_chain_terms(
-            &terms[..end],
+    let mut rewritten_terms = Vec::with_capacity(terms.len());
+    let mut changed = false;
+    let mut index = 0;
+
+    while index < terms.len() {
+        if let Some((chain, consumed)) = try_logical_and_optional_chain_prefix(
+            &terms[index..],
             unresolved_mark,
             policy,
             uninitialized_bindings,
             binding_references,
         ) {
-            if consumed != end {
-                continue;
-            }
-            if end == terms.len() {
-                return Some(chain);
-            }
-            let suffix = rewrite_logical_and_optional_chain_terms(
-                &terms[end..],
-                unresolved_mark,
-                policy,
-                uninitialized_bindings,
-                binding_references,
-            )
-            .or_else(|| {
-                build_logical_and_expr(terms[end..].iter().map(|term| (*term).clone()).collect())
-            })?;
-            return Some(make_logical_and_expr(chain, suffix));
+            rewritten_terms.push(chain);
+            index += consumed;
+            changed = true;
+        } else {
+            rewritten_terms.push(terms[index].clone());
+            index += 1;
         }
     }
 
-    None
+    changed.then(|| build_logical_and_expr(rewritten_terms))?
 }
 
-fn try_logical_and_optional_chain_terms(
+fn try_logical_and_optional_chain_prefix(
     terms: &[&Expr],
     unresolved_mark: Mark,
     policy: RewritePolicy,
@@ -426,9 +419,16 @@ fn try_logical_and_optional_chain_terms(
     let mut current_tmp = first.checked;
     let mut index = first.consumed;
 
-    while index < terms.len() - 1 {
-        let segment = extract_logical_and_non_null_segment(terms, index, unresolved_mark, policy)?;
+    while index < terms.len() {
+        let Some(segment) =
+            extract_logical_and_non_null_segment(terms, index, unresolved_mark, policy)
+        else {
+            break;
+        };
         let real_rhs = segment.real_rhs.as_ref()?;
+        if index + segment.consumed >= terms.len() {
+            break;
+        }
         let Expr::Ident(tmp) = strip_parens(&segment.checked) else {
             return None;
         };
@@ -447,13 +447,13 @@ fn try_logical_and_optional_chain_terms(
         index += segment.consumed;
     }
 
-    if index != terms.len() - 1 {
+    if index >= terms.len() {
         return None;
     }
 
     if !chain_temps_are_safe(
         &temps,
-        terms,
+        &terms[..=index],
         policy.level,
         uninitialized_bindings,
         binding_references,

--- a/crates/core/src/rules/un_optional_chaining.rs
+++ b/crates/core/src/rules/un_optional_chaining.rs
@@ -340,7 +340,65 @@ fn try_logical_and_optional_chain(
         return None;
     }
 
-    let first = extract_logical_and_non_null_segment(&terms, 0, unresolved_mark, policy)?;
+    rewrite_logical_and_optional_chain_terms(
+        &terms,
+        unresolved_mark,
+        policy,
+        uninitialized_bindings,
+        binding_references,
+    )
+}
+
+fn rewrite_logical_and_optional_chain_terms(
+    terms: &[&Expr],
+    unresolved_mark: Mark,
+    policy: RewritePolicy,
+    uninitialized_bindings: &HashSet<BindingId>,
+    binding_references: &HashMap<BindingId, usize>,
+) -> Option<Expr> {
+    for end in (3..=terms.len()).rev() {
+        if let Some((chain, consumed)) = try_logical_and_optional_chain_terms(
+            &terms[..end],
+            unresolved_mark,
+            policy,
+            uninitialized_bindings,
+            binding_references,
+        ) {
+            if consumed != end {
+                continue;
+            }
+            if end == terms.len() {
+                return Some(chain);
+            }
+            let suffix = rewrite_logical_and_optional_chain_terms(
+                &terms[end..],
+                unresolved_mark,
+                policy,
+                uninitialized_bindings,
+                binding_references,
+            )
+            .or_else(|| {
+                build_logical_and_expr(terms[end..].iter().map(|term| (*term).clone()).collect())
+            })?;
+            return Some(make_logical_and_expr(chain, suffix));
+        }
+    }
+
+    None
+}
+
+fn try_logical_and_optional_chain_terms(
+    terms: &[&Expr],
+    unresolved_mark: Mark,
+    policy: RewritePolicy,
+    uninitialized_bindings: &HashSet<BindingId>,
+    binding_references: &HashMap<BindingId, usize>,
+) -> Option<(Expr, usize)> {
+    if terms.len() < 3 {
+        return None;
+    }
+
+    let first = extract_logical_and_non_null_segment(terms, 0, unresolved_mark, policy)?;
     let mut temps = Vec::new();
     let mut temp_values = HashMap::new();
     let mut temp_call_contexts = HashMap::new();
@@ -369,7 +427,7 @@ fn try_logical_and_optional_chain(
     let mut index = first.consumed;
 
     while index < terms.len() - 1 {
-        let segment = extract_logical_and_non_null_segment(&terms, index, unresolved_mark, policy)?;
+        let segment = extract_logical_and_non_null_segment(terms, index, unresolved_mark, policy)?;
         let real_rhs = segment.real_rhs.as_ref()?;
         let Expr::Ident(tmp) = strip_parens(&segment.checked) else {
             return None;
@@ -395,7 +453,7 @@ fn try_logical_and_optional_chain(
 
     if !chain_temps_are_safe(
         &temps,
-        &[expr],
+        terms,
         policy.level,
         uninitialized_bindings,
         binding_references,
@@ -403,14 +461,30 @@ fn try_logical_and_optional_chain(
         return None;
     }
 
-    make_flattened_final_access(
+    let chain = make_flattened_final_access(
         &current_tmp,
         &chain,
         terms[index],
         &temp_values,
         &temp_call_contexts,
         unresolved_mark,
-    )
+    )?;
+    Some((chain, index + 1))
+}
+
+fn build_logical_and_expr(terms: Vec<Expr>) -> Option<Expr> {
+    let mut terms = terms.into_iter();
+    let first = terms.next()?;
+    Some(terms.fold(first, make_logical_and_expr))
+}
+
+fn make_logical_and_expr(left: Expr, right: Expr) -> Expr {
+    Expr::Bin(BinExpr {
+        span: DUMMY_SP,
+        op: BinaryOp::LogicalAnd,
+        left: Box::new(left),
+        right: Box::new(right),
+    })
 }
 
 struct LogicalAndSegment {

--- a/crates/core/tests/un_optional_chaining_rule.rs
+++ b/crates/core/tests/un_optional_chaining_rule.rs
@@ -273,6 +273,94 @@ const a = r?.foo?.bar?.baz;
 }
 
 #[test]
+fn standard_transforms_issue_166_pattern_1_babel_duplicated_access() {
+    let input = r#"
+var _tt, _tt2;
+if ((_tt = tt) != null && (_tt = _tt[bt]) != null && (_tt = _tt.blocks) != null && _tt.hideList && (_tt2 = tt) != null && (_tt2 = _tt2[bt]) != null && (_tt2 = _tt2.blocks) != null && _tt2.hideList.length) {
+  window_lodash.set(n, `${bt}.blocks.hideList`, []);
+} else {
+  window_lodash.set(n, `${bt}.blocks.hideList`, ne);
+}
+"#;
+    let expected = r#"
+var _tt, _tt2;
+if (tt?.[bt]?.blocks?.hideList && tt?.[bt]?.blocks?.hideList.length) {
+  window_lodash.set(n, `${bt}.blocks.hideList`, []);
+} else {
+  window_lodash.set(n, `${bt}.blocks.hideList`, ne);
+}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn standard_transforms_issue_166_pattern_1_mixed_duplicated_access() {
+    let input = r#"
+let e, t, l, i;
+if (tt != null && (e = tt[bt]) !== null && e !== undefined && (t = e.blocks) !== null && t !== undefined && t.hideList && tt != null && (l = tt[bt]) !== null && l !== undefined && (i = l.blocks) !== null && i !== undefined && i.hideList.length) {
+  window_lodash.set(n, `${bt}.blocks.hideList`, []);
+} else {
+  window_lodash.set(n, `${bt}.blocks.hideList`, ne);
+}
+"#;
+    let expected = r#"
+let e, t, l, i;
+if (tt?.[bt]?.blocks?.hideList && tt?.[bt]?.blocks?.hideList.length) {
+  window_lodash.set(n, `${bt}.blocks.hideList`, []);
+} else {
+  window_lodash.set(n, `${bt}.blocks.hideList`, ne);
+}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn standard_transforms_issue_166_pattern_2_loose_slug_exclusions() {
+    let input = r#"
+var _t;
+if ((_t = t) != null && (_t = _t.supports) != null && _t.editor && t.slug != "wp_template" && t.slug != "wp_template_part" && t.slug != "wp_navigation" && t.slug != "nav_menu_item" && t.slug != "cc_block") {}
+"#;
+    let expected = r#"
+var _t;
+if (t?.supports?.editor && t.slug != "wp_template" && t.slug != "wp_template_part" && t.slug != "wp_navigation" && t.slug != "nav_menu_item" && t.slug != "cc_block") {}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn standard_transforms_issue_166_pattern_2_strict_slug_exclusions() {
+    let input = r#"
+var _t;
+if ((_t = t) != null && (_t = _t.supports) != null && _t.editor && t.slug !== "wp_template" && t.slug !== "wp_template_part" && t.slug !== "wp_navigation" && t.slug !== "nav_menu_item" && t.slug !== "cc_block") {}
+"#;
+    let expected = r#"
+var _t;
+if (t?.supports?.editor && t.slug !== "wp_template" && t.slug !== "wp_template_part" && t.slug !== "wp_navigation" && t.slug !== "nav_menu_item" && t.slug !== "cc_block") {}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn standard_transforms_issue_166_pattern_2_includes_slug_exclusions() {
+    let input = r#"
+var _t;
+const excludedSlugs = ["wp_template", "wp_template_part", "wp_navigation", "nav_menu_item", "cc_block"];
+if ((_t = t) != null && (_t = _t.supports) != null && _t.editor && !excludedSlugs.includes(t.slug)) {}
+"#;
+    let expected = r#"
+var _t;
+const excludedSlugs = ["wp_template", "wp_template_part", "wp_navigation", "nav_menu_item", "cc_block"];
+if (t?.supports?.editor && !excludedSlugs.includes(t.slug)) {}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
 fn pipeline_transforms_issue_142_swc_terser_mixed_loose_root_chain() {
     // Reproduces issue #142 from:
     //   var a = (null == r ? void 0 : r.app_info?.base_info?.app_name) ?? "game";

--- a/crates/core/tests/un_optional_chaining_rule.rs
+++ b/crates/core/tests/un_optional_chaining_rule.rs
@@ -275,19 +275,19 @@ const a = r?.foo?.bar?.baz;
 #[test]
 fn standard_transforms_issue_166_pattern_1_babel_duplicated_access() {
     let input = r#"
-var _tt, _tt2;
-if ((_tt = tt) != null && (_tt = _tt[bt]) != null && (_tt = _tt.blocks) != null && _tt.hideList && (_tt2 = tt) != null && (_tt2 = _tt2[bt]) != null && (_tt2 = _tt2.blocks) != null && _tt2.hideList.length) {
-  window_lodash.set(n, `${bt}.blocks.hideList`, []);
+var _root, _root2;
+if ((_root = root) != null && (_root = _root[key]) != null && (_root = _root.group) != null && _root.items && (_root2 = root) != null && (_root2 = _root2[key]) != null && (_root2 = _root2.group) != null && _root2.items.length) {
+  sink("clear");
 } else {
-  window_lodash.set(n, `${bt}.blocks.hideList`, ne);
+  sink("fill");
 }
 "#;
     let expected = r#"
-var _tt, _tt2;
-if (tt?.[bt]?.blocks?.hideList && tt?.[bt]?.blocks?.hideList.length) {
-  window_lodash.set(n, `${bt}.blocks.hideList`, []);
+var _root, _root2;
+if (root?.[key]?.group?.items && root?.[key]?.group?.items.length) {
+  sink("clear");
 } else {
-  window_lodash.set(n, `${bt}.blocks.hideList`, ne);
+  sink("fill");
 }
 "#;
     let output = apply(input);
@@ -297,19 +297,19 @@ if (tt?.[bt]?.blocks?.hideList && tt?.[bt]?.blocks?.hideList.length) {
 #[test]
 fn standard_transforms_issue_166_pattern_1_mixed_duplicated_access() {
     let input = r#"
-let e, t, l, i;
-if (tt != null && (e = tt[bt]) !== null && e !== undefined && (t = e.blocks) !== null && t !== undefined && t.hideList && tt != null && (l = tt[bt]) !== null && l !== undefined && (i = l.blocks) !== null && i !== undefined && i.hideList.length) {
-  window_lodash.set(n, `${bt}.blocks.hideList`, []);
+let first, firstGroup, second, secondGroup;
+if (root != null && (first = root[key]) !== null && first !== undefined && (firstGroup = first.group) !== null && firstGroup !== undefined && firstGroup.items && root != null && (second = root[key]) !== null && second !== undefined && (secondGroup = second.group) !== null && secondGroup !== undefined && secondGroup.items.length) {
+  sink("clear");
 } else {
-  window_lodash.set(n, `${bt}.blocks.hideList`, ne);
+  sink("fill");
 }
 "#;
     let expected = r#"
-let e, t, l, i;
-if (tt?.[bt]?.blocks?.hideList && tt?.[bt]?.blocks?.hideList.length) {
-  window_lodash.set(n, `${bt}.blocks.hideList`, []);
+let first, firstGroup, second, secondGroup;
+if (root?.[key]?.group?.items && root?.[key]?.group?.items.length) {
+  sink("clear");
 } else {
-  window_lodash.set(n, `${bt}.blocks.hideList`, ne);
+  sink("fill");
 }
 "#;
     let output = apply(input);
@@ -317,44 +317,44 @@ if (tt?.[bt]?.blocks?.hideList && tt?.[bt]?.blocks?.hideList.length) {
 }
 
 #[test]
-fn standard_transforms_issue_166_pattern_2_loose_slug_exclusions() {
+fn standard_transforms_issue_166_pattern_2_loose_suffix_comparisons() {
     let input = r#"
-var _t;
-if ((_t = t) != null && (_t = _t.supports) != null && _t.editor && t.slug != "wp_template" && t.slug != "wp_template_part" && t.slug != "wp_navigation" && t.slug != "nav_menu_item" && t.slug != "cc_block") {}
+var _item;
+if ((_item = item) != null && (_item = _item.meta) != null && _item.enabled && item.kind != "alpha" && item.kind != "beta" && item.kind != "gamma") {}
 "#;
     let expected = r#"
-var _t;
-if (t?.supports?.editor && t.slug != "wp_template" && t.slug != "wp_template_part" && t.slug != "wp_navigation" && t.slug != "nav_menu_item" && t.slug != "cc_block") {}
+var _item;
+if (item?.meta?.enabled && item.kind != "alpha" && item.kind != "beta" && item.kind != "gamma") {}
 "#;
     let output = apply(input);
     assert_eq_normalized(&output, expected);
 }
 
 #[test]
-fn standard_transforms_issue_166_pattern_2_strict_slug_exclusions() {
+fn standard_transforms_issue_166_pattern_2_strict_suffix_comparisons() {
     let input = r#"
-var _t;
-if ((_t = t) != null && (_t = _t.supports) != null && _t.editor && t.slug !== "wp_template" && t.slug !== "wp_template_part" && t.slug !== "wp_navigation" && t.slug !== "nav_menu_item" && t.slug !== "cc_block") {}
+var _item;
+if ((_item = item) != null && (_item = _item.meta) != null && _item.enabled && item.kind !== "alpha" && item.kind !== "beta" && item.kind !== "gamma") {}
 "#;
     let expected = r#"
-var _t;
-if (t?.supports?.editor && t.slug !== "wp_template" && t.slug !== "wp_template_part" && t.slug !== "wp_navigation" && t.slug !== "nav_menu_item" && t.slug !== "cc_block") {}
+var _item;
+if (item?.meta?.enabled && item.kind !== "alpha" && item.kind !== "beta" && item.kind !== "gamma") {}
 "#;
     let output = apply(input);
     assert_eq_normalized(&output, expected);
 }
 
 #[test]
-fn standard_transforms_issue_166_pattern_2_includes_slug_exclusions() {
+fn standard_transforms_issue_166_pattern_2_includes_suffix_condition() {
     let input = r#"
-var _t;
-const excludedSlugs = ["wp_template", "wp_template_part", "wp_navigation", "nav_menu_item", "cc_block"];
-if ((_t = t) != null && (_t = _t.supports) != null && _t.editor && !excludedSlugs.includes(t.slug)) {}
+var _item;
+const blockedKinds = ["alpha", "beta", "gamma"];
+if ((_item = item) != null && (_item = _item.meta) != null && _item.enabled && !blockedKinds.includes(item.kind)) {}
 "#;
     let expected = r#"
-var _t;
-const excludedSlugs = ["wp_template", "wp_template_part", "wp_navigation", "nav_menu_item", "cc_block"];
-if (t?.supports?.editor && !excludedSlugs.includes(t.slug)) {}
+var _item;
+const blockedKinds = ["alpha", "beta", "gamma"];
+if (item?.meta?.enabled && !blockedKinds.includes(item.kind)) {}
 "#;
     let output = apply(input);
     assert_eq_normalized(&output, expected);


### PR DESCRIPTION
_Note: This PR was written by Codex (GPT 5.5, high); there may be better ways to fix this that I was unaware of. Feel free to edit / push to this branch if you have better fixes._

## Summary

Recover Babel-lowered optional chaining when the lowered `&&` guard is only a prefix of a larger logical-and expression.

This covers the failing `❌ Wakaru` examples from issue https://github.com/pionxzh/wakaru/issues/166#issuecomment-4629993597:

- Pattern 1 canonical Babel output for `tt?.[bt]?.blocks?.hideList && tt?.[bt]?.blocks?.hideList.length`.
- Pattern 1 real unpacked mixed loose-root/strict-continuation output from `module-484.js`.
- Pattern 2 Babel output for `t?.supports?.editor &&` slug exclusions using `!=`.
- Pattern 2 Babel output for the same slug exclusions using `!==`.
- Pattern 2 Babel output for `t?.supports?.editor && !excludedSlugs.includes(t.slug)`.

## Root Cause

`UnOptionalChaining` could recover a complete lowered `&&` chain, but it required the whole logical-and expression to be the optional-chain pattern. When non-optional conditions followed the optional prefix, or a second lowered optional chain followed the first, the matcher rejected the full expression and did not recover the prefix.

## Changes

- Split logical-and recovery into term-level prefix recovery.
- Rebuild suffixes so remaining `&&` terms can also be recovered in the same pass.
- Keep temp-safety checks scoped to the recovered prefix so observed temps outside the prefix still block rewrites.
- Add focused regression tests for every `❌ Wakaru` reduced Babel block in the comment, plus the real mixed Pattern 1 unpacked form.

## Validation

- `cargo test -p wakaru-core --test un_optional_chaining_rule`
- `cargo test -p wakaru-core --test noop_pipeline --test webpack4_unpack --test webpack4_unpack_raw --test bundle_unpack --test esbuild_unpack`
- `cargo fmt --check`
- `cargo clippy -p wakaru-core --all-targets -- -D warnings`