### PR TITLE
fix(systemjs): preserve IIFE exports before member assignments

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -699,7 +699,10 @@ impl SystemExecuteTransformer {
         if !is_default && !is_valid_ident_name(exported.as_ref()) {
             return None;
         }
-        let local = self.fresh_export_name();
+        let exported_local = exported_value_local(value.as_ref());
+        let local = exported_local
+            .clone()
+            .unwrap_or_else(|| self.fresh_export_name());
 
         let mut assignment = assign.clone();
         let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &mut assignment.left else {
@@ -714,20 +717,33 @@ impl SystemExecuteTransformer {
         assignment_stmt.visit_mut_with(self);
         let mut value = value;
         value.visit_mut_with(self);
-        let mut items = vec![self.binding_item(local.clone(), value)];
-        if is_default {
-            // Initialize the export before computed keys or the assignment RHS can re-enter.
-            items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
-                ExportDefaultExpr {
+        let mut items = if exported_local.is_some() {
+            self.add_export(local.clone(), exported);
+            match value.as_ref() {
+                Expr::Assign(_) => vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
                     span: DUMMY_SP,
-                    expr: Box::new(Expr::Ident(ident(local.clone()))),
-                },
-            )));
+                    expr: value,
+                }))],
+                Expr::Ident(_) => Vec::new(),
+                _ => unreachable!("exported_value_local accepted an unsupported expression"),
+            }
         } else {
-            self.declared_exports
-                .insert((local.clone(), exported.clone()));
-            items.push(named_export_item(local.clone(), exported));
-        }
+            let mut items = vec![self.binding_item(local.clone(), value)];
+            if is_default {
+                // Initialize the export before computed keys or the assignment RHS can re-enter.
+                items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
+                    ExportDefaultExpr {
+                        span: DUMMY_SP,
+                        expr: Box::new(Expr::Ident(ident(local.clone()))),
+                    },
+                )));
+            } else {
+                self.declared_exports
+                    .insert((local.clone(), exported.clone()));
+                items.push(named_export_item(local.clone(), exported));
+            }
+            items
+        };
         items.push(ModuleItem::Stmt(assignment_stmt));
         Some(items)
     }

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -3,16 +3,16 @@ use std::collections::HashSet;
 use swc_core::atoms::Atom;
 use swc_core::common::{sync::Lrc, SourceMap, Span, DUMMY_SP};
 use swc_core::ecma::ast::{
-    ArrayLit, ArrowFunctionBody, BindingIdent, CallExpr, Callee, Decl, EsVersion, ExportDecl,
-    ExportDefaultExpr, ExportNamedSpecifier, ExportSpecifier, Expr, ExprOrSpread, ExprStmt, FnExpr,
-    Function, FunctionBody, Ident, ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier,
-    ImportSpecifier, ImportStarAsSpecifier, Lit, MemberExpr, MemberProp, MetaPropExpr,
-    MetaPropKind, Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport, ObjectLit,
-    ParenExpr, Pat, Prop, PropName, PropOrSpread, ReturnStmt, Stmt, Str, UnaryOp, VarDecl,
-    VarDeclarator,
+    ArrayLit, ArrowFunctionBody, AssignTarget, BindingIdent, CallExpr, Callee, Decl, EsVersion,
+    ExportDecl, ExportDefaultExpr, ExportNamedSpecifier, ExportSpecifier, Expr, ExprOrSpread,
+    ExprStmt, FnExpr, Function, FunctionBody, Ident, ImportDecl, ImportDefaultSpecifier,
+    ImportNamedSpecifier, ImportSpecifier, ImportStarAsSpecifier, Lit, MemberExpr, MemberProp,
+    MetaPropExpr, MetaPropKind, Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport,
+    ObjectLit, ParenExpr, Pat, Prop, PropName, PropOrSpread, ReturnStmt, SimpleAssignTarget, Stmt,
+    Str, UnaryOp, VarDecl, VarDeclarator,
 };
 use swc_core::ecma::codegen::{text_writer::JsWriter, Config, Emitter};
-use swc_core::ecma::visit::{VisitMut, VisitMutWith};
+use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use crate::unpacker::{span_byte_range, BundleFormat, UnpackResult, UnpackedModule};
 
@@ -310,7 +310,12 @@ fn emit_system_module(
     }
     items.extend(register.prelude.iter().cloned().map(ModuleItem::Stmt));
 
