### PR TITLE
fix(core): rename colliding async-flatten bindings; give zero-arg setters a dummy param

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Wakaru restores structure while respecting JavaScript semantics:
   Separate canonical baselines cover multi-file ESM module graphs. See
   [test262-roundtrip.md](./docs/test262-roundtrip.md) and the current
   [`test262-stats.json`](./scripts/correctness/test262-stats.json).
-- **97.4% pattern recovery across 1,847 transpiler × minifier test shapes.**
+- **97.4% pattern recovery across 1,858 transpiler × minifier test shapes.**
   Reproduction matrices compile known inputs through real Babel/TypeScript/
   SWC/esbuild/Terser version combinations and verify Wakaru recovers the
   original construct. Current rates per matrix:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Wakaru restores structure while respecting JavaScript semantics:
   Separate canonical baselines cover multi-file ESM module graphs. See
   [test262-roundtrip.md](./docs/test262-roundtrip.md) and the current
   [`test262-stats.json`](./scripts/correctness/test262-stats.json).
-- **97.4% pattern recovery across 1,826 transpiler × minifier test shapes.**
+- **97.4% pattern recovery across 1,847 transpiler × minifier test shapes.**
   Reproduction matrices compile known inputs through real Babel/TypeScript/
   SWC/esbuild/Terser version combinations and verify Wakaru recovers the
   original construct. Current rates per matrix:

--- a/crates/core/src/rules/decl_utils.rs
+++ b/crates/core/src/rules/decl_utils.rs
@@ -1,7 +1,10 @@
 use std::collections::HashSet;
 
 use swc_core::atoms::Atom;
-use swc_core::ecma::ast::{BindingIdent, Decl, Id, Ident, Param, Pat, Stmt, VarDecl, VarDeclKind};
+use swc_core::common::{SyntaxContext, DUMMY_SP};
+use swc_core::ecma::ast::{
+    BindingIdent, Decl, Function, Id, Ident, MethodKind, Param, Pat, Stmt, VarDecl, VarDeclKind,
+};
 use swc_core::ecma::utils::find_pat_ids;
 use swc_core::ecma::visit::{Visit, VisitWith};
 
@@ -21,6 +24,73 @@ pub fn has_duplicate_param_names(params: &[Param]) -> bool {
     params.iter().any(
         |param| matches!(&param.pat, Pat::Ident(binding) if !seen.insert(binding.id.sym.clone())),
     )
+}
+
+/// Add the required value parameter to a zero-argument function that is being
+/// recovered as a class setter. The name must not capture any existing
+/// reference when the callback body moves into method scope.
+pub(crate) fn ensure_setter_has_value_param(function: &mut Function) {
+    if !function.params.is_empty() {
+        return;
+    }
+    let name = dummy_setter_param_name(function);
+    function.params.push(Param {
+        span: DUMMY_SP,
+        decorators: vec![],
+        pat: Pat::Ident(BindingIdent {
+            id: Ident::new(name, DUMMY_SP, SyntaxContext::empty()),
+            type_ann: None,
+        }),
+    });
+}
+
+/// Whether cloning a function into a class method of `kind` would create an
+/// invalid accessor or a strict-mode duplicate parameter list.
+pub(crate) fn class_method_has_invalid_signature(function: &Function, kind: MethodKind) -> bool {
+    if has_duplicate_param_names(&function.params) {
+        return true;
+    }
+    match kind {
+        MethodKind::Getter => {
+            !function.params.is_empty() || function.is_async || function.is_generator
+        }
+        MethodKind::Setter => {
+            function.params.len() != 1
+                || matches!(&function.params[0].pat, Pat::Rest(_))
+                || function.is_async
+                || function.is_generator
+        }
+        MethodKind::Method => false,
+    }
+}
+
+fn dummy_setter_param_name(function: &Function) -> Atom {
+    struct Collector<'a> {
+        names: &'a mut HashSet<Atom>,
+    }
+
+    impl Visit for Collector<'_> {
+        fn visit_ident(&mut self, ident: &Ident) {
+            self.names.insert(ident.sym.clone());
+        }
+    }
+
+    let mut names = HashSet::new();
+    function.visit_with(&mut Collector { names: &mut names });
+    for candidate in ["_", "_v", "_0", "_1", "_2"] {
+        let atom: Atom = candidate.into();
+        if !names.contains(&atom) {
+            return atom;
+        }
+    }
+    let mut index = 3u32;
+    loop {
+        let atom: Atom = format!("_{index}").into();
+        if !names.contains(&atom) {
+            return atom;
+        }
+        index += 1;
+    }
 }
 
 /// Collect all binding names declared by a `Decl` (top-level only, does not

--- a/crates/core/src/rules/decl_utils.rs
+++ b/crates/core/src/rules/decl_utils.rs
@@ -3,10 +3,13 @@ use std::collections::HashSet;
 use swc_core::atoms::Atom;
 use swc_core::common::{SyntaxContext, DUMMY_SP};
 use swc_core::ecma::ast::{
-    BindingIdent, Decl, Function, Id, Ident, MethodKind, Param, Pat, Stmt, VarDecl, VarDeclKind,
+    BindingIdent, Decl, Expr, Function, Id, Ident, Lit, MethodKind, ObjectLit, Param, Pat, Prop,
+    PropName, PropOrSpread, Stmt, VarDecl, VarDeclKind,
 };
 use swc_core::ecma::utils::find_pat_ids;
 use swc_core::ecma::visit::{Visit, VisitWith};
+
+use crate::utils::paren::strip_parens;
 
 pub(crate) use crate::analysis::{binding_id, ident_matches_binding, BindingId};
 
@@ -61,6 +64,73 @@ pub(crate) fn class_method_has_invalid_signature(function: &Function, kind: Meth
                 || function.is_generator
         }
         MethodKind::Method => false,
+    }
+}
+
+/// Whether an accessor descriptor has the property attributes produced by
+/// class syntax. Direct `Object.defineProperty` defaults `configurable` to
+/// false, while class accessors are configurable and non-enumerable.
+pub(crate) fn class_accessor_descriptor_is_compatible(descriptor: &ObjectLit) -> bool {
+    let mut seen = HashSet::new();
+    let mut has_accessor = false;
+    let mut configurable = false;
+
+    for prop in &descriptor.props {
+        let PropOrSpread::Prop(prop) = prop else {
+            return false;
+        };
+        match prop.as_ref() {
+            Prop::KeyValue(key_value) => {
+                let Some(name) = static_prop_name(&key_value.key) else {
+                    return false;
+                };
+                if !seen.insert(name.clone()) {
+                    return false;
+                }
+                match name.as_ref() {
+                    "get" | "set" => {
+                        if !matches!(strip_parens(&key_value.value), Expr::Fn(_)) {
+                            return false;
+                        }
+                        has_accessor = true;
+                    }
+                    "configurable" => {
+                        if !matches!(strip_parens(&key_value.value), Expr::Lit(Lit::Bool(value)) if value.value)
+                        {
+                            return false;
+                        }
+                        configurable = true;
+                    }
+                    "enumerable" => {
+                        if !matches!(strip_parens(&key_value.value), Expr::Lit(Lit::Bool(value)) if !value.value)
+                        {
+                            return false;
+                        }
+                    }
+                    _ => return false,
+                }
+            }
+            Prop::Method(method) => {
+                let Some(name) = static_prop_name(&method.key) else {
+                    return false;
+                };
+                if !matches!(name.as_ref(), "get" | "set") || !seen.insert(name) {
+                    return false;
+                }
+                has_accessor = true;
+            }
+            _ => return false,
+        }
+    }
+
+    has_accessor && configurable
+}
+
+fn static_prop_name(name: &PropName) -> Option<Atom> {
+    match name {
+        PropName::Ident(ident) => Some(ident.sym.clone()),
+        PropName::Str(string) => Some(string.value.as_str()?.into()),
+        _ => None,
     }
 }
 

--- a/crates/core/src/rules/decl_utils.rs
+++ b/crates/core/src/rules/decl_utils.rs
@@ -67,63 +67,76 @@ pub(crate) fn class_method_has_invalid_signature(function: &Function, kind: Meth
     }
 }
 
