### PR TITLE
feat: per-module provenance byte ranges from unpackers (--provenance)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::io::{self, IsTerminal, Read};
 use std::path::{Component, Path, PathBuf};
@@ -77,6 +78,12 @@ struct Cli {
     /// With --unpack, write raw unpacker output before the decompiler rule pipeline.
     #[arg(long, requires = "unpack")]
     raw: bool,
+
+    /// With --unpack, write a provenance.json in the output directory mapping
+    /// each module file to the byte ranges in the original input it was
+    /// extracted from.
+    #[arg(long, requires = "unpack")]
+    provenance: bool,
 
     /// Source map file (.map) for identifier recovery and import deduplication.
     #[arg(
@@ -223,6 +230,10 @@ fn run_default(cli: Cli) -> Result<()> {
         let check_existing_writes = ensure_output_dir(&out_dir, cli.force)?;
         let out_dir = canonicalize_output_dir(&out_dir)?;
 
+        // Provenance entries from single-source unpacks leave `input` empty;
+        // remember the input name so the provenance file can attribute them.
+        let single_input_name = (inputs.len() == 1).then(|| inputs[0].filename.clone());
+
         let output = if inputs.len() == 1 {
             let input = inputs.into_iter().next().expect("checked input length");
             if cli.raw {
@@ -239,6 +250,7 @@ fn run_default(cli: Cli) -> Result<()> {
         print_warnings(&output.warnings);
         let has_errors = output.has_errors();
 
+        let provenance = output.provenance;
         let pairs = output.modules;
         let pairs: Vec<(String, String)> = pairs
             .into_par_iter()
@@ -275,6 +287,31 @@ fn run_default(cli: Cli) -> Result<()> {
                     .par_iter()
                     .try_for_each(|(path, code)| write_file(path, code))?;
             }
+        }
+
+        if cli.provenance {
+            // Map each module to its final on-disk relative path: `resolved`
+            // is parallel to `pairs`, and CLI-side dedup may have renamed.
+            let final_names: HashMap<&str, String> = pairs
+                .iter()
+                .zip(resolved.iter())
+                .map(|((filename, _), (path, _))| {
+                    let relative = path
+                        .strip_prefix(&out_dir)
+                        .unwrap_or(path)
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    (filename.as_str(), relative)
+                })
+                .collect();
+            let json = render_provenance_json(
+                &provenance,
+                &final_names,
+                single_input_name.as_deref().unwrap_or(""),
+            );
+            let provenance_path = out_dir.join("provenance.json");
+            fs::write(&provenance_path, json)
+                .with_context(|| format!("failed to write {}", provenance_path.display()))?;
         }
 
         if io::stderr().is_terminal() {
@@ -760,6 +797,69 @@ fn deduplicate_path(path: &Path, seen: &mut std::collections::HashSet<String>) -
     }
 }
 
+/// Render provenance entries as a JSON document.
+///
+/// `final_names` maps the driver's module filename to the relative path the
+/// CLI actually wrote (CLI-side dedup can rename). `default_input` fills in
+/// entries whose input is empty (single-source unpacks).
+fn render_provenance_json(
+    provenance: &[wakaru_core::ModuleProvenance],
+    final_names: &HashMap<&str, String>,
+    default_input: &str,
+) -> String {
+    let mut entries: Vec<(String, &wakaru_core::ModuleProvenance)> = provenance
+        .iter()
+        .map(|entry| {
+            let name = final_names
+                .get(entry.filename.as_str())
+                .cloned()
+                .unwrap_or_else(|| entry.filename.clone());
+            (name, entry)
+        })
+        .collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut json = String::from("{\n  \"modules\": {\n");
+    for (i, (name, entry)) in entries.iter().enumerate() {
+        let input = if entry.input.is_empty() {
+            default_input
+        } else {
+            &entry.input
+        };
+        let ranges = entry
+            .ranges
+            .iter()
+            .map(|(start, end)| format!("[{start},{end}]"))
+            .collect::<Vec<_>>()
+            .join(",");
+        json.push_str(&format!(
+            "    \"{}\": {{\"input\": \"{}\", \"ranges\": [{}]}}{}\n",
+            json_escape(name),
+            json_escape(input),
+            ranges,
+            if i + 1 < entries.len() { "," } else { "" }
+        ));
+    }
+    json.push_str("  }\n}\n");
+    json
+}
+
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 fn init_profile(
     path: Option<&Path>,
     include_rule_spans: bool,
@@ -791,6 +891,40 @@ fn init_profile(
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn renders_provenance_json_with_final_names_and_default_input() {
+        let provenance = vec![
+            wakaru_core::ModuleProvenance {
+                filename: "b.js".to_string(),
+                input: String::new(),
+                ranges: vec![(10, 20), (30, 40)],
+            },
+            wakaru_core::ModuleProvenance {
+                filename: "a \"quoted\".js".to_string(),
+                input: "chunk-1.js".to_string(),
+                ranges: vec![(0, 5)],
+            },
+        ];
+        let mut final_names = HashMap::new();
+        // CLI-side dedup renamed b.js on disk.
+        final_names.insert("b.js", "b_2.js".to_string());
+
+        let json = render_provenance_json(&provenance, &final_names, "bundle.js");
+
+        assert!(
+            json.contains(r#""b_2.js": {"input": "bundle.js", "ranges": [[10,20],[30,40]]}"#),
+            "renamed module with default input missing:\n{json}"
+        );
+        assert!(
+            json.contains(r#""a \"quoted\".js": {"input": "chunk-1.js", "ranges": [[0,5]]}"#),
+            "escaped filename with explicit input missing:\n{json}"
+        );
+        // Must be alphabetically sorted and valid JSON shape.
+        assert!(json.find("a \\\"quoted\\\"").unwrap() < json.find("b_2.js").unwrap());
+        assert!(json.starts_with("{\n  \"modules\": {\n"));
+        assert!(json.ends_with("  }\n}\n"));
+    }
 
     #[test]
     fn parses_extract_without_js_input() {

--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -10,6 +10,7 @@ mod unpack_cycles;
 pub use single_file::decompile;
 pub use trace::{format_trace_events, trace_rules, RuleTraceEvent, RuleTraceOptions};
 pub use types::{
-    DecompileOptions, DecompileOutput, UnpackInput, UnpackOutput, UnpackWarning, UnpackWarningKind,
+    DecompileOptions, DecompileOutput, ModuleProvenance, UnpackInput, UnpackOutput, UnpackWarning,
+    UnpackWarningKind,
 };
 pub use unpack::{unpack, unpack_files, unpack_files_raw, unpack_raw};

--- a/crates/core/src/driver/types.rs
+++ b/crates/core/src/driver/types.rs
@@ -48,7 +48,23 @@ pub struct UnpackInput {
 #[derive(Debug, Clone, Default)]
 pub struct UnpackOutput {
     pub modules: Vec<(String, String)>,
+    /// Per-module provenance: where in the original input each module came
+    /// from. Parallel to `modules` by filename; modules without recoverable
+    /// spans have empty `ranges`.
+    pub provenance: Vec<ModuleProvenance>,
     pub warnings: Vec<UnpackWarning>,
+}
+
+/// Byte-range provenance for one unpacked module.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ModuleProvenance {
+    /// Output module filename (same value as in `UnpackOutput::modules`).
+    pub filename: String,
+    /// Input filename the ranges refer to. Empty for single-source unpacks
+    /// (the caller knows the input) and for synthesized modules.
+    pub input: String,
+    /// 0-based byte ranges `(start, end)` into the input source.
+    pub ranges: Vec<(u32, u32)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/core/src/driver/unpack.rs
+++ b/crates/core/src/driver/unpack.rs
@@ -16,7 +16,9 @@ use super::diagnostics::{
 };
 use super::io::{parse_js, parse_js_with_recovery, print_js};
 use super::single_file::decompile;
-use super::types::{DecompileOptions, UnpackInput, UnpackOutput, UnpackWarning, UnpackWarningKind};
+use super::types::{
+    DecompileOptions, ModuleProvenance, UnpackInput, UnpackOutput, UnpackWarning, UnpackWarningKind,
+};
 #[cfg(test)]
 use super::unpack_cleanup::hoist_late_runtime_helpers;
 use super::unpack_cleanup::{dedup_duplicate_exports, prune_stale_local_named_exports};
@@ -52,6 +54,7 @@ pub fn unpack(source: &str, options: DecompileOptions) -> Result<UnpackOutput> {
                 let output = decompile(source, options)?;
                 Ok(UnpackOutput {
                     modules: vec![("module.js".to_string(), output.code)],
+                    provenance: vec![whole_input_provenance("module.js", "", source)],
                     warnings: output.warnings,
                 })
             }
@@ -60,6 +63,7 @@ pub fn unpack(source: &str, options: DecompileOptions) -> Result<UnpackOutput> {
             let output = decompile(source, options)?;
             Ok(UnpackOutput {
                 modules: vec![("module.js".to_string(), output.code)],
+                provenance: vec![whole_input_provenance("module.js", "", source)],
                 warnings: output.warnings,
             })
         }
@@ -102,14 +106,19 @@ pub fn unpack_files(
             None if options.heuristic_split => {
                 match scope_hoist::split_scope_hoisted(&input.source) {
                     Some(result) if result.modules.len() > 1 => {
-                        modules.extend(result.modules.into_iter().map(MultiSourceModule::fallback))
+                        modules.extend(result.modules.into_iter().map(|mut module| {
+                            module.source_input = input.filename.clone();
+                            MultiSourceModule::fallback(module)
+                        }))
                     }
                     _ => modules.push(MultiSourceModule::fallback(
                         crate::unpacker::UnpackedModule {
                             id: input.filename.clone(),
                             is_entry: false,
-                            code: input.source,
                             filename: filename_for_fallback_input(&input.filename),
+                            source_ranges: vec![(0, input.source.len() as u32)],
+                            source_input: input.filename.clone(),
+                            code: input.source,
                         },
                     )),
                 }
@@ -118,8 +127,10 @@ pub fn unpack_files(
                 crate::unpacker::UnpackedModule {
                     id: input.filename.clone(),
                     is_entry: false,
-                    code: input.source,
                     filename: filename_for_fallback_input(&input.filename),
+                    source_ranges: vec![(0, input.source.len() as u32)],
+                    source_input: input.filename.clone(),
+                    code: input.source,
                 },
             )),
         }
@@ -155,7 +166,7 @@ pub fn unpack_raw(source: &str, options: &DecompileOptions) -> Result<UnpackOutp
         });
     match result {
         Some((result, normalize_for_runnable_split)) => {
-            let (modules, warnings) = if normalize_for_runnable_split {
+            let (modules, provenance, warnings) = if normalize_for_runnable_split {
                 // Heuristic scope-hoisted fallback does not get the esbuild
                 // detector's bundler-specific cleanup, so keep the narrow
                 // runnable normalization it still relies on.
@@ -168,6 +179,7 @@ pub fn unpack_raw(source: &str, options: &DecompileOptions) -> Result<UnpackOutp
                         (result.modules, Vec::new())
                     }
                 };
+                let provenance = module_provenance(&modules);
                 let normalized: Vec<_> = modules
                     .into_par_iter()
                     .map(|module| {
@@ -200,23 +212,51 @@ pub fn unpack_raw(source: &str, options: &DecompileOptions) -> Result<UnpackOutp
                     }
                     output_modules.push(module);
                 }
-                (output_modules, output_warnings)
+                (output_modules, provenance, output_warnings)
             } else {
+                let provenance = module_provenance(&result.modules);
                 (
                     result
                         .modules
                         .into_iter()
                         .map(|module| (module.filename, module.code))
                         .collect(),
+                    provenance,
                     Vec::new(),
                 )
             };
-            Ok(UnpackOutput { modules, warnings })
+            Ok(UnpackOutput {
+                modules,
+                provenance,
+                warnings,
+            })
         }
         None => Ok(UnpackOutput {
             modules: vec![("module.js".to_string(), source.to_string())],
+            provenance: vec![whole_input_provenance("module.js", "", source)],
             warnings: Vec::new(),
         }),
+    }
+}
+
+/// Provenance entries for a list of unpacked modules, in module order.
+fn module_provenance(modules: &[UnpackedModule]) -> Vec<ModuleProvenance> {
+    modules
+        .iter()
+        .map(|module| ModuleProvenance {
+            filename: module.filename.clone(),
+            input: module.source_input.clone(),
+            ranges: module.source_ranges.clone(),
+        })
+        .collect()
+}
+
+/// Provenance entry covering an entire input source.
+fn whole_input_provenance(filename: &str, input: &str, source: &str) -> ModuleProvenance {
+    ModuleProvenance {
+        filename: filename.to_string(),
+        input: input.to_string(),
+        ranges: vec![(0, source.len() as u32)],
     }
 }
 
@@ -269,6 +309,8 @@ pub fn unpack_files_raw(
                 is_entry: false,
                 code: input.source.to_string(),
                 filename: filename_for_fallback_input(&input.filename),
+                source_ranges: vec![(0, input.source.len() as u32)],
+                source_input: input.filename.clone(),
             })),
         }
     }
@@ -297,12 +339,15 @@ struct MultiSourceModule {
 
 impl MultiSourceModule {
     fn detected(
-        module: UnpackedModule,
+        mut module: UnpackedModule,
         chunk_ids: HashSet<usize>,
         input_filename: String,
         allow_cycle_premerge: bool,
     ) -> Self {
         let input_group = input_group_for_filename(&input_filename);
+        // Unpackers don't know which physical input they ran on; attribute
+        // provenance ranges to it here.
+        module.source_input = input_filename.clone();
         Self {
             module,
             allow_cross_chunk_rewrite: true,
@@ -561,12 +606,22 @@ fn emit_raw_modules_with_numeric_rewrites(
     modules: Vec<PreparedUnpackModule>,
     numeric_rewrite_plan: NumericRewritePlan,
 ) -> Result<UnpackOutput> {
+    let provenance: Vec<ModuleProvenance> = modules
+        .iter()
+        .map(|prepared| ModuleProvenance {
+            filename: prepared.module.filename.clone(),
+            input: prepared.module.source_input.clone(),
+            ranges: prepared.module.source_ranges.clone(),
+        })
+        .collect();
+
     if numeric_rewrite_plan.is_empty() {
         return Ok(UnpackOutput {
             modules: modules
                 .into_iter()
                 .map(|module| (module.module.filename, module.module.code))
                 .collect(),
+            provenance,
             warnings: Vec::new(),
         });
     }
@@ -616,7 +671,11 @@ fn emit_raw_modules_with_numeric_rewrites(
         }
     }
 
-    Ok(UnpackOutput { modules, warnings })
+    Ok(UnpackOutput {
+        modules,
+        provenance,
+        warnings,
+    })
 }
 
 struct WebpackNumericReferenceRewriter<'a> {
@@ -1012,6 +1071,17 @@ fn unpack_multi_module_with_plan(
             (modules, Vec::new())
         };
 
+    // Capture provenance now: filenames are final after multi-source dedup
+    // and cycle premerge, and the phase pipeline below only rewrites code.
+    let provenance: Vec<ModuleProvenance> = modules
+        .iter()
+        .map(|prepared| ModuleProvenance {
+            filename: prepared.module.filename.clone(),
+            input: prepared.module.source_input.clone(),
+            ranges: prepared.module.source_ranges.clone(),
+        })
+        .collect();
+
     // Parse the sourcemap once before the loop.
     let parsed_sourcemap = options
         .sourcemap
@@ -1262,7 +1332,11 @@ fn unpack_multi_module_with_plan(
         warnings.extend(collect_import_cycle_warnings(&modules));
     }
 
-    Ok(UnpackOutput { modules, warnings })
+    Ok(UnpackOutput {
+        modules,
+        provenance,
+        warnings,
+    })
 }
 
 fn should_merge_raw_import_cycles(_modules: &[UnpackedModule]) -> bool {
@@ -1358,6 +1432,7 @@ function load() {
             is_entry: false,
             code: "const = ;".to_string(),
             filename: "module-1.js".to_string(),
+            ..Default::default()
         }];
         let output = unpack_multi_module(modules, DecompileOptions::default())
             .expect("unparseable extracted modules should be preserved as raw code");
@@ -1442,6 +1517,7 @@ function b() { return a(); }
                     } else {
                         format!("m{index}.js")
                     },
+                    ..Default::default()
                 })
             })
             .collect();