-    let mut transformer = SystemExecuteTransformer::new(export_sym, context_sym);
+    let mut used_names = UsedIdentCollector::default();
+    register.declare.visit_with(&mut used_names);
+    for stmt in &register.prelude {
+        stmt.visit_with(&mut used_names);
+    }
+    let mut transformer = SystemExecuteTransformer::new(export_sym, context_sym, used_names.names);
     for stmt in outer_hoisted_stmts(body, &imported_locals) {
         transformer.push_stmt(stmt, &mut items);
     }
@@ -569,14 +574,18 @@ struct SystemExecuteTransformer {
     export_sym: Atom,
     context_sym: Option<Atom>,
     exports: Vec<ExportBinding>,
+    declared_exports: HashSet<(Atom, Atom)>,
+    used_names: HashSet<Atom>,
 }
 
 impl SystemExecuteTransformer {
-    fn new(export_sym: Atom, context_sym: Option<Atom>) -> Self {
+    fn new(export_sym: Atom, context_sym: Option<Atom>, used_names: HashSet<Atom>) -> Self {
         Self {
             export_sym,
             context_sym,
             exports: Vec::new(),
+            declared_exports: HashSet::new(),
+            used_names,
         }
     }
 
@@ -598,9 +607,14 @@ impl SystemExecuteTransformer {
         if self.exports.is_empty() {
             return Vec::new();
         }
-        let specifiers = self
+        let specifiers: Vec<_> = self
             .exports
             .into_iter()
+            .filter(|binding| {
+                !self
+                    .declared_exports
+                    .contains(&(binding.local.clone(), binding.exported.clone()))
+            })
             .map(|binding| {
                 let local = binding.local;
                 let exported = binding.exported;
@@ -616,6 +630,9 @@ impl SystemExecuteTransformer {
                 })
             })
             .collect();
+        if specifiers.is_empty() {
+            return Vec::new();
+        }
         vec![ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(
             NamedExport {
                 span: DUMMY_SP,
@@ -636,16 +653,19 @@ impl SystemExecuteTransformer {
                 let export_call = parse_export_call(call, &self.export_sym)?;
                 self.export_call_items(export_call)
             }
+            Expr::Assign(assign) => self.export_member_assignment_items(assign),
             Expr::Seq(seq) => {
                 let mut items = Vec::new();
                 let mut saw_export = false;
                 for expr in &seq.exprs {
-                    let export_call = match expr.as_ref() {
-                        Expr::Call(call) => parse_export_call(call, &self.export_sym),
+                    let export_items = match expr.as_ref() {
+                        Expr::Call(call) => parse_export_call(call, &self.export_sym)
+                            .and_then(|export_call| self.export_call_items(export_call)),
+                        Expr::Assign(assign) => self.export_member_assignment_items(assign),
                         _ => None,
                     };
-                    if let Some(export_call) = export_call {
-                        items.extend(self.export_call_items(export_call)?);
+                    if let Some(export_items) = export_items {
+                        items.extend(export_items);
                         saw_export = true;
                     } else {
                         let mut stmt = Stmt::Expr(ExprStmt {
@@ -659,6 +679,90 @@ impl SystemExecuteTransformer {
                 saw_export.then_some(items)
             }
             _ => None,
+        }
+    }
+
+    fn export_member_assignment_items(
+        &mut self,
+        assign: &swc_core::ecma::ast::AssignExpr,
+    ) -> Option<Vec<ModuleItem>> {
+        let member = assign.left.as_simple()?.as_member()?;
+        let Expr::Call(call) = member.obj.as_ref() else {
+            return None;
+        };
+        let ExportCall::Single { exported, value } = parse_export_call(call, &self.export_sym)?
+        else {
+            return None;
+        };
+
+        let is_default = exported.as_ref() == "default";
+        if !is_default && !is_valid_ident_name(exported.as_ref()) {
+            return None;
+        }
+        let local = self.fresh_export_name();
+
+        let mut assignment = assign.clone();
+        let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &mut assignment.left else {
+            return None;
+        };
+        *member.obj = Expr::Ident(ident(local.clone()));
+
+        let mut assignment_stmt = Stmt::Expr(ExprStmt {
+            span: DUMMY_SP,
+            expr: Box::new(Expr::Assign(assignment)),
+        });
+        assignment_stmt.visit_mut_with(self);
+        let mut value = value;
+        value.visit_mut_with(self);
+        let mut items = vec![self.binding_item(local.clone(), value)];
+        if is_default {
+            // Initialize the export before computed keys or the assignment RHS can re-enter.
+            items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
+                ExportDefaultExpr {
+                    span: DUMMY_SP,
+                    expr: Box::new(Expr::Ident(ident(local.clone()))),
+                },
+            )));
+        } else {
+            self.declared_exports
+                .insert((local.clone(), exported.clone()));
+            items.push(named_export_item(local.clone(), exported));
+        }
+        items.push(ModuleItem::Stmt(assignment_stmt));
+        Some(items)
+    }
+
+    fn binding_item(&self, local: Atom, value: Box<Expr>) -> ModuleItem {
+        let decl = Decl::Var(Box::new(VarDecl {
+            span: DUMMY_SP,
+            ctxt: Default::default(),
+            kind: swc_core::ecma::ast::VarDeclKind::Const,
+            declare: false,
+            decls: vec![VarDeclarator {
+                span: DUMMY_SP,
+                name: Pat::Ident(BindingIdent {
+                    id: ident(local),
+                    type_ann: None,
+                }),
+                init: Some(value),
+                definite: false,
+            }],
+        }));
+        ModuleItem::Stmt(Stmt::Decl(decl))
+    }
+
+    fn fresh_export_name(&mut self) -> Atom {
+        let base = Atom::from("__systemjs_export");
+        if self.used_names.insert(base.clone()) {
+            return base;
+        }
+        let mut suffix = 2u32;
+        loop {
+            let candidate = Atom::from(format!("__systemjs_export_{suffix}"));
+            if self.used_names.insert(candidate.clone()) {
+                return candidate;
+            }
+            suffix += 1;
         }
     }
 
@@ -686,6 +790,8 @@ impl SystemExecuteTransformer {
                     ))]);
                 }
                 if is_valid_ident_name(exported.as_ref()) {
+                    self.declared_exports
+                        .insert((exported.clone(), exported.clone()));
                     return Some(vec![ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(
                         ExportDecl {
                             span: DUMMY_SP,
@@ -748,6 +854,12 @@ impl SystemExecuteTransformer {
     }
 
     fn add_export(&mut self, local: Atom, exported: Atom) {
+        if self
+            .declared_exports
+            .contains(&(local.clone(), exported.clone()))
+        {
+            return;
+        }
         if self
             .exports
             .iter()
@@ -828,6 +940,21 @@ struct ExportBinding {
     exported: Atom,
 }
 
+fn named_export_item(local: Atom, exported: Atom) -> ModuleItem {
+    ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
+        span: DUMMY_SP,
+        specifiers: vec![ExportSpecifier::Named(ExportNamedSpecifier {
+            span: DUMMY_SP,
+            orig: ModuleExportName::Ident(ident(local)),
+            exported: Some(ModuleExportName::Ident(ident(exported))),
+            is_type_only: false,
+        })],
+        src: None,
+        type_only: false,
+        with: None,
+    }))
+}
+
 enum ExportCall {
     Single { exported: Atom, value: Box<Expr> },
     Bulk(Vec<(Atom, Box<Expr>)>),
@@ -881,13 +1008,35 @@ fn exported_value_local(expr: &Expr) -> Option<Atom> {
 }
 
 fn export_replacement_expr(value: Box<Expr>) -> Expr {
-    if matches!(value.as_ref(), Expr::Assign(_)) {
+    if matches!(value.as_ref(), Expr::Assign(_)) || is_function_callee_iife(value.as_ref()) {
         Expr::Paren(ParenExpr {
             span: DUMMY_SP,
             expr: value,
         })
     } else {
         *value
+    }
+}
+
+fn is_function_callee_iife(expr: &Expr) -> bool {
+    let Expr::Call(call) = expr else {
+        return false;
+    };
+    matches!(
+        &call.callee,
+        Callee::Expr(callee)
+            if matches!(callee.as_ref(), Expr::Fn(_) | Expr::Arrow(_))
+    )
+}
+
+#[derive(Default)]
+struct UsedIdentCollector {
+    names: HashSet<Atom>,
+}
+
+impl Visit for UsedIdentCollector {
+    fn visit_ident(&mut self, ident: &Ident) {
+        self.names.insert(ident.sym.clone());
     }
 }
 

--- a/crates/core/tests/bundles/systemjs-gen/dist/babel/chained-export.js
+++ b/crates/core/tests/bundles/systemjs-gen/dist/babel/chained-export.js
@@ -1,0 +1,13 @@
+System.register([], function (_export, _context) {
+  "use strict";
+
+  function item() {}
+  _export("item", item);
+  return {
+    setters: [],
+    execute: function () {
+      _export("item", item = makeOne()).a = 1;
+      _export("item", item = makeTwo()).b = 2;
+    }
+  };
+});

--- a/crates/core/tests/bundles/systemjs-gen/generate.mjs
+++ b/crates/core/tests/bundles/systemjs-gen/generate.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Generates SystemJS test fixtures from the source files in src/.
+// Generates SystemJS test fixtures from the checked-in source directories.
 // Requires Node.js + npm. Generated outputs are checked into the repo so tests
 // do not require Node.js.
 
@@ -74,6 +74,14 @@ run("npm", [
 run("npx", [
   "babel",
   "src",
+  "--out-dir",
+  "dist/babel",
+  "--plugins",
+  "@babel/plugin-transform-modules-systemjs",
+]);
+run("npx", [
+  "babel",
+  "src-babel",
   "--out-dir",
   "dist/babel",
   "--plugins",

--- a/crates/core/tests/bundles/systemjs-gen/src-babel/chained-export.js
+++ b/crates/core/tests/bundles/systemjs-gen/src-babel/chained-export.js
@@ -1,0 +1,4 @@
+export function item() {}
+
+(item = makeOne()).a = 1;
+(item = makeTwo()).b = 2;

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use wakaru_core::driver::test_support::{unpack, unpack_raw};
-use wakaru_core::DecompileOptions;
+use wakaru_core::{validate_output_modules, DecompileOptions};
 
 fn fixture(path: &str) -> String {
     let full = format!("tests/bundles/systemjs-gen/dist/{path}");
@@ -137,6 +137,42 @@ fn babel_systemjs_raw_reconstructs_outer_exports() {
     assert!(
         entry.contains("export { run, value };") || entry.contains("export { value, run };"),
         "Babel outer export and execute export should both survive:\n{entry}"
+    );
+}
+
+#[test]
+fn babel_chained_member_updates_share_one_live_export() {
+    let raw = unpack_fixture_raw("babel/chained-export.js");
+    assert_eq!(raw.len(), 1);
+
+    let entry = module_code(&raw, "entry.js");
+    assert_eq!(
+        validate_output_modules(&raw),
+        vec![],
+        "Babel chained updates should not create duplicate ESM exports:\n{entry}"
+    );
+
+    let first_value = entry
+        .find("item = makeOne();")
+        .unwrap_or_else(|| panic!("first exported assignment should survive:\n{entry}"));
+    let first_member = entry
+        .find("item.a = 1;")
+        .unwrap_or_else(|| panic!("first member update should use the live binding:\n{entry}"));
+    let second_value = entry
+        .find("item = makeTwo();")
+        .unwrap_or_else(|| panic!("second exported assignment should survive:\n{entry}"));
+    let second_member = entry
+        .find("item.b = 2;")
+        .unwrap_or_else(|| panic!("second member update should use the live binding:\n{entry}"));
+
+    assert!(
+        first_value < first_member && first_member < second_value && second_value < second_member,
+        "Babel chained export evaluation order should survive:\n{entry}"
+    );
+    assert_eq!(
+        entry.matches("export { item };").count(),
+        1,
+        "item should have one live ESM export:\n{entry}"
     );
 }
 

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -37,6 +37,17 @@ fn unpack_source(source: &str) -> Vec<(String, String)> {
     output.modules
 }
 
+fn unpack_source_raw(source: &str) -> Vec<(String, String)> {
+    let output =
+        unpack_raw(source, &DecompileOptions::default()).expect("unpack_raw should succeed");
+    assert!(
+        !output.has_errors(),
+        "unexpected raw warnings: {:?}",
+        output.warnings
+    );
+    output.modules
+}
+
 fn module_code<'a>(pairs: &'a [(String, String)], name: &str) -> &'a str {
     pairs
         .iter()
@@ -347,5 +358,362 @@ fn invalid_iife_system_register_preserves_whole_input() {
     assert!(
         output.detected_formats.is_empty(),
         "invalid IIFE System.register input should not be reported as a successful split"
+    );
+}
+
+#[test]
+fn named_iife_export_keeps_member_assignment_and_sequence_side_effect() {
+    let source = r#"
+System.register("entry", ["utils"], function (_export) {
+  var BaseClass;
+  return {
+    setters: [function (Utils) {
+      BaseClass = Utils.BaseClass;
+    }],
+    execute: function () {
+      _export("DerivedClass", function (BaseClass) {
+        function DerivedClass() {}
+        return DerivedClass;
+      }(BaseClass)).marker = "derived", after();
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    let binding = entry
+        .find("const __systemjs_export =")
+        .unwrap_or_else(|| panic!("named export binding should be recovered:\n{entry}"));
+    let named_export = entry
+        .find("export { __systemjs_export as DerivedClass };")
+        .unwrap_or_else(|| panic!("named export alias should be recovered:\n{entry}"));
+    let member_assignment = entry
+        .find("__systemjs_export.marker = \"derived\";")
+        .unwrap_or_else(|| panic!("member assignment should be preserved:\n{entry}"));
+    let after = entry
+        .find("after();")
+        .unwrap_or_else(|| panic!("sequence side effect should be preserved:\n{entry}"));
+
+    assert!(
+        binding < named_export && named_export < member_assignment && member_assignment < after,
+        "binding, named export, member assignment, and sequence side effect should preserve order:\n{entry}"
+    );
+    assert!(
+        !entry.lines().any(|line| line.starts_with("function (")),
+        "top-level anonymous function should not be emitted:\n{entry}"
+    );
+}
+
+#[test]
+fn member_export_avoids_outer_export_name_collision() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  var DerivedClass;
+  return {
+    execute: function () {
+      _export("DerivedClass", makeValue()).ready = true;
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("export { __systemjs_export as DerivedClass };")
+            && entry.contains("__systemjs_export.ready = true;"),
+        "member export should use a collision-free local alias:\n{entry}"
+    );
+    assert!(
+        !entry.contains("const DerivedClass ="),
+        "member export must not redeclare the outer binding:\n{entry}"
+    );
+}
+
+#[test]
+fn reserved_identifier_name_member_export_remains_parseable() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("class", makeValue()).ready = true;
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("export { __systemjs_export as class };")
+            && entry.contains("__systemjs_export.ready = true;"),
+        "reserved IdentifierName export should use a parseable alias:\n{entry}"
+    );
+}
+
+#[test]
+fn member_export_value_rewrites_context_import_and_meta() {
+    let source = r#"
+System.register("entry", [], function (_export, _context) {
+  return {
+    execute: function () {
+      _export("DerivedClass", makeValue(
+        _context.import("./dep.js"),
+        _context.meta.url
+      )).ready = true;
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains(r#"import("./dep.js")"#) && entry.contains("import.meta.url"),
+        "member export value should rewrite SystemJS context expressions:\n{entry}"
+    );
+    assert!(
+        !entry.contains("_context"),
+        "SystemJS context binding should not leak from the member export value:\n{entry}"
+    );
+}
+
+#[test]
+fn direct_static_class_iife_named_export_stays_supported() {
+    let source = r#"
+System.register("entry", ["utils"], function (_export) {
+  var BaseClass;
+  return {
+    setters: [function (Utils) {
+      BaseClass = Utils.BaseClass;
+    }],
+    execute: function () {
+      _export("DerivedClass", function (BaseClass) {
+        function DerivedClass() {}
+        DerivedClass.marker = "derived";
+        return DerivedClass;
+      }(BaseClass));
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("export const DerivedClass ="),
+        "direct named IIFE export should remain a declaration:\n{entry}"
+    );
+    assert!(
+        entry.contains("DerivedClass.marker = \"derived\";"),
+        "static class initialization should remain inside the IIFE:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_export_uses_one_collision_free_binding() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  var __systemjs_export;
+  var BaseClass;
+  return {
+    execute: function () {
+      _export("default", function (BaseClass) {
+        function DefaultValue() {}
+        return DefaultValue;
+      }(BaseClass)).marker = "default";
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source(source);
+    let entry = module_code(&modules, "entry.js");
+    let binding = entry
+        .find("const __systemjs_export_2 =")
+        .unwrap_or_else(|| panic!("default export should use a collision-free binding:\n{entry}"));
+    let member_assignment = entry
+        .find("__systemjs_export_2.marker = \"default\";")
+        .unwrap_or_else(|| panic!("member assignment should use the binding:\n{entry}"));
+    let default_export = entry
+        .find("export default __systemjs_export_2;")
+        .unwrap_or_else(|| panic!("default export should use the binding:\n{entry}"));
+
+    assert!(
+        binding < default_export && default_export < member_assignment,
+        "binding, default export, and member assignment should preserve order:\n{entry}"
+    );
+    assert_eq!(
+        entry.matches("function DefaultValue()").count(),
+        1,
+        "default export value should be evaluated once:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export default function") && !entry.contains("export default ("),
+        "default export must not apply the member assignment to the IIFE result:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_export_avoids_module_prelude_names() {
+    let source = r#"
+!function () {
+  var __systemjs_export;
+  System.register("entry", [], function (_export) {
+    var BaseClass;
+    return {
+      execute: function () {
+        _export("default", function (BaseClass) {
+          function DefaultValue() {}
+          return DefaultValue;
+        }(BaseClass)).ready = true;
+      }
+    };
+  });
+}();
+"#;
+
+    let modules = unpack_source(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("const __systemjs_export_2 =")
+            && entry.contains("export default __systemjs_export_2;"),
+        "default export binding should avoid names in the module prelude:\n{entry}"
+    );
+}
+
+#[test]
+fn direct_declaration_export_is_not_repeated_in_trailing_export_list() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("Utils", makeUtils());
+      _export("Utils", Utils);
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert_eq!(
+        entry.matches("export const Utils =").count(),
+        1,
+        "Utils should have exactly one export declaration:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export { Utils"),
+        "trailing named export list must not repeat Utils:\n{entry}"
+    );
+    assert_eq!(
+        entry.matches("export {").count(),
+        0,
+        "fully filtered trailing exports must not emit an empty export declaration:\n{entry}"
+    );
+}
+
+#[test]
+fn typescript_namespace_emit_is_not_double_exported() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  var Namespace;
+  return {
+    execute: function () {
+      (function (Namespace) {
+        Namespace.ready = true;
+      })(Namespace || _export("Namespace", Namespace = {}));
+      _export("Namespace", Namespace);
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert_eq!(
+        entry.matches("export const Namespace =").count(),
+        1,
+        "TypeScript namespace should have one export declaration:\n{entry}"
+    );
+    assert!(
+        entry.contains("ready: true") && !entry.contains("export { Namespace"),
+        "TypeScript namespace semantics should remain intact without a trailing duplicate:\n{entry}"
+    );
+}
+
+#[test]
+fn member_export_preserves_computed_assignment_and_sequence_order() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("DerivedClass", makeValue())[getKey()] += rhs(), after();
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    let binding = entry
+        .find("const __systemjs_export = makeValue();")
+        .unwrap_or_else(|| panic!("VALUE binding should be recovered:\n{entry}"));
+    let named_export = entry
+        .find("export { __systemjs_export as DerivedClass };")
+        .unwrap_or_else(|| panic!("named export alias should be recovered:\n{entry}"));
+    let assignment = entry
+        .find("__systemjs_export[getKey()] += rhs();")
+        .unwrap_or_else(|| panic!("computed assignment should be preserved:\n{entry}"));
+    let rest = entry
+        .find("after();")
+        .unwrap_or_else(|| panic!("sequence rest should be preserved:\n{entry}"));
+
+    assert!(
+        binding < named_export && named_export < assignment && assignment < rest,
+        "VALUE binding, named export, computed assignment, and sequence rest should preserve order:\n{entry}"
+    );
+    for call in ["makeValue()", "getKey()", "rhs()", "after()"] {
+        assert_eq!(
+            entry.matches(call).count(),
+            1,
+            "{call} should appear exactly once:\n{entry}"
+        );
+    }
+    assert!(
+        entry.contains("__systemjs_export[getKey()] += rhs();"),
+        "assignment operator and computed member should be preserved:\n{entry}"
+    );
+}
+
+#[test]
+fn nested_iife_export_replacement_remains_parseable() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("DefaultValue", function () {
+        function DefaultValue() {}
+        return DefaultValue;
+      }()).marker();
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains(".marker();") && !entry.contains("_export"),
+        "nested IIFE replacement should remain parseable without leaking the helper:\n{entry}"
     );
 }


### PR DESCRIPTION
## Summary
- Reconstruct SystemJS `_export(name, IIFE).member = ...` as a collision-free binding + export + member assignment, preserving sequence side effects.
- Keep default IIFE member exports single-evaluated and initialized before RHS/computed key side effects.
- Add `systemjs_unpack` regressions for named/default/sequence/reserved-name/collision cases.

## Test plan
- [ ] `cargo fmt --check`
- [ ] `cargo test -p wakaru-core --test systemjs_unpack`
- [ ] `cargo test -p wakaru-core systemjs`
- [ ] `cargo clippy -p wakaru-core --all-targets -- -D warnings`