-/// Whether an accessor descriptor has the property attributes produced by
-/// class syntax. Direct `Object.defineProperty` defaults `configurable` to
-/// false, while class accessors are configurable and non-enumerable.
-pub(crate) fn class_accessor_descriptor_is_compatible(descriptor: &ObjectLit) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClassAccessorDescriptorAttributes {
+    ClassCompatible,
+    Enumerable,
+}
+
+/// Classify exact accessor descriptors that can be traced back to class
+/// syntax. Direct `Object.defineProperty` defaults `configurable` to false,
+/// while class accessors are configurable and non-enumerable. TypeScript
+/// 3.5–3.8 is the known producer of the enumerable variant.
+pub(crate) fn class_accessor_descriptor_attributes(
+    descriptor: &ObjectLit,
+) -> Option<ClassAccessorDescriptorAttributes> {
     let mut seen = HashSet::new();
     let mut has_accessor = false;
     let mut configurable = false;
+    let mut enumerable = false;
 
     for prop in &descriptor.props {
         let PropOrSpread::Prop(prop) = prop else {
-            return false;
+            return None;
         };
         match prop.as_ref() {
             Prop::KeyValue(key_value) => {
-                let Some(name) = static_prop_name(&key_value.key) else {
-                    return false;
-                };
+                let name = static_prop_name(&key_value.key)?;
                 if !seen.insert(name.clone()) {
-                    return false;
+                    return None;
                 }
                 match name.as_ref() {
                     "get" | "set" => {
                         if !matches!(strip_parens(&key_value.value), Expr::Fn(_)) {
-                            return false;
+                            return None;
                         }
                         has_accessor = true;
                     }
                     "configurable" => {
                         if !matches!(strip_parens(&key_value.value), Expr::Lit(Lit::Bool(value)) if value.value)
                         {
-                            return false;
+                            return None;
                         }
                         configurable = true;
                     }
                     "enumerable" => {
-                        if !matches!(strip_parens(&key_value.value), Expr::Lit(Lit::Bool(value)) if !value.value)
-                        {
-                            return false;
-                        }
+                        let Expr::Lit(Lit::Bool(value)) = strip_parens(&key_value.value) else {
+                            return None;
+                        };
+                        enumerable = value.value;
                     }
-                    _ => return false,
+                    _ => return None,
                 }
             }
             Prop::Method(method) => {
-                let Some(name) = static_prop_name(&method.key) else {
-                    return false;
-                };
+                let name = static_prop_name(&method.key)?;
                 if !matches!(name.as_ref(), "get" | "set") || !seen.insert(name) {
-                    return false;
+                    return None;
                 }
                 has_accessor = true;
             }
-            _ => return false,
+            _ => return None,
         }
     }
 
-    has_accessor && configurable
+    if !has_accessor || !configurable {
+        return None;
+    }
+    Some(if enumerable {
+        ClassAccessorDescriptorAttributes::Enumerable
+    } else {
+        ClassAccessorDescriptorAttributes::ClassCompatible
+    })
 }
 
 fn static_prop_name(name: &PropName) -> Option<Atom> {

--- a/crates/core/src/rules/un_async_await.rs
+++ b/crates/core/src/rules/un_async_await.rs
@@ -418,7 +418,10 @@ fn hygienically_move_callback_locals(
     if colliding.is_empty() {
         return true;
     }
-    if stmts_have_direct_eval_or_with(moved_stmts) {
+    if stmts_have_direct_eval_or_with(moved_stmts)
+        || stmts_have_direct_eval_or_with(&destination_stmts[..replaced_index])
+        || stmts_have_direct_eval_or_with(&destination_stmts[replaced_index + 1..])
+    {
         return false;
     }
 

--- a/crates/core/src/rules/un_async_await.rs
+++ b/crates/core/src/rules/un_async_await.rs
@@ -13,9 +13,12 @@ use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 use super::cross_module_helper_refs::{
     collect_cross_module_ts_helper_refs, cross_module_ts_member_helper,
 };
-use super::decl_utils::{collect_decl_names, collect_pat_names, collect_var_decl_names};
+use super::decl_utils::{
+    collect_decl_binding_ids, collect_pat_names, collect_var_decl_binding_ids,
+};
+use super::eval_utils::is_direct_eval_call;
 use super::helper_matcher::{binding_key, ident_matches_binding};
-use super::rename_utils::BindingId;
+use super::rename_utils::{rename_bindings, BindingId, BindingRename};
 use super::state_machine::{
     invert_condition, stmts_contain_state_opcode_return, ForwardJumpJoin, IndexLoopContinueMode,
     OpcodeReturnScan, StateMachineProgram,
@@ -288,12 +291,13 @@ fn try_transform_generator(
         None => return false,
     };
 
-    let extracted = match extract_generator_stmts(body.stmts[return_idx].clone(), helpers) {
+    let mut extracted = match extract_generator_stmts(body.stmts[return_idx].clone(), helpers) {
         Some(extracted) => extracted,
         None => return false,
     };
-    if callback_locals_collide_with_destination(
-        &extracted.callback_local_names,
+    if !hygienically_move_callback_locals(
+        &mut extracted.stmts,
+        &extracted.callback_local_ids,
         &body.stmts,
         return_idx,
         reserved_names,
@@ -320,7 +324,7 @@ fn is_generator_return(stmt: &Stmt, helpers: &AsyncHelperContext) -> bool {
 
 struct ExtractedGenerator {
     stmts: Vec<Stmt>,
-    callback_local_names: HashSet<Atom>,
+    callback_local_ids: HashSet<BindingId>,
 }
 
 fn extract_generator_stmts(stmt: Stmt, helpers: &AsyncHelperContext) -> Option<ExtractedGenerator> {
@@ -350,7 +354,7 @@ fn extract_generator_stmts(stmt: Stmt, helpers: &AsyncHelperContext) -> Option<E
     let body = fn_expr.function.body?;
     let mut state_stmt = None;
     let mut callback_locals = Vec::new();
-    let mut callback_local_names = HashSet::new();
+    let mut callback_local_ids = HashSet::new();
     for stmt in body.stmts {
         match stmt {
             Stmt::Switch(_) | Stmt::Return(_) => {
@@ -362,7 +366,7 @@ fn extract_generator_stmts(stmt: Stmt, helpers: &AsyncHelperContext) -> Option<E
                 if var.kind == VarDeclKind::Var
                     && var.decls.iter().all(|decl| decl.init.is_none()) =>
             {
-                collect_var_decl_names(&var, &mut callback_local_names);
+                collect_var_decl_binding_ids(&var, &mut callback_local_ids);
                 callback_locals.push(Stmt::Decl(Decl::Var(var)));
             }
             Stmt::Empty(_) => {}
@@ -379,7 +383,7 @@ fn extract_generator_stmts(stmt: Stmt, helpers: &AsyncHelperContext) -> Option<E
     callback_locals.extend(decoded);
     Some(ExtractedGenerator {
         stmts: callback_locals,
-        callback_local_names,
+        callback_local_ids,
     })
 }
 
@@ -391,20 +395,93 @@ fn binding_names_from_params(params: &[Param]) -> HashSet<Atom> {
     names
 }
 
-fn callback_locals_collide_with_destination(
-    callback_local_names: &HashSet<Atom>,
+/// Rename moved callback locals that would collide with the destination
+/// function's parameters or other identifiers. Direct `eval` / `with` can
+/// observe the original names as strings, so those cases stay fail-closed.
+fn hygienically_move_callback_locals(
+    moved_stmts: &mut [Stmt],
+    moved_ids: &HashSet<BindingId>,
     destination_stmts: &[Stmt],
     replaced_index: usize,
     reserved_names: &HashSet<Atom>,
 ) -> bool {
-    if callback_local_names.is_empty() {
-        return false;
+    if moved_ids.is_empty() {
+        return true;
     }
     let destination_names =
         destination_identifier_names(destination_stmts, Some(replaced_index), reserved_names);
-    callback_local_names
+    let colliding: Vec<BindingId> = moved_ids
         .iter()
-        .any(|name| destination_names.contains(name))
+        .filter(|(name, _)| destination_names.contains(name))
+        .cloned()
+        .collect();
+    if colliding.is_empty() {
+        return true;
+    }
+    if stmts_have_direct_eval_or_with(moved_stmts) {
+        return false;
+    }
+
+    let mut reserved = destination_names;
+    reserved.extend(destination_identifier_names(
+        moved_stmts,
+        None,
+        &HashSet::new(),
+    ));
+    let renames: Vec<BindingRename> = colliding
+        .into_iter()
+        .map(|old| {
+            let new = allocate_unique_name(&old.0, &mut reserved);
+            BindingRename { old, new }
+        })
+        .collect();
+    for stmt in moved_stmts.iter_mut() {
+        rename_bindings(stmt, &renames);
+    }
+    true
+}
+
+fn allocate_unique_name(base: &Atom, reserved: &mut HashSet<Atom>) -> Atom {
+    let mut index = 1u32;
+    loop {
+        let candidate: Atom = format!("{base}{index}").into();
+        if reserved.insert(candidate.clone()) {
+            return candidate;
+        }
+        index += 1;
+    }
+}
+
+fn stmts_have_direct_eval_or_with(stmts: &[Stmt]) -> bool {
+    struct Finder {
+        found: bool,
+    }
+
+    impl Visit for Finder {
+        fn visit_with_stmt(&mut self, _: &swc_core::ecma::ast::WithStmt) {
+            self.found = true;
+        }
+
+        fn visit_call_expr(&mut self, call: &CallExpr) {
+            if self.found {
+                return;
+            }
+            if is_direct_eval_call(call) {
+                self.found = true;
+                return;
+            }
+            call.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder { found: false };
+    for stmt in stmts {
+        stmt.visit_with(&mut finder);
+        if finder.found {
+            return true;
+        }
+    }
+    false
 }
 
 fn destination_identifier_names(
@@ -1586,10 +1663,11 @@ fn try_transform_awaiter(
         .iter()
         .position(|stmt| is_awaiter_return(stmt, helpers))?;
 
-    let inner_stmts = extract_awaiter_body(body.stmts[return_idx].clone(), helpers)?;
-    let moved_names = moved_function_scope_names(&inner_stmts);
-    if callback_locals_collide_with_destination(
-        &moved_names,
+    let mut inner_stmts = extract_awaiter_body(body.stmts[return_idx].clone(), helpers)?;
+    let moved_ids = moved_function_scope_binding_ids(&inner_stmts);
+    if !hygienically_move_callback_locals(
+        &mut inner_stmts,
+        &moved_ids,
         &body.stmts,
         return_idx,
         reserved_names,
@@ -1602,7 +1680,6 @@ fn try_transform_awaiter(
     body.stmts.remove(return_idx);
 
     // Replace yield with await in the extracted statements
-    let mut inner_stmts = inner_stmts;
     replace_yield_with_await(&mut inner_stmts);
 
     // Splice the inner statements in place of the return
@@ -1610,27 +1687,27 @@ fn try_transform_awaiter(
     Some(saved_stmts)
 }
 
-/// Names whose binding scope changes when the awaiter callback body is spliced
+/// Bindings whose scope changes when the awaiter callback body is spliced
 /// into its containing function. Function-scoped `var` declarations are
 /// collected through nested blocks, while top-level lexical/function/class
 /// declarations are collected directly. Nested callable and class scopes stay
 /// intact and are not part of the move.
-fn moved_function_scope_names(stmts: &[Stmt]) -> HashSet<Atom> {
-    let mut names = HashSet::new();
+fn moved_function_scope_binding_ids(stmts: &[Stmt]) -> HashSet<BindingId> {
+    let mut ids = HashSet::new();
     for stmt in stmts {
         if let Stmt::Decl(decl) = stmt {
-            collect_decl_names(decl, &mut names);
+            collect_decl_binding_ids(decl, &mut ids);
         }
     }
 
-    struct FunctionVarNameCollector<'a> {
-        names: &'a mut HashSet<Atom>,
+    struct FunctionVarIdCollector<'a> {
+        ids: &'a mut HashSet<BindingId>,
     }
 
-    impl Visit for FunctionVarNameCollector<'_> {
+    impl Visit for FunctionVarIdCollector<'_> {
         fn visit_var_decl(&mut self, var: &VarDecl) {
             if var.kind == VarDeclKind::Var {
-                collect_var_decl_names(var, self.names);
+                collect_var_decl_binding_ids(var, self.ids);
             }
         }
 
@@ -1641,11 +1718,11 @@ fn moved_function_scope_names(stmts: &[Stmt]) -> HashSet<Atom> {
         fn visit_class(&mut self, _class: &swc_core::ecma::ast::Class) {}
     }
 
-    let mut collector = FunctionVarNameCollector { names: &mut names };
+    let mut collector = FunctionVarIdCollector { ids: &mut ids };
     for stmt in stmts {
         stmt.visit_with(&mut collector);
     }
-    names
+    ids
 }
 
 fn is_awaiter_return(stmt: &Stmt, helpers: &AsyncHelperContext) -> bool {

--- a/crates/core/src/rules/un_async_await.rs
+++ b/crates/core/src/rules/un_async_await.rs
@@ -3,10 +3,10 @@ use std::collections::{HashMap, HashSet};
 use swc_core::atoms::Atom;
 use swc_core::common::{Mark, Span, Spanned, DUMMY_SP};
 use swc_core::ecma::ast::{
-    ArrowExpr, AssignExpr, AssignOp, AssignTarget, AwaitExpr, CallExpr, Callee, Decl, Expr,
-    ExprOrSpread, ExprStmt, Function, FunctionBody, Ident, IfStmt, MemberExpr, Module, Param, Pat,
-    Prop, PropName, ReturnStmt, SeqExpr, SimpleAssignTarget, Stmt, SwitchCase, VarDecl,
-    VarDeclKind, VarDeclarator, YieldExpr,
+    ArrowExpr, AssignExpr, AssignOp, AssignTarget, AssignTargetPat, AwaitExpr, CallExpr, Callee,
+    Decl, Expr, ExprOrSpread, ExprStmt, Function, FunctionBody, Ident, IfStmt, MemberExpr, Module,
+    ObjectPat, ObjectPatProp, Param, Pat, Prop, PropName, ReturnStmt, SeqExpr, SimpleAssignTarget,
+    Stmt, SwitchCase, VarDecl, VarDeclKind, VarDeclarator, YieldExpr,
 };
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
@@ -14,7 +14,7 @@ use super::cross_module_helper_refs::{
     collect_cross_module_ts_helper_refs, cross_module_ts_member_helper,
 };
 use super::decl_utils::{
-    collect_decl_binding_ids, collect_pat_names, collect_var_decl_binding_ids,
+    binding_id, collect_decl_binding_ids, collect_pat_names, collect_var_decl_binding_ids,
 };
 use super::eval_utils::is_direct_eval_call;
 use super::helper_matcher::{binding_key, ident_matches_binding};
@@ -397,7 +397,9 @@ fn binding_names_from_params(params: &[Param]) -> HashSet<Atom> {
 
 /// Rename moved callback locals that would collide with the destination
 /// function's parameters or other identifiers. Direct `eval` / `with` can
-/// observe the original names as strings, so those cases stay fail-closed.
+/// observe the original names as strings, and callable declarations or
+/// anonymous initializers can expose them through `.name`, so those cases stay
+/// fail-closed.
 fn hygienically_move_callback_locals(
     moved_stmts: &mut [Stmt],
     moved_ids: &HashSet<BindingId>,
@@ -424,6 +426,9 @@ fn hygienically_move_callback_locals(
     {
         return false;
     }
+    if renaming_changes_callable_name(moved_stmts, &colliding) {
+        return false;
+    }
 
     let mut reserved = destination_names;
     reserved.extend(destination_identifier_names(
@@ -442,6 +447,165 @@ fn hygienically_move_callback_locals(
         rename_bindings(stmt, &renames);
     }
     true
+}
+
+/// Whether renaming any colliding binding would change an observable
+/// `Function.name` / class `name`. Declarations carry their binding name
+/// directly; anonymous function, class, and arrow expressions also infer a
+/// name from direct declarations, assignments, and destructuring defaults.
+fn renaming_changes_callable_name(stmts: &[Stmt], colliding: &[BindingId]) -> bool {
+    let colliding: HashSet<BindingId> = colliding.iter().cloned().collect();
+
+    for stmt in stmts {
+        let Stmt::Decl(decl) = stmt else {
+            continue;
+        };
+        let id = match decl {
+            Decl::Fn(function) => Some(binding_id(&function.ident)),
+            Decl::Class(class) => Some(binding_id(&class.ident)),
+            _ => None,
+        };
+        if id.is_some_and(|id| colliding.contains(&id)) {
+            return true;
+        }
+    }
+
+    struct Finder<'a> {
+        colliding: &'a HashSet<BindingId>,
+        found: bool,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_var_declarator(&mut self, declarator: &VarDeclarator) {
+            if self.found {
+                return;
+            }
+            if pat_default_infers_colliding_name(&declarator.name, self.colliding)
+                || matches!(
+                    (&declarator.name, declarator.init.as_deref()),
+                    (Pat::Ident(binding), Some(init))
+                        if self.colliding.contains(&binding_id(&binding.id))
+                            && is_anonymous_callable(init)
+                )
+            {
+                self.found = true;
+                return;
+            }
+            declarator.visit_children_with(self);
+        }
+
+        fn visit_assign_expr(&mut self, assign: &AssignExpr) {
+            if self.found {
+                return;
+            }
+            let direct_target_infers_name = matches!(
+                assign.op,
+                AssignOp::Assign
+                    | AssignOp::AndAssign
+                    | AssignOp::OrAssign
+                    | AssignOp::NullishAssign
+            ) && assign_target_binding(&assign.left)
+                .is_some_and(|id| self.colliding.contains(&id))
+                && is_anonymous_callable(&assign.right);
+            let pattern_default_infers_name = match &assign.left {
+                AssignTarget::Pat(pattern) => {
+                    assign_target_pat_default_infers_colliding_name(pattern, self.colliding)
+                }
+                AssignTarget::Simple(_) => false,
+            };
+            if direct_target_infers_name || pattern_default_infers_name {
+                self.found = true;
+                return;
+            }
+            assign.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder {
+        colliding: &colliding,
+        found: false,
+    };
+    for stmt in stmts {
+        stmt.visit_with(&mut finder);
+        if finder.found {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_anonymous_callable(expr: &Expr) -> bool {
+    match strip_parens(expr) {
+        Expr::Arrow(_) => true,
+        Expr::Fn(function) => function.ident.is_none(),
+        Expr::Class(class) => class.ident.is_none(),
+        _ => false,
+    }
+}
+
+fn assign_target_binding(target: &AssignTarget) -> Option<BindingId> {
+    let AssignTarget::Simple(target) = target else {
+        return None;
+    };
+    match target {
+        SimpleAssignTarget::Ident(binding) => Some(binding_id(&binding.id)),
+        SimpleAssignTarget::Paren(paren) => match strip_parens(&paren.expr) {
+            Expr::Ident(ident) => Some(binding_id(ident)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn assign_target_pat_default_infers_colliding_name(
+    pattern: &AssignTargetPat,
+    colliding: &HashSet<BindingId>,
+) -> bool {
+    match pattern {
+        AssignTargetPat::Array(array) => array
+            .elems
+            .iter()
+            .flatten()
+            .any(|pattern| pat_default_infers_colliding_name(pattern, colliding)),
+        AssignTargetPat::Object(object) => {
+            object_pat_default_infers_colliding_name(object, colliding)
+        }
+        AssignTargetPat::Invalid(_) => false,
+    }
+}
+
+fn pat_default_infers_colliding_name(pattern: &Pat, colliding: &HashSet<BindingId>) -> bool {
+    match pattern {
+        Pat::Assign(assign) => {
+            matches!(assign.left.as_ref(), Pat::Ident(binding)
+                if colliding.contains(&binding_id(&binding.id))
+                    && is_anonymous_callable(&assign.right))
+                || pat_default_infers_colliding_name(&assign.left, colliding)
+        }
+        Pat::Array(array) => array
+            .elems
+            .iter()
+            .flatten()
+            .any(|pattern| pat_default_infers_colliding_name(pattern, colliding)),
+        Pat::Object(object) => object_pat_default_infers_colliding_name(object, colliding),
+        Pat::Rest(rest) => pat_default_infers_colliding_name(&rest.arg, colliding),
+        Pat::Ident(_) | Pat::Expr(_) | Pat::Invalid(_) => false,
+    }
+}
+
+fn object_pat_default_infers_colliding_name(
+    object: &ObjectPat,
+    colliding: &HashSet<BindingId>,
+) -> bool {
+    object.props.iter().any(|prop| match prop {
+        ObjectPatProp::Assign(assign) => assign.value.as_deref().is_some_and(|default| {
+            colliding.contains(&binding_id(&assign.key.id)) && is_anonymous_callable(default)
+        }),
+        ObjectPatProp::KeyValue(key_value) => {
+            pat_default_infers_colliding_name(&key_value.value, colliding)
+        }
+        ObjectPatProp::Rest(rest) => pat_default_infers_colliding_name(&rest.arg, colliding),
+    })
 }
 
 fn allocate_unique_name(base: &Atom, reserved: &mut HashSet<Atom>) -> Atom {

--- a/crates/core/src/rules/un_es6_class.rs
+++ b/crates/core/src/rules/un_es6_class.rs
@@ -15,8 +15,8 @@ use swc_core::ecma::utils::find_pat_ids;
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use super::decl_utils::{
-    class_accessor_descriptor_is_compatible, class_method_has_invalid_signature,
-    ensure_setter_has_value_param,
+    class_accessor_descriptor_attributes, class_method_has_invalid_signature,
+    ensure_setter_has_value_param, ClassAccessorDescriptorAttributes,
 };
 use super::expr_utils::is_unresolved_ident;
 use super::helper_matcher::{binding_key, BindingKey};
@@ -1311,7 +1311,7 @@ fn parse_class_body(
     create_class_helpers: &HashSet<BindingKey>,
     call_super_helpers: &HashSet<BindingKey>,
     has_super: bool,
-    allow_static_fields: bool,
+    allow_standard_assumptions: bool,
     unresolved_mark: Mark,
 ) -> Option<Vec<ClassMember>> {
     // The first real statement should define the constructor function.
@@ -1440,7 +1440,7 @@ fn parse_class_body(
             //
             // In derived classes this is observably different from a static
             // field if the superclass has a setter for that property.
-            if allow_static_fields
+            if allow_standard_assumptions
                 && !has_super
                 && try_parse_static_field_assignment(expr, inner_ctor_name, &mut members)
             {
@@ -1453,6 +1453,7 @@ fn parse_class_body(
                 inner_ctor_name,
                 &proto_alias,
                 &mut members,
+                allow_standard_assumptions,
                 unresolved_mark,
             ) {
                 continue;
@@ -1762,6 +1763,7 @@ fn try_parse_object_define_property(
     ctor_name: &str,
     proto_alias: &Option<Atom>,
     members: &mut Vec<ClassMember>,
+    allow_legacy_typescript_attributes: bool,
     unresolved_mark: Mark,
 ) -> bool {
     let Expr::Call(call) = expr else {
@@ -1800,16 +1802,32 @@ fn try_parse_object_define_property(
 
     let original_len = members.len();
     let value_fn = descriptor_value_method_fn(obj);
-    let accessor_descriptor_is_compatible = class_accessor_descriptor_is_compatible(obj);
+    let accessor_descriptor_is_compatible = match class_accessor_descriptor_attributes(obj) {
+        Some(ClassAccessorDescriptorAttributes::ClassCompatible) => true,
+        // Assumption: `transpiled_class_accessor_attributes`. TypeScript
+        // 3.5–3.8 emits `enumerable: true` while lowering source-level class
+        // accessors. Only UnEs6Class has the surrounding class-IIFE proof.
+        Some(ClassAccessorDescriptorAttributes::Enumerable) => allow_legacy_typescript_attributes,
+        None => false,
+    };
 
     for prop in &obj.props {
-        let swc_core::ecma::ast::PropOrSpread::Prop(p) = prop else {
+        let swc_core::ecma::ast::PropOrSpread::Prop(prop) = prop else {
             continue;
         };
-        let swc_core::ecma::ast::Prop::KeyValue(kv) = p.as_ref() else {
-            continue;
+        let (key, function) = match prop.as_ref() {
+            swc_core::ecma::ast::Prop::KeyValue(kv) => {
+                let Expr::Fn(fn_expr) = strip_parens(&kv.value) else {
+                    continue;
+                };
+                (&kv.key, fn_expr.function.as_ref())
+            }
+            // Native descriptor method syntax and ObjMethodShorthand both
+            // store the callback as a MethodProp under swc_core 77.
+            swc_core::ecma::ast::Prop::Method(method) => (&method.key, method.function.as_ref()),
+            _ => continue,
         };
-        let key_name = match &kv.key {
+        let key_name = match key {
             PropName::Ident(iden) => iden.sym.clone(),
             PropName::Str(s) => s.value.as_str().unwrap_or("").into(),
             _ => continue,
@@ -1822,12 +1840,8 @@ fn try_parse_object_define_property(
         if !accessor_descriptor_is_compatible {
             return false;
         }
-        let fn_expr = match strip_parens(&kv.value) {
-            Expr::Fn(f) => f,
-            _ => continue,
-        };
         let method_key = PropName::Ident(IdentName::new(sym.clone(), DUMMY_SP));
-        let method = build_class_method(method_key, fn_expr, false, kind);
+        let method = build_class_method_from_function(method_key, function, false, kind);
         members.push(ClassMember::Method(method));
     }
 
@@ -3396,12 +3410,21 @@ fn build_class_method(
     is_static: bool,
     kind: MethodKind,
 ) -> ClassMethod {
-    let method_span = if fn_expr.function.span.lo.0 != 0 {
-        fn_expr.function.span
+    build_class_method_from_function(key, &fn_expr.function, is_static, kind)
+}
+
+fn build_class_method_from_function(
+    key: PropName,
+    source: &Function,
+    is_static: bool,
+    kind: MethodKind,
+) -> ClassMethod {
+    let method_span = if source.span.lo.0 != 0 {
+        source.span
     } else {
         DUMMY_SP
     };
-    let mut function = fn_expr.function.clone();
+    let mut function = Box::new(source.clone());
     // Object.defineProperty setters may have zero parameters; class `set`
     // accessors must have exactly one.
     if kind == MethodKind::Setter {

--- a/crates/core/src/rules/un_es6_class.rs
+++ b/crates/core/src/rules/un_es6_class.rs
@@ -14,7 +14,10 @@ use swc_core::ecma::ast::{
 use swc_core::ecma::utils::find_pat_ids;
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
-use super::decl_utils::{class_method_has_invalid_signature, ensure_setter_has_value_param};
+use super::decl_utils::{
+    class_accessor_descriptor_is_compatible, class_method_has_invalid_signature,
+    ensure_setter_has_value_param,
+};
 use super::expr_utils::is_unresolved_ident;
 use super::helper_matcher::{binding_key, BindingKey};
 use super::transpiler_helper_utils::{
@@ -1797,6 +1800,7 @@ fn try_parse_object_define_property(
 
     let original_len = members.len();
     let value_fn = descriptor_value_method_fn(obj);
+    let accessor_descriptor_is_compatible = class_accessor_descriptor_is_compatible(obj);
 
     for prop in &obj.props {
         let swc_core::ecma::ast::PropOrSpread::Prop(p) = prop else {
@@ -1815,6 +1819,9 @@ fn try_parse_object_define_property(
             "set" => MethodKind::Setter,
             _ => continue,
         };
+        if !accessor_descriptor_is_compatible {
+            return false;
+        }
         let fn_expr = match strip_parens(&kv.value) {
             Expr::Fn(f) => f,
             _ => continue,

--- a/crates/core/src/rules/un_es6_class.rs
+++ b/crates/core/src/rules/un_es6_class.rs
@@ -3391,15 +3391,63 @@ fn build_class_method(
     } else {
         DUMMY_SP
     };
+    let mut function = fn_expr.function.clone();
+    // Object.defineProperty setters may have zero parameters; class `set`
+    // accessors must have exactly one.
+    if kind == MethodKind::Setter {
+        ensure_setter_has_value_param(&mut function);
+    }
     ClassMethod {
         span: method_span,
         key,
-        function: fn_expr.function.clone(),
+        function,
         kind,
         is_static,
         accessibility: None,
         is_abstract: false,
         is_optional: false,
         is_override: false,
+    }
+}
+
+fn ensure_setter_has_value_param(function: &mut Function) {
+    if !function.params.is_empty() {
+        return;
+    }
+    let name = dummy_setter_param_name(function);
+    function.params.push(Param {
+        span: DUMMY_SP,
+        decorators: vec![],
+        pat: Pat::Ident(BindingIdent {
+            id: Ident::new(name, DUMMY_SP, SyntaxContext::empty()),
+            type_ann: None,
+        }),
+    });
+}
+
+fn dummy_setter_param_name(function: &Function) -> Atom {
+    let mut names = HashSet::new();
+    struct Collector<'a> {
+        names: &'a mut HashSet<Atom>,
+    }
+    impl Visit for Collector<'_> {
+        fn visit_ident(&mut self, ident: &Ident) {
+            self.names.insert(ident.sym.clone());
+        }
+    }
+    function.visit_with(&mut Collector { names: &mut names });
+    for candidate in ["_", "_v", "_0", "_1", "_2"] {
+        let atom: Atom = candidate.into();
+        if !names.contains(&atom) {
+            return atom;
+        }
+    }
+    let mut index = 3u32;
+    loop {
+        let atom: Atom = format!("_{index}").into();
+        if !names.contains(&atom) {
+            return atom;
+        }
+        index += 1;
     }
 }

--- a/crates/core/src/rules/un_es6_class.rs
+++ b/crates/core/src/rules/un_es6_class.rs
@@ -14,7 +14,7 @@ use swc_core::ecma::ast::{
 use swc_core::ecma::utils::find_pat_ids;
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
-use super::decl_utils::has_duplicate_param_names;
+use super::decl_utils::{class_method_has_invalid_signature, ensure_setter_has_value_param};
 use super::expr_utils::is_unresolved_ident;
 use super::helper_matcher::{binding_key, BindingKey};
 use super::transpiler_helper_utils::{
@@ -1516,9 +1516,10 @@ fn parse_class_body(
         return None;
     }
 
-    // Class bodies are strict mode, so a sloppy-mode duplicate parameter list
-    // on any member would be an early error — keep the original IIFE.
-    if members.iter().any(class_member_has_duplicate_params) {
+    // Class bodies are strict mode and accessor syntax has stricter signatures
+    // than descriptor callback functions. Keep the original IIFE rather than
+    // emit an early error or silently discard observable parameters.
+    if members.iter().any(class_member_has_invalid_signature) {
         return None;
     }
 
@@ -1526,7 +1527,7 @@ fn parse_class_body(
     Some(members)
 }
 
-fn class_member_has_duplicate_params(member: &ClassMember) -> bool {
+fn class_member_has_invalid_signature(member: &ClassMember) -> bool {
     match member {
         ClassMember::Constructor(ctor) => {
             let mut seen = HashSet::new();
@@ -1538,7 +1539,9 @@ fn class_member_has_duplicate_params(member: &ClassMember) -> bool {
                 )
             })
         }
-        ClassMember::Method(method) => has_duplicate_param_names(&method.function.params),
+        ClassMember::Method(method) => {
+            class_method_has_invalid_signature(&method.function, method.kind)
+        }
         _ => false,
     }
 }
@@ -3407,47 +3410,5 @@ fn build_class_method(
         is_abstract: false,
         is_optional: false,
         is_override: false,
-    }
-}
-
-fn ensure_setter_has_value_param(function: &mut Function) {
-    if !function.params.is_empty() {
-        return;
-    }
-    let name = dummy_setter_param_name(function);
-    function.params.push(Param {
-        span: DUMMY_SP,
-        decorators: vec![],
-        pat: Pat::Ident(BindingIdent {
-            id: Ident::new(name, DUMMY_SP, SyntaxContext::empty()),
-            type_ann: None,
-        }),
-    });
-}
-
-fn dummy_setter_param_name(function: &Function) -> Atom {
-    let mut names = HashSet::new();
-    struct Collector<'a> {
-        names: &'a mut HashSet<Atom>,
-    }
-    impl Visit for Collector<'_> {
-        fn visit_ident(&mut self, ident: &Ident) {
-            self.names.insert(ident.sym.clone());
-        }
-    }
-    function.visit_with(&mut Collector { names: &mut names });
-    for candidate in ["_", "_v", "_0", "_1", "_2"] {
-        let atom: Atom = candidate.into();
-        if !names.contains(&atom) {
-            return atom;
-        }
-    }
-    let mut index = 3u32;
-    loop {
-        let atom: Atom = format!("_{index}").into();
-        if !names.contains(&atom) {
-            return atom;
-        }
-        index += 1;
     }
 }

--- a/crates/core/src/rules/un_prototype_class.rs
+++ b/crates/core/src/rules/un_prototype_class.rs
@@ -12,7 +12,9 @@ use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use crate::utils::paren::strip_parens;
 
-use super::decl_utils::has_duplicate_param_names;
+use super::decl_utils::{
+    class_method_has_invalid_signature, ensure_setter_has_value_param, has_duplicate_param_names,
+};
 use super::helper_matcher::{binding_key, BindingKey};
 
 pub struct UnPrototypeClass;
@@ -1138,15 +1140,16 @@ fn extract_define_property(stmt: &Stmt, ctor_binding: &BindingKey) -> Option<Vec
         let Expr::Fn(fn_expr) = kv.value.as_ref() else {
             continue;
         };
-        if has_duplicate_param_names(&fn_expr.function.params) {
+        let method_key = PropName::Ident(IdentName::new(sym.clone(), DUMMY_SP));
+        let mut method = build_class_method_from_fn(method_key, fn_expr, false);
+        method.kind = kind;
+        if kind == MethodKind::Setter {
+            ensure_setter_has_value_param(&mut method.function);
+        }
+        if class_method_has_invalid_signature(&method.function, kind) {
             return None;
         }
-        let method_key = PropName::Ident(IdentName::new(sym.clone(), DUMMY_SP));
-        methods.push(build_class_method_from_fn(method_key, fn_expr, false));
-        // Update kind
-        if let Some(last) = methods.last_mut() {
-            last.kind = kind;
-        }
+        methods.push(method);
     }
 
     if let Some(fn_expr) = value_fn {

--- a/crates/core/src/rules/un_prototype_class.rs
+++ b/crates/core/src/rules/un_prototype_class.rs
@@ -13,8 +13,8 @@ use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 use crate::utils::paren::strip_parens;
 
 use super::decl_utils::{
-    class_accessor_descriptor_is_compatible, class_method_has_invalid_signature,
-    ensure_setter_has_value_param, has_duplicate_param_names,
+    class_accessor_descriptor_attributes, class_method_has_invalid_signature,
+    ensure_setter_has_value_param, has_duplicate_param_names, ClassAccessorDescriptorAttributes,
 };
 use super::helper_matcher::{binding_key, BindingKey};
 
@@ -1117,7 +1117,10 @@ fn extract_define_property(stmt: &Stmt, ctor_binding: &BindingKey) -> Option<Vec
 
     let mut methods = Vec::new();
     let value_fn = descriptor_value_method_fn(obj);
-    let accessor_descriptor_is_compatible = class_accessor_descriptor_is_compatible(obj);
+    let accessor_descriptor_is_compatible = matches!(
+        class_accessor_descriptor_attributes(obj),
+        Some(ClassAccessorDescriptorAttributes::ClassCompatible)
+    );
     if value_fn.is_some_and(|fn_expr| has_duplicate_param_names(&fn_expr.function.params)) {
         return None;
     }

--- a/crates/core/src/rules/un_prototype_class.rs
+++ b/crates/core/src/rules/un_prototype_class.rs
@@ -13,7 +13,8 @@ use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 use crate::utils::paren::strip_parens;
 
 use super::decl_utils::{
-    class_method_has_invalid_signature, ensure_setter_has_value_param, has_duplicate_param_names,
+    class_accessor_descriptor_is_compatible, class_method_has_invalid_signature,
+    ensure_setter_has_value_param, has_duplicate_param_names,
 };
 use super::helper_matcher::{binding_key, BindingKey};
 
@@ -1116,18 +1117,28 @@ fn extract_define_property(stmt: &Stmt, ctor_binding: &BindingKey) -> Option<Vec
 
     let mut methods = Vec::new();
     let value_fn = descriptor_value_method_fn(obj);
+    let accessor_descriptor_is_compatible = class_accessor_descriptor_is_compatible(obj);
     if value_fn.is_some_and(|fn_expr| has_duplicate_param_names(&fn_expr.function.params)) {
         return None;
     }
 
     for prop in &obj.props {
-        let swc_core::ecma::ast::PropOrSpread::Prop(p) = prop else {
+        let swc_core::ecma::ast::PropOrSpread::Prop(prop) = prop else {
             continue;
         };
-        let swc_core::ecma::ast::Prop::KeyValue(kv) = p.as_ref() else {
-            continue;
+        let (key, function) = match prop.as_ref() {
+            swc_core::ecma::ast::Prop::KeyValue(kv) => {
+                let Expr::Fn(fn_expr) = kv.value.as_ref() else {
+                    continue;
+                };
+                (&kv.key, fn_expr.function.as_ref())
+            }
+            // ObjMethodShorthand runs before UnPrototypeClass in the full
+            // pipeline, so descriptor callbacks can already be method props.
+            swc_core::ecma::ast::Prop::Method(method) => (&method.key, method.function.as_ref()),
+            _ => continue,
         };
-        let key_name = match &kv.key {
+        let key_name = match key {
             PropName::Ident(i) => i.sym.clone(),
             PropName::Str(s) => s.value.as_str().unwrap_or("").into(),
             _ => continue,
@@ -1137,11 +1148,11 @@ fn extract_define_property(stmt: &Stmt, ctor_binding: &BindingKey) -> Option<Vec
             "set" => MethodKind::Setter,
             _ => continue,
         };
-        let Expr::Fn(fn_expr) = kv.value.as_ref() else {
-            continue;
-        };
+        if !accessor_descriptor_is_compatible {
+            return None;
+        }
         let method_key = PropName::Ident(IdentName::new(sym.clone(), DUMMY_SP));
-        let mut method = build_class_method_from_fn(method_key, fn_expr, false);
+        let mut method = build_class_method_from_function(method_key, function, false);
         method.kind = kind;
         if kind == MethodKind::Setter {
             ensure_setter_has_value_param(&mut method.function);
@@ -1329,10 +1340,18 @@ fn build_constructor_from_fn(
 }
 
 fn build_class_method_from_fn(key: PropName, fn_expr: &FnExpr, is_static: bool) -> ClassMethod {
+    build_class_method_from_function(key, &fn_expr.function, is_static)
+}
+
+fn build_class_method_from_function(
+    key: PropName,
+    function: &Function,
+    is_static: bool,
+) -> ClassMethod {
     ClassMethod {
         span: DUMMY_SP,
         key,
-        function: fn_expr.function.clone(),
+        function: Box::new(function.clone()),
         kind: MethodKind::Method,
         is_static,
         accessibility: None,

--- a/crates/core/tests/un_async_await_rule.rs
+++ b/crates/core/tests/un_async_await_rule.rs
@@ -286,7 +286,9 @@ function* loadValue() {
 }
 
 #[test]
-fn generator_callback_local_colliding_with_destination_param_fails_closed() {
+fn generator_callback_local_colliding_with_destination_param_is_renamed() {
+    // TypeScript `__generator` callback `var` shadows an outer parameter.
+    // Flattening must rename the moved binding, not the parameter list.
     let input = r#"
 function loadValue(localValue) {
   return __generator(this, function (_state) {
@@ -299,15 +301,21 @@ function loadValue(localValue) {
   });
 }
 "#;
+    let expected = r#"
+function* loadValue(localValue) {
+  var localValue1;
+  localValue1 = createValue();
+  return localValue1;
+}
+"#;
     let output = apply(input);
-    assert!(
-        output.contains("return __generator(this, function(_state)"),
-        "moving a shadowing callback local onto a parameter must fail closed:\n{output}"
-    );
+    assert_eq_normalized(&output, expected);
+    let findings = validate_output_modules(&[("input.js".to_string(), output)]);
+    assert!(findings.is_empty(), "{findings:#?}");
 }
 
 #[test]
-fn awaiter_callback_local_colliding_with_destination_param_fails_closed() {
+fn awaiter_callback_local_colliding_with_destination_param_is_renamed() {
     let input = r#"
 function loadValue(localValue) {
   return __awaiter(this, void 0, void 0, function () {
@@ -322,17 +330,118 @@ function loadValue(localValue) {
   });
 }
 "#;
+    let expected = r#"
+async function loadValue(localValue) {
+  var localValue1;
+  localValue1 = createValue();
+  return localValue1;
+}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+    let findings = validate_output_modules(&[("input.js".to_string(), output)]);
+    assert!(findings.is_empty(), "{findings:#?}");
+}
+
+#[test]
+fn awaiter_callback_var_colliding_with_unused_param_is_renamed() {
+    // Minified TypeScript `__awaiter` + `__generator`: unused outer `o` plus
+    // a callback-local `var o` that holds the awaited result.
+    let input = r#"
+function join(t, i, n, o, s, c) {
+  return __awaiter(this, void 0, void 0, function () {
+    var o, r;
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          return [4 /*yield*/, send(c)];
+        case 1:
+          o = _a.sent();
+          r = o;
+          return [2 /*return*/, r];
+      }
+    });
+  });
+}
+"#;
+    let expected = r#"
+async function join(t, i, n, o, s, c) {
+  var o1, r;
+  o1 = await send(c);
+  r = o1;
+  return r;
+}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+    let findings = validate_output_modules(&[("input.js".to_string(), output)]);
+    assert!(findings.is_empty(), "{findings:#?}");
+}
+
+#[test]
+fn awaiter_renames_only_moved_binding_when_outer_param_is_also_used() {
+    let input = r#"
+function join(o) {
+  useOuter(o);
+  return __awaiter(this, void 0, void 0, function () {
+    var o;
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          return [4 /*yield*/, send()];
+        case 1:
+          o = _a.sent();
+          return [2 /*return*/, o];
+      }
+    });
+  });
+}
+"#;
+    let expected = r#"
+async function join(o) {
+  useOuter(o);
+  var o1;
+  o1 = await send();
+  return o1;
+}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+    let findings = validate_output_modules(&[("input.js".to_string(), output)]);
+    assert!(findings.is_empty(), "{findings:#?}");
+}
+
+#[test]
+fn awaiter_callback_local_colliding_with_eval_fails_closed() {
+    // Direct `eval` can observe the original callback-local name as a string.
+    // Rename would rebind that string, so keep the function boundary.
+    let input = r#"
+function loadValue(localValue) {
+  return __awaiter(this, void 0, void 0, function () {
+    return __generator(this, function (_state) {
+      switch (_state.label) {
+        case 0:
+          eval("localValue");
+          localValue = createValue();
+          return [2 /*return*/, localValue];
+      }
+      var localValue;
+    });
+  });
+}
+"#;
     let output = apply(input);
     assert!(
         output.contains("function loadValue(localValue)")
-            && output.contains("return async function()")
-            && output.contains("var localValue;"),
-        "a collision may recover to a nested async IIFE, but must retain the function boundary:\n{output}"
+            && output.contains("eval(\"localValue\")"),
+        "direct eval must keep the original callback-local name:\n{output}"
     );
     assert!(
         !output.contains("async function loadValue(localValue)"),
-        "the shadowing callback local must not be lifted onto the outer parameter:\n{output}"
+        "eval plus a colliding callback local must not flatten onto the parameter:\n{output}"
     );
+    let findings = validate_output_modules(&[("input.js".to_string(), output)]);
+    assert!(findings.is_empty(), "{findings:#?}");
 }
 
 #[test]

--- a/crates/core/tests/un_async_await_rule.rs
+++ b/crates/core/tests/un_async_await_rule.rs
@@ -484,6 +484,148 @@ function loadValue(localValue) {
 }
 
 #[test]
+fn awaiter_callback_function_decl_name_collision_fails_closed() {
+    let input = r#"
+function loadValue(worker) {
+  return __awaiter(this, void 0, void 0, function* () {
+    function worker() {}
+    observe(worker.name);
+    yield ready();
+  });
+}
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("return async function()")
+            && output.contains("function worker()")
+            && output.contains("observe(worker.name)"),
+        "renaming a moved function declaration would change Function.name:\n{output}"
+    );
+    assert!(
+        !output.contains("async function loadValue(worker)"),
+        "an observable function declaration name must keep the callback boundary:\n{output}"
+    );
+}
+
+#[test]
+fn awaiter_callback_class_decl_name_collision_fails_closed() {
+    let input = r#"
+function loadValue(Worker) {
+  return __awaiter(this, void 0, void 0, function* () {
+    class Worker {}
+    observe(Worker.name);
+    yield ready();
+  });
+}
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("return async function()")
+            && output.contains("class Worker")
+            && output.contains("observe(Worker.name)"),
+        "renaming a moved class declaration would change its name:\n{output}"
+    );
+    assert!(
+        !output.contains("async function loadValue(Worker)"),
+        "an observable class declaration name must keep the callback boundary:\n{output}"
+    );
+}
+
+#[test]
+fn awaiter_callback_inferred_initializer_name_collision_fails_closed() {
+    let input = r#"
+function loadValue(task) {
+  return __awaiter(this, void 0, void 0, function* () {
+    var task = function () {};
+    observe(task.name);
+    yield ready();
+  });
+}
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("return async function()")
+            && output.contains("var task = function()")
+            && output.contains("observe(task.name)"),
+        "renaming a binding must not change an anonymous initializer's inferred name:\n{output}"
+    );
+    assert!(
+        !output.contains("async function loadValue(task)"),
+        "an inferred initializer name must keep the callback boundary:\n{output}"
+    );
+}
+
+#[test]
+fn awaiter_callback_named_initializer_collision_can_rename() {
+    let input = r#"
+function loadValue(task) {
+  return __awaiter(this, void 0, void 0, function* () {
+    var task = function namedTask() {};
+    observe(task.name);
+    yield ready();
+  });
+}
+"#;
+    let expected = r#"
+async function loadValue(task) {
+  var task1 = function namedTask() {};
+  observe(task1.name);
+  await ready();
+}
+"#;
+    assert_eq_normalized(&apply(input), expected);
+}
+
+#[test]
+fn awaiter_callback_inferred_assignment_name_collision_fails_closed() {
+    let input = r#"
+function loadValue(task) {
+  return __awaiter(this, void 0, void 0, function* () {
+    var task;
+    task ||= class {};
+    observe(task.name);
+    yield ready();
+  });
+}
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("return async function()")
+            && output.contains("task ||= class")
+            && output.contains("observe(task.name)"),
+        "renaming a logical-assignment target would change the class name:\n{output}"
+    );
+    assert!(
+        !output.contains("async function loadValue(task)"),
+        "an inferred assignment name must keep the callback boundary:\n{output}"
+    );
+}
+
+#[test]
+fn awaiter_callback_inferred_destructuring_default_name_collision_fails_closed() {
+    let input = r#"
+function loadValue(task) {
+  return __awaiter(this, void 0, void 0, function* () {
+    var { task = () => {} } = {};
+    observe(task.name);
+    yield ready();
+  });
+}
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("return async function()")
+            && output.contains("var { task =")
+            && output.contains("observe(task.name)"),
+        "renaming a destructuring binding would change its default arrow's name:\n{output}"
+    );
+    assert!(
+        !output.contains("async function loadValue(task)"),
+        "an inferred destructuring default name must keep the callback boundary:\n{output}"
+    );
+}
+
+#[test]
 fn generator_callback_with_observable_trailing_statement_fails_closed() {
     let input = r#"
 function loadValue() {

--- a/crates/core/tests/un_async_await_rule.rs
+++ b/crates/core/tests/un_async_await_rule.rs
@@ -345,8 +345,10 @@ async function loadValue(localValue) {
 
 #[test]
 fn awaiter_callback_var_colliding_with_unused_param_is_renamed() {
-    // Minified TypeScript `__awaiter` + `__generator`: unused outer `o` plus
-    // a callback-local `var o` that holds the awaited result.
+    // Reproduced with the repo's TypeScript 5 ES5 + Terser 5 mangle harness
+    // from an async function with two parameters and two awaited locals.
+    // Terser reuses an outer parameter name for a callback-local `var`; this
+    // reduced form keeps the same cross-function binding collision.
     let input = r#"
 function join(t, i, n, o, s, c) {
   return __awaiter(this, void 0, void 0, function () {
@@ -439,6 +441,39 @@ function loadValue(localValue) {
     assert!(
         !output.contains("async function loadValue(localValue)"),
         "eval plus a colliding callback local must not flatten onto the parameter:\n{output}"
+    );
+    let findings = validate_output_modules(&[("input.js".to_string(), output)]);
+    assert!(findings.is_empty(), "{findings:#?}");
+}
+
+#[test]
+fn awaiter_callback_local_collision_with_destination_eval_fails_closed() {
+    // A rename to `localValue1` would introduce a hoisted binding that captures
+    // the outer eval source. The eval is outside the callback being moved, so
+    // both sides of the function-boundary move must participate in the guard.
+    let input = r#"
+function loadValue(localValue) {
+  observe(eval("typeof localValue1"));
+  return __awaiter(this, void 0, void 0, function () {
+    return __generator(this, function (_state) {
+      switch (_state.label) {
+        case 0:
+          localValue = createValue();
+          return [2 /*return*/, localValue];
+      }
+      var localValue;
+    });
+  });
+}
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("eval(\"typeof localValue1\")"),
+        "the destination eval must be preserved:\n{output}"
+    );
+    assert!(
+        !output.contains("async function loadValue(localValue)"),
+        "a renamed callback local must not capture a destination eval source:\n{output}"
     );
     let findings = validate_output_modules(&[("input.js".to_string(), output)]);
     assert!(findings.is_empty(), "{findings:#?}");

--- a/crates/core/tests/un_async_await_rule.rs
+++ b/crates/core/tests/un_async_await_rule.rs
@@ -435,8 +435,10 @@ function loadValue(localValue) {
     let output = apply(input);
     assert!(
         output.contains("function loadValue(localValue)")
+            && output.contains("return async function()")
+            && output.contains("var localValue;")
             && output.contains("eval(\"localValue\")"),
-        "direct eval must keep the original callback-local name:\n{output}"
+        "direct eval must keep the nested callback boundary and original local:\n{output}"
     );
     assert!(
         !output.contains("async function loadValue(localValue)"),
@@ -468,8 +470,10 @@ function loadValue(localValue) {
 "#;
     let output = apply(input);
     assert!(
-        output.contains("eval(\"typeof localValue1\")"),
-        "the destination eval must be preserved:\n{output}"
+        output.contains("eval(\"typeof localValue1\")")
+            && output.contains("return async function()")
+            && output.contains("var localValue;"),
+        "destination eval must preserve the nested callback boundary:\n{output}"
     );
     assert!(
         !output.contains("async function loadValue(localValue)"),

--- a/crates/core/tests/un_async_await_rule.rs
+++ b/crates/core/tests/un_async_await_rule.rs
@@ -602,6 +602,31 @@ function loadValue(task) {
 }
 
 #[test]
+fn awaiter_callback_inferred_plain_assignment_name_collision_fails_closed() {
+    let input = r#"
+function loadValue(task) {
+  return __awaiter(this, void 0, void 0, function* () {
+    var task;
+    task = function () {};
+    observe(task.name);
+    yield ready();
+  });
+}
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("return async function()")
+            && output.contains("task = function()")
+            && output.contains("observe(task.name)"),
+        "renaming a plain-assignment target would change the function name:\n{output}"
+    );
+    assert!(
+        !output.contains("async function loadValue(task)"),
+        "an inferred plain-assignment name must keep the callback boundary:\n{output}"
+    );
+}
+
+#[test]
 fn awaiter_callback_inferred_destructuring_default_name_collision_fails_closed() {
     let input = r#"
 function loadValue(task) {

--- a/crates/core/tests/un_es6_class_rule.rs
+++ b/crates/core/tests/un_es6_class_rule.rs
@@ -636,6 +636,8 @@ fn test_getter_setter_define_property() {
 var MyClass = (function() {
     function t(val) { this._val = val; }
     Object.defineProperty(t.prototype, "value", {
+        enumerable: false,
+        configurable: true,
         get: function() { return this._val; },
         set: function(v) { this._val = v; }
     });
@@ -660,6 +662,8 @@ fn define_property_zero_param_setter_gets_dummy_arg() {
 var Widget = (function() {
     function t() {}
     Object.defineProperty(t.prototype, "text", {
+        enumerable: false,
+        configurable: true,
         get: function() { return null; },
         set: function() {}
     });
@@ -716,6 +720,8 @@ fn define_property_zero_param_setter_avoids_underscore_collision() {
 var Widget = (function() {
     function t() {}
     Object.defineProperty(t.prototype, "text", {
+        enumerable: false,
+        configurable: true,
         get: function() { return null; },
         set: function() { console.log(_); }
     });
@@ -737,6 +743,8 @@ fn define_property_multi_param_setter_preserves_iife_shape() {
 var Widget = (function() {
     function t() {}
     Object.defineProperty(t.prototype, "text", {
+        enumerable: false,
+        configurable: true,
         set: function(value, metadata) { use(value, metadata); }
     });
     return t;
@@ -747,6 +755,47 @@ var Widget = (function() {
         output.contains("Object.defineProperty(t.prototype, \"text\"")
             && !output.contains("class Widget"),
         "an incompatible setter signature must keep the descriptor callback:\n{output}"
+    );
+}
+
+#[test]
+fn define_property_enumerable_accessor_preserves_iife_shape() {
+    let input = r#"
+var Widget = (function() {
+    function t() {}
+    Object.defineProperty(t.prototype, "text", {
+        enumerable: true,
+        configurable: true,
+        set: function() {}
+    });
+    return t;
+}());
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("Object.defineProperty(t.prototype, \"text\"")
+            && !output.contains("class Widget"),
+        "an enumerable descriptor cannot become a non-enumerable class accessor:\n{output}"
+    );
+}
+
+#[test]
+fn define_property_nonconfigurable_accessor_preserves_iife_shape() {
+    let input = r#"
+var Widget = (function() {
+    function t() {}
+    Object.defineProperty(t.prototype, "text", {
+        enumerable: false,
+        set: function() {}
+    });
+    return t;
+}());
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("Object.defineProperty(t.prototype, \"text\"")
+            && !output.contains("class Widget"),
+        "a nonconfigurable descriptor cannot become a configurable class accessor:\n{output}"
     );
 }
 

--- a/crates/core/tests/un_es6_class_rule.rs
+++ b/crates/core/tests/un_es6_class_rule.rs
@@ -732,6 +732,25 @@ class Widget {
 }
 
 #[test]
+fn define_property_multi_param_setter_preserves_iife_shape() {
+    let input = r#"
+var Widget = (function() {
+    function t() {}
+    Object.defineProperty(t.prototype, "text", {
+        set: function(value, metadata) { use(value, metadata); }
+    });
+    return t;
+}());
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("Object.defineProperty(t.prototype, \"text\"")
+            && !output.contains("class Widget"),
+        "an incompatible setter signature must keep the descriptor callback:\n{output}"
+    );
+}
+
+#[test]
 fn test_define_property_value_function_method() {
     let input = r#"
 var MyClass = (function() {

--- a/crates/core/tests/un_es6_class_rule.rs
+++ b/crates/core/tests/un_es6_class_rule.rs
@@ -653,6 +653,85 @@ class MyClass {
 }
 
 #[test]
+fn define_property_zero_param_setter_gets_dummy_arg() {
+    // `Object.defineProperty` setters may be zero-arg; class `set` must have
+    // exactly one parameter. FairyGUI-style empty setters need a dummy.
+    let input = r#"
+var Widget = (function() {
+    function t() {}
+    Object.defineProperty(t.prototype, "text", {
+        get: function() { return null; },
+        set: function() {}
+    });
+    return t;
+}());
+"#;
+    let expected = r#"
+class Widget {
+    get text() { return null; }
+    set text(_) {}
+}
+"#;
+    assert_eq_normalized(&apply(input), expected);
+}
+
+#[test]
+fn create_class_zero_param_setter_gets_dummy_arg() {
+    let input = r#"
+var _createClass = function() {
+    function e(e, t) {
+        for (var n = 0; n < t.length; n++) {
+            var r = t[n];
+            r.enumerable = r.enumerable || false;
+            r.configurable = true;
+            "value" in r && (r.writable = true);
+            Object.defineProperty(e, r.key, r);
+        }
+    }
+    return function(t, n, r) {
+        return n && e(t.prototype, n), r && e(t, r), t;
+    };
+}();
+var Widget = (function() {
+    function t() {}
+    _createClass(t, [
+        { key: "text", get: function() { return null; } },
+        { key: "text", set: function() {} }
+    ]);
+    return t;
+}());
+"#;
+    let expected = r#"
+class Widget {
+    get text() { return null; }
+    set text(_) {}
+}
+"#;
+    assert_eq_normalized(&apply(input), expected);
+}
+
+#[test]
+fn define_property_zero_param_setter_avoids_underscore_collision() {
+    let input = r#"
+var Widget = (function() {
+    function t() {}
+    Object.defineProperty(t.prototype, "text", {
+        get: function() { return null; },
+        set: function() { console.log(_); }
+    });
+    return t;
+}());
+"#;
+    let expected = r#"
+class Widget {
+    get text() { return null; }
+    set text(_v) { console.log(_); }
+}
+"#;
+    assert_eq_normalized(&apply(input), expected);
+}
+
+#[test]
 fn test_define_property_value_function_method() {
     let input = r#"
 var MyClass = (function() {

--- a/crates/core/tests/un_es6_class_rule.rs
+++ b/crates/core/tests/un_es6_class_rule.rs
@@ -759,23 +759,44 @@ var Widget = (function() {
 }
 
 #[test]
-fn define_property_enumerable_accessor_preserves_iife_shape() {
+fn legacy_typescript_enumerable_accessor_recovers_at_standard() {
     let input = r#"
 var Widget = (function() {
     function t() {}
     Object.defineProperty(t.prototype, "text", {
         enumerable: true,
         configurable: true,
-        set: function() {}
+        set: function(value) { this._text = value; }
     });
     return t;
 }());
 "#;
-    let output = apply(input);
+    let expected = r#"
+class Widget {
+    set text(value) { this._text = value; }
+}
+"#;
+    assert_eq_normalized(&apply(input), expected);
+}
+
+#[test]
+fn legacy_typescript_enumerable_accessor_preserves_iife_at_minimal() {
+    let input = r#"
+var Widget = (function() {
+    function t() {}
+    Object.defineProperty(t.prototype, "text", {
+        enumerable: true,
+        configurable: true,
+        set: function(value) { this._text = value; }
+    });
+    return t;
+}());
+"#;
+    let output = apply_minimal(input);
     assert!(
         output.contains("Object.defineProperty(t.prototype, \"text\"")
             && !output.contains("class Widget"),
-        "an enumerable descriptor cannot become a non-enumerable class accessor:\n{output}"
+        "minimal must preserve the emitted enumerable descriptor:\n{output}"
     );
 }
 
@@ -797,6 +818,28 @@ var Widget = (function() {
             && !output.contains("class Widget"),
         "a nonconfigurable descriptor cannot become a configurable class accessor:\n{output}"
     );
+}
+
+#[test]
+fn define_property_mixed_function_and_method_accessors_preserve_both() {
+    let input = r#"
+var Widget = (function() {
+    function t() {}
+    Object.defineProperty(t.prototype, "text", {
+        configurable: true,
+        get: function() { return this._text; },
+        set(value) { this._text = value; }
+    });
+    return t;
+}());
+"#;
+    let expected = r#"
+class Widget {
+    get text() { return this._text; }
+    set text(value) { this._text = value; }
+}
+"#;
+    assert_eq_normalized(&apply(input), expected);
 }
 
 #[test]

--- a/crates/core/tests/un_prototype_class_rule.rs
+++ b/crates/core/tests/un_prototype_class_rule.rs
@@ -644,6 +644,8 @@ fn test_getter_setter() {
     let input = r#"
 function Foo(val) { this._val = val; }
 Object.defineProperty(Foo.prototype, "value", {
+    enumerable: false,
+    configurable: true,
     get: function() { return this._val; },
     set: function(v) { this._val = v; }
 });
@@ -663,6 +665,8 @@ fn define_property_zero_param_setter_gets_dummy_arg() {
     let input = r#"
 function Foo() {}
 Object.defineProperty(Foo.prototype, "value", {
+    enumerable: false,
+    configurable: true,
     set: function() {}
 });
 "#;
@@ -675,10 +679,38 @@ class Foo {
 }
 
 #[test]
+fn define_property_zero_param_setter_survives_obj_method_shorthand() {
+    let input = r#"
+function Foo() {}
+Object.defineProperty(Foo.prototype, "value", {
+    enumerable: false,
+    configurable: true,
+    get: function() { return this._value; },
+    set: function() {}
+});
+var foo = new Foo();
+use(foo.value);
+foo.value = 1;
+"#;
+    let expected = r#"
+class Foo {
+    get value() { return this._value; }
+    set value(_) {}
+}
+const foo = new Foo();
+use(foo.value);
+foo.value = 1;
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
 fn define_property_param_getter_preserves_original_shape() {
     let input = r#"
 function Foo() {}
 Object.defineProperty(Foo.prototype, "value", {
+    enumerable: false,
+    configurable: true,
     get: function(unexpected) { return unexpected; }
 });
 "#;
@@ -690,6 +722,8 @@ fn define_property_rest_setter_preserves_original_shape() {
     let input = r#"
 function Foo() {}
 Object.defineProperty(Foo.prototype, "value", {
+    enumerable: false,
+    configurable: true,
     set: function(...values) { use(values); }
 });
 "#;
@@ -701,7 +735,34 @@ fn duplicate_getter_params_preserve_define_property_shape() {
     let input = r#"
 function Foo(val) { this._val = val; }
 Object.defineProperty(Foo.prototype, "value", {
+    enumerable: false,
+    configurable: true,
     get: function(a, a) { return this._val; }
+});
+"#;
+    assert_eq_normalized(&apply(input), input);
+}
+
+#[test]
+fn define_property_enumerable_accessor_preserves_original_shape() {
+    let input = r#"
+function Foo() {}
+Object.defineProperty(Foo.prototype, "value", {
+    enumerable: true,
+    configurable: true,
+    set: function() {}
+});
+"#;
+    assert_eq_normalized(&apply(input), input);
+}
+
+#[test]
+fn define_property_nonconfigurable_accessor_preserves_original_shape() {
+    let input = r#"
+function Foo() {}
+Object.defineProperty(Foo.prototype, "value", {
+    enumerable: false,
+    set: function() {}
 });
 "#;
     assert_eq_normalized(&apply(input), input);

--- a/crates/core/tests/un_prototype_class_rule.rs
+++ b/crates/core/tests/un_prototype_class_rule.rs
@@ -659,6 +659,44 @@ class Foo {
 }
 
 #[test]
+fn define_property_zero_param_setter_gets_dummy_arg() {
+    let input = r#"
+function Foo() {}
+Object.defineProperty(Foo.prototype, "value", {
+    set: function() {}
+});
+"#;
+    let expected = r#"
+class Foo {
+    set value(_) {}
+}
+"#;
+    assert_eq_normalized(&apply(input), expected);
+}
+
+#[test]
+fn define_property_param_getter_preserves_original_shape() {
+    let input = r#"
+function Foo() {}
+Object.defineProperty(Foo.prototype, "value", {
+    get: function(unexpected) { return unexpected; }
+});
+"#;
+    assert_eq_normalized(&apply(input), input);
+}
+
+#[test]
+fn define_property_rest_setter_preserves_original_shape() {
+    let input = r#"
+function Foo() {}
+Object.defineProperty(Foo.prototype, "value", {
+    set: function(...values) { use(values); }
+});
+"#;
+    assert_eq_normalized(&apply(input), input);
+}
+
+#[test]
 fn duplicate_getter_params_preserve_define_property_shape() {
     let input = r#"
 function Foo(val) { this._val = val; }

--- a/docs/rewrite-assumptions.md
+++ b/docs/rewrite-assumptions.md
@@ -229,6 +229,26 @@ Affects: `UnComputedProperties`.
 
 Level: `standard` and above. `minimal` preserves the sequence.
 
+### `transpiled_class_accessor_attributes`
+
+Recovering an accessor descriptor inside a proven class-lowering IIFE assumes
+that its attributes describe the original source construct rather than an
+intentional handwritten descriptor. TypeScript 3.5–3.8 lowered class accessors
+with `enumerable: true, configurable: true`; TypeScript 3.9 changed that output
+to the native class attributes (`enumerable: false, configurable: true`).
+
+At `standard` and above, `UnEs6Class` accepts both variants after the enclosing
+IIFE has independently matched a transpiler class shape. This preserves source
+recovery for older TypeScript even though reflecting on the emitted descriptor
+can observe the enumerability difference. `UnPrototypeClass` has no equivalent
+producer proof and accepts only the native class attributes. A missing or false
+`configurable` flag is rejected at every level.
+
+Affects: `UnEs6Class` direct `Object.defineProperty` accessor recovery.
+
+Level: `standard` and above. `minimal` requires attributes exactly representable
+by class syntax.
+
 ## Generated Temporaries
 
 Temporaries introduced by compilers are handled by binding analysis, not by

--- a/scripts/repro/class-accessor-matrix/matrix.mjs
+++ b/scripts/repro/class-accessor-matrix/matrix.mjs
@@ -5,6 +5,7 @@ import {
   esbuildBatch,
   runMatrix,
   swcBatch,
+  tscBatch,
   withTerserVariants,
 } from "../lib/runner.mjs";
 import { mangleValidator } from "../lib/compare.mjs";
@@ -12,7 +13,7 @@ import { mangleValidator } from "../lib/compare.mjs";
 // Class syntax cannot express a zero-argument setter, but descriptor callbacks
 // can and do occur in real bundles. These inputs start at that legal ES5 shape
 // and exercise the distinct class-recovery paths after production minifiers.
-const snippets = [
+const descriptorSnippets = [
   {
     name: "prototype-zero-arg-setter",
     source: `
@@ -54,6 +55,26 @@ second.text = "ignored";
 `,
     expected: ["class ", "get text()", "set text(", ".text = \"ignored\""],
     rejected: ["set text()"],
+    execute: {},
+  },
+  {
+    name: "iife-mixed-accessor-syntax",
+    source: `
+var Widget = (function() {
+  function Inner() {}
+  Object.defineProperty(Inner.prototype, "value", {
+    configurable: true,
+    get: function() { return null; },
+    set() {}
+  });
+  return Inner;
+}());
+var widget = new Widget();
+use(widget.value);
+widget.value = 1;
+`,
+    expected: ["class ", "get value()", "set value(", ".value = 1"],
+    rejected: ["set value()", "Object.defineProperty("],
     execute: {},
   },
   {
@@ -128,9 +149,43 @@ widget.value = 1;
     rejected: ["class "],
     execute: {},
   },
+].map((snippet) => ({
+  ...snippet,
+  transformerFilter: ({ name }) => !name.startsWith("tsc-"),
+}));
+
+const snippets = [
+  ...descriptorSnippets,
+  {
+    name: "typescript-accessor-version-boundary",
+    source: `
+class Widget {
+  get value() { return this._value; }
+  set value(next) { this._value = next; }
+}
+const first = new Widget();
+const second = new Widget();
+first.value = nextValue();
+second.value = nextValue();
+use(first.value, second.value);
+`,
+    expected: ["class Widget", "get value()", "set value(next)"],
+    expectedAny: [
+      ["class Widget", "get value()", "set value(next)"],
+      ["class ", "get value()", "set value("],
+    ],
+    rejected: ["Object.defineProperty("],
+    // TypeScript 3.5–3.8 intentionally emits enumerable:true here, while
+    // 3.9+ emits the native class attributes. The standard-level recovery of
+    // the older shape is tracked as a named source-recovery assumption; this
+    // execution check observes accessor behavior but not descriptor metadata.
+    execute: { returns: { nextValue: 7 } },
+    transformerFilter: ({ name }) => name.startsWith("tsc-"),
+  },
 ];
 
 const allSources = snippets.map((snippet) => snippet.source);
+const typescriptVersions = ["3.5.3", "3.8.3", "3.9.10", "4.3.5"];
 const transformers = [
   ...withTerserVariants("source", allSources, (source) => source),
   {
@@ -141,6 +196,13 @@ const transformers = [
     name: "esbuild-es2015-minify-mangle",
     run: batchRunner(() => esbuildBatch(allSources, { target: "es2015", minify: true })),
   },
+  ...typescriptVersions.flatMap((version) =>
+    withTerserVariants(
+      `tsc-${version}-es5`,
+      allSources,
+      batchRunner(() => tscBatch(allSources, { target: "ES5", version })),
+    ),
+  ),
 ];
 
 runMatrix({

--- a/scripts/repro/class-accessor-matrix/matrix.mjs
+++ b/scripts/repro/class-accessor-matrix/matrix.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import {
+  batchRunner,
+  esbuildBatch,
+  runMatrix,
+  swcBatch,
+  withTerserVariants,
+} from "../lib/runner.mjs";
+import { mangleValidator } from "../lib/compare.mjs";
+
+// Class syntax cannot express a zero-argument setter, but descriptor callbacks
+// can and do occur in real bundles. These inputs start at that legal ES5 shape
+// and exercise the distinct class-recovery paths after production minifiers.
+const snippets = [
+  {
+    name: "prototype-zero-arg-setter",
+    source: `
+function Widget() {}
+Object.defineProperty(Widget.prototype, "value", {
+  enumerable: false,
+  configurable: true,
+  get: function() { return this._value; },
+  set: function() {}
+});
+var widget = new Widget();
+var descriptor = Object.getOwnPropertyDescriptor(Widget.prototype, "value");
+use(descriptor.enumerable, descriptor.configurable, widget.value);
+widget.value = 1;
+`,
+    expected: ["class ", "get value()", "set value(", ".value = 1"],
+    rejected: ["set value()"],
+    execute: {},
+  },
+  {
+    name: "iife-zero-arg-setter",
+    source: `
+var Widget = (function() {
+  function Inner() {}
+  Object.defineProperty(Inner.prototype, "text", {
+    enumerable: false,
+    configurable: true,
+    get: function() { return null; },
+    set: function() {}
+  });
+  return Inner;
+}());
+var first = new Widget();
+var second = new Widget();
+var descriptor = Object.getOwnPropertyDescriptor(Widget.prototype, "text");
+use(descriptor.enumerable, descriptor.configurable, first.text, second.text);
+first.text = "ignored";
+second.text = "ignored";
+`,
+    expected: ["class ", "get text()", "set text(", ".text = \"ignored\""],
+    rejected: ["set text()"],
+    execute: {},
+  },
+  {
+    name: "create-class-zero-arg-setter",
+    source: `
+var _createClass = function() {
+  function defineProperties(target, descriptors) {
+    for (var index = 0; index < descriptors.length; index++) {
+      var descriptor = descriptors[index];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      "value" in descriptor && (descriptor.writable = true);
+      Object.defineProperty(target, descriptor.key, descriptor);
+    }
+  }
+  return function(Constructor, prototypeDescriptors, staticDescriptors) {
+    prototypeDescriptors && defineProperties(Constructor.prototype, prototypeDescriptors);
+    staticDescriptors && defineProperties(Constructor, staticDescriptors);
+    return Constructor;
+  };
+}();
+var Widget = (function() {
+  function Inner() {}
+  _createClass(Inner, [
+    { key: "text", get: function() { return null; } },
+    { key: "text", set: function() {} }
+  ]);
+  return Inner;
+}());
+var first = new Widget();
+var second = new Widget();
+var descriptor = Object.getOwnPropertyDescriptor(Widget.prototype, "text");
+use(descriptor.enumerable, descriptor.configurable, first.text, second.text);
+first.text = "ignored";
+second.text = "ignored";
+`,
+    expected: ["class ", "get text()", "set text(", ".text = \"ignored\""],
+    rejected: ["set text()", "_createClass("],
+    execute: {},
+  },
+  {
+    name: "multi-param-setter-fails-closed",
+    source: `
+function Widget() {}
+Object.defineProperty(Widget.prototype, "value", {
+  enumerable: false,
+  configurable: true,
+  set: function(value, metadata) { use(value, metadata); }
+});
+var widget = new Widget();
+widget.value = 1;
+`,
+    expected: ["Object.defineProperty(", "set ("],
+    rejected: ["class "],
+    execute: {},
+  },
+  {
+    name: "enumerable-setter-fails-closed",
+    source: `
+function Widget() {}
+Object.defineProperty(Widget.prototype, "value", {
+  enumerable: true,
+  configurable: true,
+  set: function() { use("set"); }
+});
+var descriptor = Object.getOwnPropertyDescriptor(Widget.prototype, "value");
+use(descriptor.enumerable, descriptor.configurable);
+var widget = new Widget();
+widget.value = 1;
+`,
+    expected: ["Object.defineProperty(", "set ("],
+    rejected: ["class "],
+    execute: {},
+  },
+];
+
+const allSources = snippets.map((snippet) => snippet.source);
+const transformers = [
+  ...withTerserVariants("source", allSources, (source) => source),
+  {
+    name: "swc-es5-minify-mangle",
+    run: batchRunner(() => swcBatch(allSources, { target: "es5", minify: true })),
+  },
+  {
+    name: "esbuild-es2015-minify-mangle",
+    run: batchRunner(() => esbuildBatch(allSources, { target: "es2015", minify: true })),
+  },
+];
+
+runMatrix({
+  name: "class-accessor",
+  snippets,
+  transformers,
+  ...mangleValidator(),
+});

--- a/scripts/repro/collect-stats.mjs
+++ b/scripts/repro/collect-stats.mjs
@@ -39,6 +39,7 @@ if (jobsFlagIndex !== -1) {
 const matrices = [
   "array-spread-rest",
   "async-await",
+  "class-accessor",
   "closure-compiler",
   "conditional-switch",
   "enum",

--- a/scripts/repro/lib/runner.mjs
+++ b/scripts/repro/lib/runner.mjs
@@ -935,7 +935,9 @@ process.stdout.write(JSON.stringify(results));
 
 export function tscBatch(sources, options = {}) {
   const target = options.target ?? "ES5";
-  const toolDir = ensureNodeTool("typescript", ["typescript@5"]);
+  const version = options.version ?? "5";
+  const toolName = version === "5" ? "typescript" : `typescript-${version}`;
+  const toolDir = ensureNodeTool(toolName, [`typescript@${version}`]);
   const helper = join(toolDir, "tsc-batch.cjs");
   writeFileSync(
     helper,

--- a/scripts/repro/stats.json
+++ b/scripts/repro/stats.json
@@ -1,9 +1,9 @@
 {
-  "commit": "086c7161",
-  "date": "2026-07-22",
+  "commit": "96c36050",
+  "date": "2026-08-18",
   "aggregate": {
-    "yes": 1778,
-    "total": 1826,
+    "yes": 1799,
+    "total": 1847,
     "pct": 97.4
   },
   "matrices": [
@@ -22,6 +22,14 @@
       "error": 44,
       "total": 415,
       "pct": 96.9
+    },
+    {
+      "name": "class-accessor",
+      "yes": 21,
+      "no": 0,
+      "error": 0,
+      "total": 21,
+      "pct": 100
     },
     {
       "name": "closure-compiler",

--- a/scripts/repro/stats.json
+++ b/scripts/repro/stats.json
@@ -1,9 +1,9 @@
 {
-  "commit": "96c36050",
+  "commit": "66c77ef0",
   "date": "2026-08-18",
   "aggregate": {
-    "yes": 1799,
-    "total": 1847,
+    "yes": 1810,
+    "total": 1858,
     "pct": 97.4
   },
   "matrices": [
@@ -25,10 +25,10 @@
     },
     {
       "name": "class-accessor",
-      "yes": 21,
+      "yes": 32,
       "no": 0,
       "error": 0,
-      "total": 21,
+      "total": 32,
       "pct": 100
     },
     {

--- a/website/index.html
+++ b/website/index.html
@@ -133,7 +133,7 @@
         </a>
         <a class="stat" href="https://github.com/pionxzh/wakaru/blob/main/scripts/repro/stats.json">
           <span class="stat-value">97.4%</span>
-          <span class="stat-label">pattern recovery across 1,847 transpiler/minifier test shapes</span>
+          <span class="stat-label">pattern recovery across 1,858 transpiler/minifier test shapes</span>
           <span class="stat-src">&rarr; scripts/repro/stats.json</span>
         </a>
         <a class="stat" href="https://github.com/pionxzh/wakaru#tested-like-a-compiler">

--- a/website/index.html
+++ b/website/index.html
@@ -133,7 +133,7 @@
         </a>
         <a class="stat" href="https://github.com/pionxzh/wakaru/blob/main/scripts/repro/stats.json">
           <span class="stat-value">97.4%</span>
-          <span class="stat-label">pattern recovery across 1,826 transpiler/minifier test shapes</span>
+          <span class="stat-label">pattern recovery across 1,847 transpiler/minifier test shapes</span>
           <span class="stat-src">&rarr; scripts/repro/stats.json</span>
         </a>
         <a class="stat" href="https://github.com/pionxzh/wakaru#tested-like-a-compiler">


### PR DESCRIPTION
## Summary

- `UnAsyncAwait`: flattening `__awaiter` / `__generator` callback locals into the enclosing async function can redeclare a parameter (`async f(..., o, ...) { let o; }`). Rename the **moved** binding (`o` → `o1`) instead of fail-closing; keep the outer parameter list. Direct `eval` / `with` still fail-closed.
- `UnEs6Class`: `Object.defineProperty` / `_createClass` zero-arg setters become illegal `set text() {}`. Insert a collision-safe dummy formal (`_`, then `_v`, `_0`, …). Existing one-arg setters are unchanged.

v1.9.0 flattened without a hygiene check. `main` already fail-closes on name collision. This keeps flatten and only renames the binding that originally shadowed the parameter.

## Test plan

- [x] `cargo test -p wakaru-core --test un_async_await_rule`
- [x] `cargo test -p wakaru-core --test un_es6_class_rule`
- [x] `cargo nextest run --workspace --profile ci` (3712 passed, 2 skipped)
- [x] `node scripts/repro/collect-stats.mjs --check` (1778/1826, 97.4%; async-await rate unchanged)