@@ -1464,6 +1540,7 @@ function b() { return a(); }
                         is_entry: module.module.is_entry,
                         code: module.module.code.clone(),
                         filename: module.module.filename.clone(),
+                        ..Default::default()
                     },
                     false,
                 )
@@ -1487,6 +1564,7 @@ function b() { return a(); }
                 is_entry: module.module.is_entry,
                 code: module.module.code.clone(),
                 filename: module.module.filename.clone(),
+                ..Default::default()
             })
             .collect();
         assert!(
@@ -1504,6 +1582,7 @@ function b() { return a(); }
                     is_entry: true,
                     code: r#"import { b } from "./b.js"; export const a = b + 1;"#.to_string(),
                     filename: "entry.js".to_string(),
+                    ..Default::default()
                 },
                 false,
             ),
@@ -1513,6 +1592,7 @@ function b() { return a(); }
                     is_entry: false,
                     code: r#"import { a } from "./entry.js"; export const b = a + 1;"#.to_string(),
                     filename: "b.js".to_string(),
+                    ..Default::default()
                 },
                 false,
             ),
@@ -1582,6 +1662,7 @@ module.exports = (a = (i = require("./module-2.js")).lib, o = a.WordArray, i.SHA
 "#
             .to_string(),
             filename: "module-1.js".to_string(),
+            ..Default::default()
         }];
 
         let output = unpack_multi_module(modules, DecompileOptions::default())
@@ -1617,6 +1698,7 @@ exports.default = o.default(l);
 "#
             .to_string(),
             filename: "module-1.js".to_string(),
+            ..Default::default()
         }];
 
         let output = unpack_multi_module(modules, DecompileOptions::default())
@@ -1645,6 +1727,7 @@ exports.default = o.default(l);
                     is_entry: false,
                     code: "const other = require(999);".to_string(),
                     filename: "module-20.js".to_string(),
+                    ..Default::default()
                 },
                 HashSet::new(),
                 "entry.js".to_string(),
@@ -1656,6 +1739,7 @@ exports.default = o.default(l);
                     is_entry: false,
                     code: "export default 1;".to_string(),
                     filename: "module-999.js".to_string(),
+                    ..Default::default()
                 },
                 HashSet::new(),
                 "chunk.js".to_string(),
@@ -1710,6 +1794,7 @@ export { create, wrap };
 "#
             .to_string(),
             filename: "helper.js".to_string(),
+            ..Default::default()
         }];
 
         let output = unpack_multi_module(
@@ -1748,6 +1833,7 @@ export { helper };
 "#
             .to_string(),
             filename: "entry.js".to_string(),
+            ..Default::default()
         }];
 
         let output = unpack_multi_module(
@@ -1806,18 +1892,21 @@ export { helper };
                 is_entry: false,
                 code: r#"import { b } from "./b.js"; export const a = b + 1;"#.to_string(),
                 filename: "a.js".to_string(),
+                ..Default::default()
             },
             UnpackedModule {
                 id: "b".to_string(),
                 is_entry: false,
                 code: r#"import { a } from "./a.js"; export const b = a + 1;"#.to_string(),
                 filename: "b.js".to_string(),
+                ..Default::default()
             },
             UnpackedModule {
                 id: "c".to_string(),
                 is_entry: false,
                 code: r#"import { b } from "./b.js"; export const c = b;"#.to_string(),
                 filename: "c.js".to_string(),
+                ..Default::default()
             },
         ];
 
@@ -1857,18 +1946,21 @@ export { helper };
                 is_entry: false,
                 code: r#"import { b } from "./b.js"; export const a = b + 1;"#.to_string(),
                 filename: "a.js".to_string(),
+                ..Default::default()
             },
             UnpackedModule {
                 id: "b".to_string(),
                 is_entry: false,
                 code: r#"import { a } from "./a.js"; export const b = a + 1;"#.to_string(),
                 filename: "b.js".to_string(),
+                ..Default::default()
             },
             UnpackedModule {
                 id: "d".to_string(),
                 is_entry: false,
                 code: untouched_code.to_string(),
                 filename: "d.js".to_string(),
+                ..Default::default()
             },
         ];
 
@@ -1894,6 +1986,7 @@ export { helper };
                 code: r#"import { shared } from "./x.js"; import { b } from "./b.js"; export const a = b + shared;"#
                     .to_string(),
                 filename: "a.js".to_string(),
+                ..Default::default()
             },
             UnpackedModule {
                 id: "b".to_string(),
@@ -1901,6 +1994,7 @@ export { helper };
                 code: r#"import { shared } from "./x.js"; import { a } from "./a.js"; export const b = a + shared;"#
                     .to_string(),
                 filename: "b.js".to_string(),
+                ..Default::default()
             },
         ];
 
@@ -1936,6 +2030,7 @@ export { helper };
                 code: r#"import { b } from "./b.js"; export function f() { return b; }"#
                     .to_string(),
                 filename: "a.js".to_string(),
+                ..Default::default()
             },
             UnpackedModule {
                 id: "b".to_string(),
@@ -1943,6 +2038,7 @@ export { helper };
                 code: r#"import { f } from "./a.js"; export const b = 1; export { f };"#
                     .to_string(),
                 filename: "b.js".to_string(),
+                ..Default::default()
             },
         ];
 
@@ -2022,6 +2118,7 @@ export { helper, cache };
                     r#"import { b } from "./b.js"; const shared = 1; export const a = b + shared;"#
                         .to_string(),
                 filename: "a.js".to_string(),
+                ..Default::default()
             },
             UnpackedModule {
                 id: "b".to_string(),
@@ -2030,6 +2127,7 @@ export { helper, cache };
                     r#"import { a } from "./a.js"; const shared = 2; export const b = a + shared;"#
                         .to_string(),
                 filename: "b.js".to_string(),
+                ..Default::default()
             },
         ];
 
@@ -2066,6 +2164,7 @@ export { helper, cache };
                         r#"import {{ v{next} }} from "./m{next}.js"; export const v{index} = v{next} + {index};"#
                     ),
                     filename: format!("m{index}.js"),
+                    ..Default::default()
                 }
             })
             .collect();
@@ -2091,6 +2190,7 @@ export { helper, cache };
                 code: r#"import { b } from "./b.js"; var shared = 1; export const a = b + shared;"#
                     .to_string(),
                 filename: "a.js".to_string(),
+                ..Default::default()
             },
             UnpackedModule {
                 id: "b".to_string(),
@@ -2098,6 +2198,7 @@ export { helper, cache };
                 code: r#"import { a } from "./a.js"; var shared = 2; export const b = a + shared;"#
                     .to_string(),
                 filename: "b.js".to_string(),
+                ..Default::default()
             },
         ];
         let module_by_filename: HashMap<String, &UnpackedModule> = modules

--- a/crates/core/src/driver/unpack_cycles.rs
+++ b/crates/core/src/driver/unpack_cycles.rs
@@ -186,6 +186,29 @@ pub(crate) fn merge_import_cycles(
                 );
                 (code, is_entry)
             };
+            // Provenance: a merged cycle covers the union of its members'
+            // ranges, but only when all members came from the same input.
+            let member_modules: Vec<_> = members
+                .iter()
+                .filter_map(|name| module_by_filename.get(name.as_str()))
+                .collect();
+            let inputs: HashSet<&str> = member_modules
+                .iter()
+                .map(|m| m.source_input.as_str())
+                .collect();
+            let (source_ranges, source_input) = if inputs.len() <= 1 {
+                let mut ranges: Vec<(u32, u32)> = member_modules
+                    .iter()
+                    .flat_map(|m| m.source_ranges.iter().copied())
+                    .collect();
+                ranges.sort_unstable();
+                (
+                    ranges,
+                    inputs.into_iter().next().unwrap_or_default().to_string(),
+                )
+            } else {
+                (Vec::new(), String::new())
+            };
             merged_modules.push(crate::unpacker::UnpackedModule {
                 id: representative
                     .strip_suffix(".js")
@@ -194,6 +217,8 @@ pub(crate) fn merge_import_cycles(
                 is_entry,
                 code,
                 filename: representative.clone(),
+                source_ranges,
+                source_input,
             });
         } else {
             let code = if module_imports_retargeted_cycle_member(
@@ -217,6 +242,8 @@ pub(crate) fn merge_import_cycles(
                 is_entry: module.is_entry,
                 code,
                 filename: module.filename.clone(),
+                source_ranges: module.source_ranges.clone(),
+                source_input: module.source_input.clone(),
             });
         }
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,8 +19,8 @@ pub mod utils;
 
 pub use driver::{
     decompile, format_trace_events, trace_rules, unpack, unpack_files, unpack_files_raw,
-    unpack_raw, DecompileOptions, DecompileOutput, RuleTraceEvent, RuleTraceOptions, UnpackInput,
-    UnpackOutput, UnpackWarning, UnpackWarningKind,
+    unpack_raw, DecompileOptions, DecompileOutput, ModuleProvenance, RuleTraceEvent,
+    RuleTraceOptions, UnpackInput, UnpackOutput, UnpackWarning, UnpackWarningKind,
 };
 pub use facts::{
     collect_module_facts, ExportFact, ExportKind, HelperExportFact, HelperKind, ImportFact,

--- a/crates/core/src/unpacker/browserify.rs
+++ b/crates/core/src/unpacker/browserify.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use swc_core::atoms::Atom;
-use swc_core::common::{sync::Lrc, Mark, SourceMap, SyntaxContext, GLOBALS};
+use swc_core::common::{sync::Lrc, Mark, SourceMap, Spanned, SyntaxContext, GLOBALS};
 use swc_core::ecma::ast::{
     ArrayLit, Callee, Expr, ExprOrSpread, ExprStmt, FnExpr, Function, Lit, Module, ModuleItem,
     Number, Pat, Stmt,
@@ -11,7 +11,7 @@ use swc_core::ecma::transforms::base::{fixer::fixer, resolver};
 use swc_core::ecma::utils::replace_ident;
 use swc_core::ecma::visit::VisitMutWith;
 
-use crate::unpacker::{UnpackResult, UnpackedModule};
+use crate::unpacker::{span_byte_range, UnpackResult, UnpackedModule};
 
 pub fn detect_and_extract(source: &str) -> Option<UnpackResult> {
     GLOBALS.set(&Default::default(), || {
@@ -99,6 +99,10 @@ fn extract_browserify_modules(
             is_entry,
             code,
             filename,
+            source_ranges: span_byte_range(&cm, key_value.value.span())
+                .into_iter()
+                .collect(),
+            source_input: String::new(),
         });
     }
 

--- a/crates/core/src/unpacker/esbuild.rs
+++ b/crates/core/src/unpacker/esbuild.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
 use swc_core::atoms::Atom;
-use swc_core::common::{sync::Lrc, FileName, Mark, SourceMap, SyntaxContext, DUMMY_SP, GLOBALS};
+use swc_core::common::{
+    sync::Lrc, FileName, Mark, SourceMap, Span, Spanned, SyntaxContext, DUMMY_SP, GLOBALS,
+};
 use swc_core::ecma::ast::{
     ArrowExpr, BindingIdent, BlockStmt, BlockStmtOrExpr, Bool, CallExpr, Callee, ClassDecl, Decl,
     ExportDecl, ExportNamedSpecifier, ExportSpecifier, Expr, ExprOrSpread, ExprStmt, FnDecl,
@@ -15,7 +17,10 @@ use swc_core::ecma::utils::find_pat_ids;
 use swc_core::ecma::visit::{Visit, VisitMutWith, VisitWith};
 
 use crate::rules::rename_utils::{rename_bindings, BindingRename};
-use crate::unpacker::{module_item_declared_binding_ids, BindingId, UnpackResult, UnpackedModule};
+use crate::unpacker::{
+    module_item_declared_binding_ids, span_byte_range, spans_byte_ranges, BindingId, UnpackResult,
+    UnpackedModule,
+};
 
 pub fn detect_and_extract(source: &str) -> Option<UnpackResult> {
     GLOBALS.set(&Default::default(), || {
@@ -144,6 +149,7 @@ pub(super) fn detect_from_module(module: &Module, cm: Lrc<SourceMap>) -> Option<
         body_stmts: Vec<Stmt>,
         referenced_bindings: HashSet<BindingId>,
         write_bindings: HashSet<BindingId>,
+        span: Span,
     }
 
     let mut pending_factories: Vec<PendingFactory> = Vec::new();
@@ -172,6 +178,7 @@ pub(super) fn detect_from_module(module: &Module, cm: Lrc<SourceMap>) -> Option<
             body_stmts: factory.body_stmts,
             referenced_bindings,
             write_bindings,
+            span: factory.span,
         });
     }
 
@@ -765,10 +772,13 @@ pub(super) fn detect_from_module(module: &Module, cm: Lrc<SourceMap>) -> Option<
             is_entry: false,
             code,
             filename: factory.filename,
+            source_ranges: span_byte_range(&cm, factory.span).into_iter().collect(),
+            source_input: String::new(),
         });
     }
 
     if !remaining_entry.is_empty() {
+        let entry_ranges = spans_byte_ranges(&cm, remaining_entry.iter().map(|item| item.span()));
         let remaining_entry = repair_entry_imports(remaining_entry, &binding_to_filename);
         let entry_module = Module {
             span: Default::default(),
@@ -781,6 +791,8 @@ pub(super) fn detect_from_module(module: &Module, cm: Lrc<SourceMap>) -> Option<
             is_entry: true,
             code,
             filename: "entry.js".to_string(),
+            source_ranges: entry_ranges,
+            source_input: String::new(),
         });
     }
 
@@ -970,6 +982,8 @@ struct Factory {
     body_stmts: Vec<Stmt>,
     /// The statements inside the factory function body (resolved — for reference collection).
     analysis_body_stmts: Vec<Stmt>,
+    /// Span of the factory's `var` declarator in the original bundle (provenance).
+    span: Span,
 }
 
 #[derive(Clone)]
@@ -1178,6 +1192,7 @@ fn try_extract_factory(
                             .flatten(),
                         body_stmts,
                         analysis_body_stmts,
+                        span: decl.span,
                     });
                 }
             }
@@ -1204,6 +1219,7 @@ fn try_extract_factory(
                     .flatten(),
                 body_stmts,
                 analysis_body_stmts,
+                span: decl.span,
             })
         }
 
@@ -1227,6 +1243,7 @@ fn try_extract_factory(
                     .flatten(),
                 body_stmts,
                 analysis_body_stmts,
+                span: decl.span,
             })
         }
 
@@ -1948,8 +1965,10 @@ fn extract_scope_hoisted_modules(
 
         // Body items with export promotion for exported bindings.
         let mut remaining_exports = exports;
+        let mut body_spans: Vec<Span> = Vec::with_capacity(meta.body_indices.len());
         for &i in &meta.body_indices {
             let item = source_slots[i].take().expect("body item already consumed");
+            body_spans.push(item.span());
             if remaining_exports.is_empty() {
                 module_items.push(item);
                 continue;
@@ -1986,6 +2005,8 @@ fn extract_scope_hoisted_modules(
             is_entry: false,
             code,
             filename: meta.filename.clone(),
+            source_ranges: spans_byte_ranges(&cm, body_spans.into_iter()),
+            source_input: String::new(),
         });
     }
 

--- a/crates/core/src/unpacker/mod.rs
+++ b/crates/core/src/unpacker/mod.rs
@@ -7,15 +7,55 @@ pub mod webpack5;
 mod wrappers;
 
 use swc_core::atoms::Atom;
-use swc_core::common::{sync::Lrc, FileName, SourceMap, SyntaxContext, GLOBALS};
+use swc_core::common::{sync::Lrc, FileName, SourceMap, Span, SyntaxContext, GLOBALS};
 use swc_core::ecma::ast::{Decl, Module, ModuleDecl, ModuleItem, Stmt, VarDecl};
 use swc_core::ecma::parser::{lexer::Lexer, EsSyntax, Parser, StringInput, Syntax};
 
+#[derive(Default)]
 pub struct UnpackedModule {
     pub id: String,
     pub is_entry: bool,
     pub code: String,
     pub filename: String,
+    /// Byte ranges in the original input source this module was extracted
+    /// from (provenance). Empty when the extraction site has no real spans
+    /// (fully synthesized modules).
+    pub source_ranges: Vec<(u32, u32)>,
+    /// Input filename the ranges refer to. Unpackers leave this empty; the
+    /// driver fills it in for multi-source unpacks.
+    pub source_input: String,
+}
+
+/// Convert an AST span to a 0-based byte range into the parsed source.
+///
+/// Returns `None` for dummy/synthesized spans and anything that does not
+/// fall inside the span's source file.
+pub(crate) fn span_byte_range(cm: &SourceMap, span: Span) -> Option<(u32, u32)> {
+    if span.lo.0 == 0 || span.hi.0 == 0 || span.lo > span.hi {
+        return None;
+    }
+    let file = cm.lookup_byte_offset(span.lo).sf;
+    let start = span.lo.0.checked_sub(file.start_pos.0)?;
+    let end = span.hi.0.checked_sub(file.start_pos.0)?;
+    (end as usize <= file.src.len()).then_some((start, end))
+}
+
+/// Collect byte ranges for a sequence of spans, sorted and coalesced
+/// (overlapping or touching ranges are merged).
+pub(crate) fn spans_byte_ranges(
+    cm: &SourceMap,
+    spans: impl Iterator<Item = Span>,
+) -> Vec<(u32, u32)> {
+    let mut ranges: Vec<(u32, u32)> = spans.filter_map(|s| span_byte_range(cm, s)).collect();
+    ranges.sort_unstable();
+    let mut out: Vec<(u32, u32)> = Vec::new();
+    for (lo, hi) in ranges {
+        match out.last_mut() {
+            Some(last) if lo <= last.1 => last.1 = last.1.max(hi),
+            _ => out.push((lo, hi)),
+        }
+    }
+    out
 }
 
 pub struct UnpackResult {

--- a/crates/core/src/unpacker/scope_hoist.rs
+++ b/crates/core/src/unpacker/scope_hoist.rs
@@ -1,12 +1,12 @@
 use std::collections::{HashMap, HashSet};
 
 use swc_core::atoms::Atom;
-use swc_core::common::{sync::Lrc, FileName, SourceMap, GLOBALS};
+use swc_core::common::{sync::Lrc, FileName, SourceMap, Spanned, GLOBALS};
 use swc_core::ecma::ast::*;
 use swc_core::ecma::codegen::{text_writer::JsWriter, Config, Emitter};
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
-use super::{module_item_declared_names, UnpackResult, UnpackedModule};
+use super::{module_item_declared_names, spans_byte_ranges, UnpackResult, UnpackedModule};
 
 const MIN_DECLARATIONS: usize = 10;
 
@@ -1204,6 +1204,11 @@ fn emit_clusters(
             is_entry: cluster.is_entry,
             code,
             filename: filenames[ci].clone(),
+            source_ranges: spans_byte_ranges(
+                &cm,
+                cluster.item_indices.iter().map(|&i| body[i].span()),
+            ),
+            source_input: String::new(),
         });
     }
 

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use swc_core::atoms::Atom;
-use swc_core::common::{sync::Lrc, SourceMap, DUMMY_SP};
+use swc_core::common::{sync::Lrc, SourceMap, Span, DUMMY_SP};
 use swc_core::ecma::ast::{
     ArrayLit, BindingIdent, BlockStmt, BlockStmtOrExpr, CallExpr, Callee, Decl, EsVersion,
     ExportDecl, ExportDefaultExpr, ExportNamedSpecifier, ExportSpecifier, Expr, ExprOrSpread,
@@ -13,7 +13,7 @@ use swc_core::ecma::ast::{
 use swc_core::ecma::codegen::{text_writer::JsWriter, Config, Emitter};
 use swc_core::ecma::visit::{VisitMut, VisitMutWith};
 
-use crate::unpacker::{UnpackResult, UnpackedModule};
+use crate::unpacker::{span_byte_range, UnpackResult, UnpackedModule};
 
 pub(super) fn detect_from_module(module: &Module, cm: Lrc<SourceMap>) -> Option<UnpackResult> {
     let mut registers = Vec::new();
@@ -40,7 +40,13 @@ pub(super) fn detect_from_module(module: &Module, cm: Lrc<SourceMap>) -> Option<
     let mut seen = HashSet::new();
     let mut modules = Vec::new();
     for (idx, register) in registers.into_iter().enumerate() {
-        if let Some(result) = try_unpack_dynamic_export_bundle(&register, cm.clone()) {
+        let register_range = span_byte_range(&cm, register.span);
+        if let Some(mut result) = try_unpack_dynamic_export_bundle(&register, cm.clone()) {
+            // The nested bundle was re-parsed from emitted code, so its
+            // spans are meaningless here; attribute the whole register call.
+            for module in &mut result.modules {
+                module.source_ranges = register_range.into_iter().collect();
+            }
             modules.extend(result.modules);
             continue;
         }
@@ -53,6 +59,8 @@ pub(super) fn detect_from_module(module: &Module, cm: Lrc<SourceMap>) -> Option<
             is_entry,
             code,
             filename,
+            source_ranges: register_range.into_iter().collect(),
+            source_input: String::new(),
         });
     }
 
@@ -101,6 +109,8 @@ struct SystemRegister {
     name: Option<String>,
     deps: Vec<String>,
     declare: Function,
+    /// Span of the whole `System.register(...)` call (provenance).
+    span: Span,
 }
 
 fn is_system_register_call(call: &CallExpr) -> bool {
@@ -130,6 +140,7 @@ fn parse_register_call(call: &CallExpr) -> Option<SystemRegister> {
         name,
         deps,
         declare,
+        span: call.span,
     })
 }
 

--- a/crates/core/src/unpacker/webpack4.rs
+++ b/crates/core/src/unpacker/webpack4.rs
@@ -15,7 +15,7 @@ use swc_core::ecma::transforms::base::{fixer::fixer, resolver};
 use swc_core::ecma::utils::replace_ident;
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
-use crate::unpacker::{UnpackResult, UnpackedModule};
+use crate::unpacker::{span_byte_range, UnpackResult, UnpackedModule};
 use crate::utils::paren::strip_parens;
 
 /// Identifies a webpack module by either its numeric index (array-form) or
@@ -570,6 +570,10 @@ fn extract_webpack4_array_modules(
             is_entry,
             code,
             filename,
+            source_ranges: span_byte_range(&cm, fn_expr.function.span)
+                .into_iter()
+                .collect(),
+            source_input: String::new(),
         });
     }
 
@@ -715,6 +719,10 @@ fn extract_webpack4_object_modules(
             is_entry,
             code,
             filename,
+            source_ranges: span_byte_range(&cm, fn_expr.function.span)
+                .into_iter()
+                .collect(),
+            source_input: String::new(),
         });
     }
 

--- a/crates/core/src/unpacker/webpack5.rs
+++ b/crates/core/src/unpacker/webpack5.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::anyhow;
 use swc_core::atoms::Atom;
-use swc_core::common::{sync::Lrc, Mark, SourceMap, SyntaxContext, DUMMY_SP, GLOBALS};
+use swc_core::common::{sync::Lrc, Mark, SourceMap, Spanned, SyntaxContext, DUMMY_SP, GLOBALS};
 use swc_core::ecma::ast::{
     ArrayLit, AssignExpr, AssignOp, AssignTarget, BinExpr, BinaryOp, BlockStmtOrExpr, CallExpr,
     Callee, Expr, ExprStmt, FnExpr, Ident, IdentName, Lit, MemberExpr, MemberProp, Module,
@@ -16,7 +16,7 @@ use swc_core::ecma::utils::replace_ident;
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use crate::unpacker::webpack4::{rewrite_require_n_accesses, RequireIdRewriter};
-use crate::unpacker::{UnpackResult, UnpackedModule};
+use crate::unpacker::{spans_byte_ranges, UnpackResult, UnpackedModule};
 use crate::utils::paren::strip_parens;
 
 struct Webpack5RuntimeNormalizer {
@@ -275,6 +275,8 @@ pub(super) fn detect_runtime_entry_from_module(
                 is_entry: true,
                 code: source.to_string(),
                 filename: "entry.js".to_string(),
+                source_ranges: vec![(0, source.len() as u32)],
+                source_input: String::new(),
             }]));
         }
     }
@@ -576,6 +578,8 @@ fn extract_modules_from_object(
             is_entry: false,
             code,
             filename: entry.filename.clone(),
+            source_ranges: spans_byte_ranges(&cm, entry.body_stmts.iter().map(|s| s.span())),
+            source_input: String::new(),
         });
     }
 
@@ -635,18 +639,23 @@ fn extract_webpack5_modules(
                 is_entry: false,
                 code,
                 filename: entry.filename.clone(),
+                source_ranges: spans_byte_ranges(&cm, entry.body_stmts.iter().map(|s| s.span())),
+                source_input: String::new(),
             });
         }
     }
 
     // Check for trailing IIFE entry point
     let has_trailing_entry = if let Some(entry_body) = extract_trailing_entry_body(bootstrap_body) {
+        let entry_ranges = spans_byte_ranges(&cm, entry_body.iter().map(|s| s.span()));
         let code = emit_webpack5_entry_module(entry_body, cm.clone(), &id_to_filename)?;
         modules.push(UnpackedModule {
             id: "entry".to_string(),
             is_entry: true,
             code,
             filename: "entry.js".to_string(),
+            source_ranges: entry_ranges,
+            source_input: String::new(),
         });
         true
     } else {

--- a/crates/core/tests/unpack_provenance.rs
+++ b/crates/core/tests/unpack_provenance.rs
@@ -1,0 +1,260 @@
+//! Provenance: every unpacked module reports the byte ranges in the original
+//! bundle it was extracted from, so callers (package detection, ground-truth
+//! builders) can map modules back to source-map positions.
+
+use wakaru_core::{
+    unpack, unpack_files, unpack_raw, DecompileOptions, ModuleProvenance, UnpackInput,
+};
+
+fn provenance_for<'a>(provenance: &'a [ModuleProvenance], filename: &str) -> &'a ModuleProvenance {
+    provenance
+        .iter()
+        .find(|entry| entry.filename == filename)
+        .unwrap_or_else(|| {
+            panic!(
+                "no provenance for {filename}; have {:?}",
+                provenance.iter().map(|p| &p.filename).collect::<Vec<_>>()
+            )
+        })
+}
+
+fn range_text<'s>(source: &'s str, entry: &ModuleProvenance) -> Vec<&'s str> {
+    entry
+        .ranges
+        .iter()
+        .map(|&(start, end)| &source[start as usize..end as usize])
+        .collect()
+}
+
+#[test]
+fn esbuild_factory_modules_report_factory_decl_ranges() {
+    let source = r#"
+var y = (q,K)=>()=>(q&&(K=q(q=0)),K);
+var mod_a = y(() => {
+    mod_a_val = 42;
+});
+var mod_b = y(() => { mod_b_val = "hello"; });
+var mod_c = y(() => { mod_c_val = true; });
+var mod_d = y(() => { mod_d_val = null; });
+var mod_e = y(() => { mod_e_val = undefined; });
+// entry
+mod_a();
+mod_b();
+mod_c();
+mod_d();
+mod_e();
+console.log(mod_a_val);
+"#;
+    let output = unpack(
+        source,
+        DecompileOptions {
+            filename: "bundle.js".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("unpack should succeed");
+
+    let mod_a = provenance_for(&output.provenance, "mod_a.js");
+    let texts = range_text(source, mod_a);
+    assert_eq!(texts.len(), 1, "factory module should have one range");
+    assert!(
+        texts[0].starts_with("mod_a = y(") && texts[0].contains("mod_a_val = 42"),
+        "range should cover the factory declarator, got: {:?}",
+        texts[0]
+    );
+
+    let entry = provenance_for(&output.provenance, "entry.js");
+    let entry_text = range_text(source, entry).join("\n");
+    assert!(
+        entry_text.contains("mod_a()") && entry_text.contains("console.log(mod_a_val)"),
+        "entry ranges should cover the trailing entry statements, got: {entry_text:?}"
+    );
+    assert!(
+        !entry_text.contains("mod_b_val = \"hello\""),
+        "entry ranges should not cover factory bodies, got: {entry_text:?}"
+    );
+}
+
+#[test]
+fn webpack5_modules_report_factory_body_ranges() {
+    let source = r#"
+(() => {
+  var __webpack_modules__ = ({
+    "./src/cjs.js": ((module) => {
+      module.exports = function greet(name) {
+        return "Hello, " + name;
+      };
+    }),
+    "./src/index.js": ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+      __webpack_require__.r(__webpack_exports__);
+      var _cjs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./src/cjs.js");
+      console.log(_cjs__WEBPACK_IMPORTED_MODULE_0__("Ada"));
+    })
+  });
+  var __webpack_module_cache__ = {};
+  function __webpack_require__(moduleId) {
+    var module = __webpack_module_cache__[moduleId] = { exports: {} };
+    __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+    return module.exports;
+  }
+  __webpack_require__("./src/index.js");
+})();
+"#;
+    let output = unpack(
+        source,
+        DecompileOptions {
+            filename: "bundle.js".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("unpack should succeed");
+
+    let cjs = provenance_for(&output.provenance, "src/cjs.js");
+    let texts = range_text(source, cjs).join("\n");
+    assert!(
+        texts.contains("Hello, "),
+        "cjs module range should cover its factory body, got: {texts:?}"
+    );
+    assert!(
+        !texts.contains("console.log"),
+        "cjs module range should not cover the index module, got: {texts:?}"
+    );
+}
+
+#[test]
+fn browserify_modules_report_module_entry_ranges() {
+    let source_path = "../../testcases/browserify/dist/index.js";
+    let source = std::fs::read_to_string(source_path).expect("failed to read browserify testcase");
+    let output = unpack(
+        &source,
+        DecompileOptions {
+            filename: source_path.to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("unpack should succeed");
+
+    let module = output
+        .provenance
+        .iter()
+        .find(|entry| entry.filename != "entry.js" && !entry.ranges.is_empty())
+        .expect("a non-entry browserify module should have provenance ranges");
+    let texts = range_text(&source, module).join("\n");
+    let code = output
+        .modules
+        .iter()
+        .find(|(name, _)| *name == module.filename)
+        .map(|(_, code)| code)
+        .expect("provenance filename should match an output module");
+    // The range must cover the module's own factory; spot-check that a
+    // distinctive token from the decompiled output appears inside the range.
+    let token = code
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .filter(|tok| tok.len() >= 8)
+        .find(|tok| texts.contains(tok));
+    assert!(
+        token.is_some(),
+        "no distinctive token of {} found inside its provenance range",
+        module.filename
+    );
+}
+
+#[test]
+fn raw_unpack_reports_provenance() {
+    let source = r#"
+var y = (q,K)=>()=>(q&&(K=q(q=0)),K);
+var mod_a = y(() => { mod_a_val = 42; });
+var mod_b = y(() => { mod_b_val = 7; });
+var mod_c = y(() => { mod_c_val = 1; });
+var mod_d = y(() => { mod_d_val = 2; });
+var mod_e = y(() => { mod_e_val = 3; });
+mod_a();
+mod_b();
+mod_c();
+mod_d();
+mod_e();
+console.log(mod_a_val);
+"#;
+    let output = unpack_raw(source, &DecompileOptions::default()).expect("raw unpack");
+    let mod_a = provenance_for(&output.provenance, "mod_a.js");
+    let texts = range_text(source, mod_a);
+    assert!(
+        texts[0].contains("mod_a_val = 42"),
+        "raw provenance should cover the factory, got: {texts:?}"
+    );
+}
+
+#[test]
+fn multi_source_unpack_attributes_provenance_to_inputs() {
+    let chunk_a = r#"
+(() => {
+  var __webpack_modules__ = ({
+    101: ((module) => {
+      module.exports = "from chunk a";
+    })
+  });
+  var __webpack_module_cache__ = {};
+  function __webpack_require__(moduleId) {
+    var module = __webpack_module_cache__[moduleId] = { exports: {} };
+    __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+    return module.exports;
+  }
+  __webpack_require__(101);
+})();
+"#;
+    let chunk_b = r#"
+(() => {
+  var __webpack_modules__ = ({
+    202: ((module) => {
+      module.exports = "from chunk b";
+    })
+  });
+  var __webpack_module_cache__ = {};
+  function __webpack_require__(moduleId) {
+    var module = __webpack_module_cache__[moduleId] = { exports: {} };
+    __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+    return module.exports;
+  }
+  __webpack_require__(202);
+})();
+"#;
+    let output = unpack_files(
+        vec![
+            UnpackInput {
+                filename: "chunk-a.js".to_string(),
+                source: chunk_a.to_string(),
+            },
+            UnpackInput {
+                filename: "chunk-b.js".to_string(),
+                source: chunk_b.to_string(),
+            },
+        ],
+        DecompileOptions::default(),
+    )
+    .expect("multi-source unpack should succeed");
+
+    let module_a = output
+        .provenance
+        .iter()
+        .find(|entry| {
+            let (start, end) = match entry.ranges.first() {
+                Some(&range) => range,
+                None => return false,
+            };
+            entry.input == "chunk-a.js"
+                && chunk_a[start as usize..end as usize].contains("from chunk a")
+        })
+        .expect("a module should be attributed to chunk-a.js with a covering range");
+    assert!(
+        !module_a.filename.is_empty(),
+        "provenance entries must name their module file"
+    );
+
+    assert!(
+        output
+            .provenance
+            .iter()
+            .any(|entry| entry.input == "chunk-b.js"),
+        "some module should be attributed to chunk-b.js"
+    );
+}


### PR DESCRIPTION
## What

Every `UnpackedModule` now records **where in the original bundle it came from**: `source_ranges` (byte ranges into the input source) and `source_input` (which physical input file, for multi-source unpacks). `UnpackOutput` exposes them as a `provenance` field, and the CLI gains `--unpack --provenance`, which writes a `provenance.json` next to the unpacked modules:

```json
{
  "modules": {
    "iP4_2.js": { "input": "cli.js", "ranges": [[2035682, 2050604]] }
  }
}
```

Ranges per format:
- esbuild factories: the factory var declarator span
- esbuild/Bun scope-hoisted modules: coalesced body-item spans (multiple ranges)
- webpack4/5: factory function / body statement spans
- browserify: module array entry span
- systemjs: `System.register` call span
- cycle premerge: union of member ranges (same-input cycles only)
- whole-input fallbacks: `(0, len)`

Keys in `provenance.json` use the final on-disk names (after CLI-side case-collision dedup), so consumers can join directly against the output directory.

## Why

Provenance turns unpacked modules back into addressable slices of the original bundle, enabling map-based and map-free tooling that was previously format-specific or impossible:
- **package-origin ground truth / detection** for any bundler with a source map (one position lookup instead of per-format anchoring heuristics)
- license/vuln auditing, bundle diffing across versions
- jumping from a decompiled module to the exact minified original

## Validation

- New integration suite `crates/core/tests/unpack_provenance.rs` (esbuild factory + entry, webpack5, browserify testcase, raw unpack, multi-source input attribution) and a CLI unit test for the JSON writer.
- Real-world check on a 9 MB esbuild bundle (4,796 modules): every module reports ranges; sampled factory ranges start exactly at their factory declarator byte offset.
- `cargo test -p wakaru-core` pipeline suites, `cargo test -p wakaru-cli`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` all green.

## Notes

- Dummy/synthesized spans yield empty `ranges` rather than fabricated positions.
- `span_byte_range` guards against out-of-file spans; ranges are byte offsets (UTF-8), documented in the field docs.