### PR TITLE
fix(rules): recover minified TypeScript CJS enum IIFE exports

### DIFF
--- a/crates/core/src/rules/un_enum.rs
+++ b/crates/core/src/rules/un_enum.rs
@@ -6,16 +6,19 @@ use swc_core::ecma::ast::{
     ArrowFunctionBody, AssignExpr, AssignOp, AssignTarget, BinExpr, BinaryOp, BindingIdent,
     CallExpr, Callee, ComputedPropName, Decl, ExportDecl, ExportNamedSpecifier, ExportSpecifier,
     Expr, ExprStmt, FnExpr, Ident, IdentName, KeyValueProp, Lit, MemberExpr, MemberProp,
-    ModuleDecl, ModuleExportName, ModuleItem, NamedExport, Number, ObjectLit, Pat, Prop, PropName,
-    PropOrSpread, SimpleAssignTarget, Stmt, Str, UnaryExpr, UnaryOp, VarDecl, VarDeclKind,
-    VarDeclarator,
+    ModuleDecl, ModuleExportName, ModuleItem, NamedExport, Number, ObjectLit, OptCall,
+    OptChainBase, Pat, Prop, PropName, PropOrSpread, SimpleAssignTarget, Stmt, Str, TaggedTpl,
+    UnaryExpr, UnaryOp, VarDecl, VarDeclKind, VarDeclarator,
 };
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use super::decl_utils::collect_decl_names;
-use super::eval_utils::{js_source_mentions_binding, DirectEvalAnalyzer};
+use super::eval_utils::{
+    direct_eval_call_source, js_source_mentions_binding, DirectEvalAnalyzer, EvalCallSource,
+};
 use crate::js_names::{is_reserved_binding_name, is_valid_identifier_name};
 use crate::utils::paren::strip_parens;
+use crate::utils::prototype_members::is_prototype_mutating_member_name;
 
 pub struct UnEnum {
     unresolved_mark: Option<Mark>,
@@ -258,18 +261,21 @@ impl PublicExportUseFinder<'_> {
     }
 
     /// Match a property access on an export surface: hazard when the key is
-    /// the public name or is not statically known.
+    /// the public name, a prototype-mutating member, or not statically known.
     fn check_surface_prop(&mut self, prop: &MemberProp, hazard_name: &Atom) {
         match prop {
             MemberProp::Ident(ident_name) => {
-                if ident_name.sym == *hazard_name {
+                if ident_name.sym == *hazard_name
+                    || is_prototype_mutating_member_name(ident_name.sym.as_ref())
+                {
                     self.found = true;
                 }
             }
             MemberProp::Computed(computed) => {
                 match computed_key_atom(computed) {
                     Some(name) => {
-                        if name == *hazard_name {
+                        if name == *hazard_name || is_prototype_mutating_member_name(name.as_ref())
+                        {
                             self.found = true;
                         }
                     }
@@ -280,6 +286,41 @@ impl PublicExportUseFinder<'_> {
             }
             MemberProp::PrivateName(_) => {}
         }
+    }
+
+    /// A call whose receiver is the export surface or the `module` object
+    /// can observe the property (`exports.hasOwnProperty("Mode")`) or return
+    /// the surface itself (`exports.valueOf()`, `module.valueOf()`).
+    fn is_surface_receiver(&self, callee: &Expr) -> bool {
+        let Some(member) = member_like(callee) else {
+            return false;
+        };
+        let obj = strip_parens(&member.obj);
+        if self.is_exports_object(obj) {
+            return true;
+        }
+        matches!(obj, Expr::Ident(ident) if is_unresolved_named(ident, "module", self.unresolved_mark))
+    }
+
+    /// Direct eval resolves `exports`/`module` from the calling scope, so it
+    /// can read the surface invisibly to the AST scan. Returns true when the
+    /// call was a direct eval (handled here, hazardous or not).
+    fn check_direct_eval(&mut self, call: &CallExpr) -> bool {
+        let Some(source) = direct_eval_call_source(call) else {
+            return false;
+        };
+        match source {
+            EvalCallSource::NoSource => {}
+            EvalCallSource::Unknown => self.found = true,
+            EvalCallSource::Known(source) => {
+                if js_source_mentions_binding(&source, &Atom::from("exports"))
+                    || js_source_mentions_binding(&source, &Atom::from("module"))
+                {
+                    self.found = true;
+                }
+            }
+        }
+        true
     }
 }
 
@@ -314,6 +355,58 @@ impl Visit for PublicExportUseFinder<'_> {
         {
             self.found = true;
         }
+    }
+
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if self.found {
+            return;
+        }
+        if !self.check_direct_eval(call) {
+            if let Callee::Expr(callee) = &call.callee {
+                if self.is_surface_receiver(strip_parens(callee)) {
+                    self.found = true;
+                    return;
+                }
+            }
+        }
+        if !self.found {
+            call.visit_children_with(self);
+        }
+    }
+
+    fn visit_opt_call(&mut self, call: &OptCall) {
+        if self.found {
+            return;
+        }
+        // `eval?.()` is an indirect eval per spec, so only the receiver
+        // classification applies here.
+        if self.is_surface_receiver(strip_parens(&call.callee)) {
+            self.found = true;
+            return;
+        }
+        call.visit_children_with(self);
+    }
+
+    fn visit_tagged_tpl(&mut self, tpl: &TaggedTpl) {
+        if self.found {
+            return;
+        }
+        if self.is_surface_receiver(strip_parens(&tpl.tag)) {
+            self.found = true;
+            return;
+        }
+        tpl.visit_children_with(self);
+    }
+}
+
+fn member_like(expr: &Expr) -> Option<&MemberExpr> {
+    match strip_parens(expr) {
+        Expr::Member(member) => Some(member),
+        Expr::OptChain(chain) => match &*chain.base {
+            OptChainBase::Member(member) => Some(member),
+            OptChainBase::Call(_) => None,
+        },
+        _ => None,
     }
 }
 

--- a/crates/core/src/rules/un_enum.rs
+++ b/crates/core/src/rules/un_enum.rs
@@ -13,6 +13,8 @@ use swc_core::ecma::ast::{
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use super::decl_utils::collect_decl_names;
+use super::eval_utils::{js_source_mentions_binding, DirectEvalAnalyzer};
+use crate::js_names::is_reserved_binding_name;
 use crate::utils::paren::strip_parens;
 
 pub struct UnEnum {
@@ -105,8 +107,12 @@ fn process_module_items_for_enum(items: &mut Vec<ModuleItem>, unresolved_mark: O
                             })
                             .filter(|(public_name, _)| !exported_names.contains(public_name))
                             .filter(|(public_name, _)| {
+                                // Earlier items matter too: a function defined
+                                // before the IIFE can defer a read of
+                                // `exports.X` until after the fold removed its
+                                // only write.
                                 !module_items_reference_public_export(
-                                    remaining.iter().skip(1),
+                                    items.iter().chain(remaining.iter().skip(1)),
                                     public_name,
                                     unresolved_mark.expect("exported enum parsing requires a mark"),
                                 )
@@ -137,13 +143,21 @@ fn process_module_items_for_enum(items: &mut Vec<ModuleItem>, unresolved_mark: O
                             if *synthesized_local {
                                 // Collapsed `exports.X || (exports.X = {})` has no
                                 // local assignment and no `var Local`. Synthesize
-                                // the public name only when it appears nowhere
-                                // else in the module (no declaration to collide
-                                // with, no global reference to capture).
-                                !module_items_use_name(
-                                    items.iter().chain(remaining.iter()),
-                                    &local_ident.sym,
-                                )
+                                // the public name only when it is legal as a
+                                // binding and appears nowhere else in the module
+                                // (no declaration to collide with, no global
+                                // reference to capture) — including inside
+                                // direct eval sources, which the AST scan
+                                // cannot see.
+                                !is_reserved_binding_name(&local_ident.sym)
+                                    && !module_items_use_name(
+                                        items.iter().chain(remaining.iter()),
+                                        &local_ident.sym,
+                                    )
+                                    && !module_items_direct_eval_can_observe(
+                                        items.iter().chain(remaining.iter()),
+                                        &local_ident.sym,
+                                    )
                             } else {
                                 has_safe_prior_bare_var(
                                     items,
@@ -154,8 +168,11 @@ fn process_module_items_for_enum(items: &mut Vec<ModuleItem>, unresolved_mark: O
                             }
                         })
                         .filter(|(_, public_name, _, _)| {
+                            // Earlier items matter too: a function defined
+                            // before the IIFE can defer a read of `exports.X`
+                            // until after the fold removed its only write.
                             !module_items_reference_public_export(
-                                remaining.iter(),
+                                items.iter().chain(remaining.iter()),
                                 public_name,
                                 unresolved_mark.expect("exported enum parsing requires a mark"),
                             )
@@ -944,6 +961,26 @@ impl Visit for NameUseFinder<'_> {
             self.found = true;
         }
     }
+}
+
+/// Direct eval resolves names lexically, invisibly to the AST scan above: a
+/// synthesized module-level binding would capture an `eval("X")` that read a
+/// global before. Reject when any direct eval source is unknown or a known
+/// source mentions the name. Indirect eval runs in global scope and cannot
+/// observe module bindings, so it stays irrelevant here.
+fn module_items_direct_eval_can_observe<'a>(
+    items: impl IntoIterator<Item = &'a ModuleItem>,
+    name: &Atom,
+) -> bool {
+    let mut analyzer = DirectEvalAnalyzer::default();
+    for item in items {
+        item.visit_with(&mut analyzer);
+    }
+    analyzer.unknown_direct_eval
+        || analyzer
+            .known_direct_eval_sources
+            .iter()
+            .any(|source| js_source_mentions_binding(source, name))
 }
 
 fn collect_exported_names(items: &[ModuleItem]) -> HashSet<Atom> {

--- a/crates/core/src/rules/un_enum.rs
+++ b/crates/core/src/rules/un_enum.rs
@@ -4,9 +4,9 @@ use swc_core::atoms::{Atom, Wtf8Atom};
 use swc_core::common::{Mark, Span, Spanned, DUMMY_SP};
 use swc_core::ecma::ast::{
     ArrowFunctionBody, AssignExpr, AssignOp, AssignTarget, BinExpr, BinaryOp, BindingIdent,
-    CallExpr, Callee, ComputedPropName, Decl, ExportNamedSpecifier, ExportSpecifier, Expr,
-    ExprStmt, FnExpr, Ident, IdentName, KeyValueProp, Lit, MemberExpr, MemberProp, ModuleDecl,
-    ModuleExportName, ModuleItem, NamedExport, Number, ObjectLit, Pat, Prop, PropName,
+    CallExpr, Callee, ComputedPropName, Decl, ExportDecl, ExportNamedSpecifier, ExportSpecifier,
+    Expr, ExprStmt, FnExpr, Ident, IdentName, KeyValueProp, Lit, MemberExpr, MemberProp,
+    ModuleDecl, ModuleExportName, ModuleItem, NamedExport, Number, ObjectLit, Pat, Prop, PropName,
     PropOrSpread, SimpleAssignTarget, Stmt, Str, UnaryExpr, UnaryOp, VarDecl, VarDeclKind,
     VarDeclarator,
 };
@@ -129,30 +129,56 @@ fn process_module_items_for_enum(items: &mut Vec<ModuleItem>, unresolved_mark: O
                     continue;
                 }
 
-                if let Some((local_ident, public_name, members)) = unresolved_mark
-                    .and_then(|mark| parse_exported_enum_iife_standalone(&stmt, mark))
-                    .filter(|(_, public_name, _)| !exported_names.contains(public_name))
-                    .filter(|(local_ident, public_name, _)| {
-                        has_safe_prior_bare_var(
-                            items,
-                            local_ident,
-                            public_name,
-                            unresolved_mark.expect("exported enum parsing requires a mark"),
-                        )
-                    })
-                    .filter(|(_, public_name, _)| {
-                        !module_items_reference_public_export(
-                            remaining.iter(),
-                            public_name,
-                            unresolved_mark.expect("exported enum parsing requires a mark"),
-                        )
-                    })
+                if let Some((local_ident, public_name, members, synthesized_local)) =
+                    unresolved_mark
+                        .and_then(|mark| parse_exported_enum_iife_standalone(&stmt, mark))
+                        .filter(|(_, public_name, _, _)| !exported_names.contains(public_name))
+                        .filter(|(local_ident, public_name, _, synthesized_local)| {
+                            if *synthesized_local {
+                                // Collapsed `exports.X || (exports.X = {})` has no
+                                // local assignment and no `var Local`. Synthesize
+                                // the public name only when it appears nowhere
+                                // else in the module (no declaration to collide
+                                // with, no global reference to capture).
+                                !module_items_use_name(
+                                    items.iter().chain(remaining.iter()),
+                                    &local_ident.sym,
+                                )
+                            } else {
+                                has_safe_prior_bare_var(
+                                    items,
+                                    local_ident,
+                                    public_name,
+                                    unresolved_mark.expect("exported enum parsing requires a mark"),
+                                )
+                            }
+                        })
+                        .filter(|(_, public_name, _, _)| {
+                            !module_items_reference_public_export(
+                                remaining.iter(),
+                                public_name,
+                                unresolved_mark.expect("exported enum parsing requires a mark"),
+                            )
+                        })
                 {
-                    let new_stmt =
-                        build_enum_assign_stmt(local_ident.clone(), members, stmt.span());
-                    items.push(ModuleItem::Stmt(new_stmt));
-                    exported_names.insert(public_name.clone());
-                    items.push(build_named_enum_export(&local_ident, public_name));
+                    if synthesized_local {
+                        // The binding is fresh and carries the public name, so
+                        // export the declaration directly.
+                        let Stmt::Decl(decl) = build_enum_var_decl(&local_ident, members, &stmt)
+                        else {
+                            unreachable!("build_enum_var_decl builds a declaration");
+                        };
+                        items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                            span: stmt.span(),
+                            decl,
+                        })));
+                    } else {
+                        let new_stmt =
+                            build_enum_assign_stmt(local_ident.clone(), members, stmt.span());
+                        items.push(ModuleItem::Stmt(new_stmt));
+                        items.push(build_named_enum_export(&local_ident, public_name.clone()));
+                    }
+                    exported_names.insert(public_name);
                     continue;
                 }
 
@@ -308,7 +334,8 @@ fn parse_enum_iife(stmt: &Stmt, expected_ident: &Ident) -> Option<Vec<EnumMember
 /// `var Local; (function (e) { ... })(Local = exports.Public || (exports.Public = {}));`
 ///
 /// A second emitted form, `Local || (exports.Public = Local = {})`, is also
-/// accepted. The exported variant is intentionally stricter than local enum
+/// accepted, as is the minified collapse `exports.Public || (exports.Public = {})`.
+/// The exported variant is intentionally stricter than local enum
 /// recovery: the body may contain only literal enum values, so replacing the
 /// early CommonJS publication with an ESM binding cannot hide observable work.
 fn parse_exported_enum_iife(
@@ -316,15 +343,22 @@ fn parse_exported_enum_iife(
     local_ident: &Ident,
     unresolved_mark: Mark,
 ) -> Option<(Atom, Vec<EnumMember>)> {
-    let (parsed_local, public_name, members) =
+    let (parsed_local, public_name, members, synthesized_local) =
         parse_exported_enum_iife_standalone(stmt, unresolved_mark)?;
+    // The collapsed form never assigns the local, so a preceding bare
+    // `var Local;` must keep its `undefined` value. Folding here would
+    // change what later reads of the local observe; the standalone path
+    // also declines it because the name is already declared.
+    if synthesized_local {
+        return None;
+    }
     same_binding(&parsed_local, local_ident).then_some((public_name, members))
 }
 
 fn parse_exported_enum_iife_standalone(
     stmt: &Stmt,
     unresolved_mark: Mark,
-) -> Option<(Ident, Atom, Vec<EnumMember>)> {
+) -> Option<(Ident, Atom, Vec<EnumMember>, bool)> {
     let Stmt::Expr(ExprStmt { expr, .. }) = stmt else {
         return None;
     };
@@ -334,7 +368,8 @@ fn parse_exported_enum_iife_standalone(
     if call.args.len() != 1 {
         return None;
     }
-    let (local_ident, public_name) = parse_exported_enum_arg(&call.args[0].expr, unresolved_mark)?;
+    let (local_ident, public_name, synthesized_local) =
+        parse_exported_enum_arg(&call.args[0].expr, unresolved_mark)?;
 
     let Callee::Expr(callee) = &call.callee else {
         return None;
@@ -349,10 +384,10 @@ fn parse_exported_enum_iife_standalone(
         return None;
     }
 
-    Some((local_ident, public_name, members))
+    Some((local_ident, public_name, members, synthesized_local))
 }
 
-fn parse_exported_enum_arg(expr: &Expr, unresolved_mark: Mark) -> Option<(Ident, Atom)> {
+fn parse_exported_enum_arg(expr: &Expr, unresolved_mark: Mark) -> Option<(Ident, Atom, bool)> {
     let expr = strip_parens(expr);
 
     // `Local = exports.Public || (exports.Public = {})`
@@ -381,12 +416,13 @@ fn parse_exported_enum_arg(expr: &Expr, unresolved_mark: Mark) -> Option<(Ident,
         };
         let public_name = unresolved_exports_member(left_member, unresolved_mark)?;
         if assign_member_empty_object(right, &public_name, unresolved_mark) {
-            return Some((local_ident, public_name));
+            return Some((local_ident, public_name, false));
         }
         return None;
     }
 
     // `Local || (exports.Public = Local = {})`
+    // or the collapsed form `exports.Public || (exports.Public = {})`
     let Expr::Bin(BinExpr {
         op: BinaryOp::LogicalOr,
         left,
@@ -396,25 +432,35 @@ fn parse_exported_enum_arg(expr: &Expr, unresolved_mark: Mark) -> Option<(Ident,
     else {
         return None;
     };
-    let Expr::Ident(left_ident) = strip_parens(left) else {
+    if let Expr::Ident(left_ident) = strip_parens(left) {
+        let local_ident = left_ident.clone();
+        let Expr::Assign(AssignExpr {
+            op: AssignOp::Assign,
+            left,
+            right,
+            ..
+        }) = strip_parens(right)
+        else {
+            return None;
+        };
+        let AssignTarget::Simple(SimpleAssignTarget::Member(export_member)) = left else {
+            return None;
+        };
+        let public_name = unresolved_exports_member(export_member, unresolved_mark)?;
+        return if is_assign_empty_obj(right, &local_ident) {
+            Some((local_ident, public_name, false))
+        } else {
+            None
+        };
+    }
+
+    let Expr::Member(left_member) = strip_parens(left) else {
         return None;
     };
-    let local_ident = left_ident.clone();
-    let Expr::Assign(AssignExpr {
-        op: AssignOp::Assign,
-        left,
-        right,
-        ..
-    }) = strip_parens(right)
-    else {
-        return None;
-    };
-    let AssignTarget::Simple(SimpleAssignTarget::Member(export_member)) = left else {
-        return None;
-    };
-    let public_name = unresolved_exports_member(export_member, unresolved_mark)?;
-    if is_assign_empty_obj(right, &local_ident) {
-        Some((local_ident, public_name))
+    let public_name = unresolved_exports_member(left_member, unresolved_mark)?;
+    if assign_member_empty_object(right, &public_name, unresolved_mark) {
+        let local_ident = Ident::new_no_ctxt(public_name.clone(), DUMMY_SP);
+        Some((local_ident, public_name, true))
     } else {
         None
     }
@@ -868,6 +914,36 @@ fn is_valid_identifier(s: &str) -> bool {
         return false;
     }
     chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+}
+
+/// Whether `name` occurs as any identifier — binding or reference, at any
+/// depth, including import/export specifiers — in the given items.
+/// Synthesizing a module-level binding is only safe when the name is
+/// completely unused: a same-name declaration (imports and block-nested
+/// hoisted `var`s included) would collide, and a same-name reference to a
+/// global would be captured by the new binding.
+fn module_items_use_name<'a>(items: impl IntoIterator<Item = &'a ModuleItem>, name: &Atom) -> bool {
+    let mut finder = NameUseFinder { name, found: false };
+    for item in items {
+        item.visit_with(&mut finder);
+        if finder.found {
+            return true;
+        }
+    }
+    false
+}
+
+struct NameUseFinder<'a> {
+    name: &'a Atom,
+    found: bool,
+}
+
+impl Visit for NameUseFinder<'_> {
+    fn visit_ident(&mut self, ident: &Ident) {
+        if ident.sym == *self.name {
+            self.found = true;
+        }
+    }
 }
 
 fn collect_exported_names(items: &[ModuleItem]) -> HashSet<Atom> {

--- a/crates/core/src/rules/un_enum.rs
+++ b/crates/core/src/rules/un_enum.rs
@@ -14,7 +14,7 @@ use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use super::decl_utils::collect_decl_names;
 use super::eval_utils::{js_source_mentions_binding, DirectEvalAnalyzer};
-use crate::js_names::is_reserved_binding_name;
+use crate::js_names::{is_reserved_binding_name, is_valid_identifier_name};
 use crate::utils::paren::strip_parens;
 
 pub struct UnEnum {
@@ -149,7 +149,8 @@ fn process_module_items_for_enum(items: &mut Vec<ModuleItem>, unresolved_mark: O
                                 // reference to capture) — including inside
                                 // direct eval sources, which the AST scan
                                 // cannot see.
-                                !is_reserved_binding_name(&local_ident.sym)
+                                is_valid_identifier_name(&local_ident.sym)
+                                    && !is_reserved_binding_name(&local_ident.sym)
                                     && !module_items_use_name(
                                         items.iter().chain(remaining.iter()),
                                         &local_ident.sym,
@@ -229,20 +230,112 @@ fn module_items_reference_public_export<'a>(
     })
 }
 
+/// Finds uses that could observe `exports.<public_name>` after the fold
+/// removed its only write. Beyond the direct static member, this treats the
+/// CommonJS export surface fail-closed: a dynamic `exports[key]` access, a
+/// bare `exports` or `module` escaping as a value, or `module.exports`
+/// escaping can all reach the property at runtime.
 struct PublicExportUseFinder<'a> {
     public_name: &'a Atom,
     unresolved_mark: Mark,
     found: bool,
 }
 
-impl Visit for PublicExportUseFinder<'_> {
-    fn visit_member_expr(&mut self, member: &MemberExpr) {
-        self.found |= unresolved_exports_member(member, self.unresolved_mark).as_ref()
-            == Some(self.public_name);
-        if !self.found {
-            member.visit_children_with(self);
+impl PublicExportUseFinder<'_> {
+    fn is_exports_object(&self, expr: &Expr) -> bool {
+        match expr {
+            Expr::Ident(ident) => is_unresolved_named(ident, "exports", self.unresolved_mark),
+            // `module.exports`
+            Expr::Member(member) => {
+                let Expr::Ident(obj) = strip_parens(&member.obj) else {
+                    return false;
+                };
+                is_unresolved_named(obj, "module", self.unresolved_mark)
+                    && member_prop_names(&member.prop, "exports")
+            }
+            _ => false,
         }
     }
+
+    /// Match a property access on an export surface: hazard when the key is
+    /// the public name or is not statically known.
+    fn check_surface_prop(&mut self, prop: &MemberProp, hazard_name: &Atom) {
+        match prop {
+            MemberProp::Ident(ident_name) => {
+                if ident_name.sym == *hazard_name {
+                    self.found = true;
+                }
+            }
+            MemberProp::Computed(computed) => {
+                match computed_key_atom(computed) {
+                    Some(name) => {
+                        if name == *hazard_name {
+                            self.found = true;
+                        }
+                    }
+                    // A dynamic key can name the property at runtime.
+                    None => self.found = true,
+                }
+                computed.expr.visit_with(self);
+            }
+            MemberProp::PrivateName(_) => {}
+        }
+    }
+}
+
+impl Visit for PublicExportUseFinder<'_> {
+    fn visit_member_expr(&mut self, member: &MemberExpr) {
+        if self.found {
+            return;
+        }
+        let obj = strip_parens(&member.obj);
+        if self.is_exports_object(obj) {
+            self.check_surface_prop(&member.prop, self.public_name);
+            // The `exports` / `module.exports` inside `obj` is accounted for.
+            return;
+        }
+        if let Expr::Ident(obj_ident) = obj {
+            if is_unresolved_named(obj_ident, "module", self.unresolved_mark) {
+                // Reaching `module.exports` here — not as the object of an
+                // outer member — means the exports object itself escapes as a
+                // value. Other static `module` properties cannot reach it.
+                self.check_surface_prop(&member.prop, &Atom::from("exports"));
+                return;
+            }
+        }
+        member.visit_children_with(self);
+    }
+
+    fn visit_ident(&mut self, ident: &Ident) {
+        // A bare `exports` or `module` surviving to here escaped the member
+        // classification above; the exports object itself becomes observable.
+        if is_unresolved_named(ident, "exports", self.unresolved_mark)
+            || is_unresolved_named(ident, "module", self.unresolved_mark)
+        {
+            self.found = true;
+        }
+    }
+}
+
+fn is_unresolved_named(ident: &Ident, name: &str, unresolved_mark: Mark) -> bool {
+    ident.sym == *name && ident.ctxt.outer() == unresolved_mark
+}
+
+fn member_prop_names(prop: &MemberProp, name: &str) -> bool {
+    match prop {
+        MemberProp::Ident(ident_name) => ident_name.sym == *name,
+        MemberProp::Computed(computed) => {
+            computed_key_atom(computed).is_some_and(|key| key == *name)
+        }
+        MemberProp::PrivateName(_) => false,
+    }
+}
+
+fn computed_key_atom(computed: &ComputedPropName) -> Option<Atom> {
+    let Expr::Lit(Lit::Str(value)) = strip_parens(&computed.expr) else {
+        return None;
+    };
+    value.value.as_str().map(Atom::from)
 }
 
 fn process_stmts_for_enum(stmts: &mut Vec<Stmt>) {
@@ -921,16 +1014,13 @@ fn extract_string_value(expr: &Expr) -> Option<Wtf8Atom> {
     }
 }
 
+/// JavaScript identifier grammar, reserved words allowed. Property keys and
+/// export names may legally be reserved words (`exports.default`,
+/// `export { X as default }`), so reservation is checked separately where a
+/// name becomes a binding. Reserved words are all plain ASCII, so appending
+/// them to the grammar check cannot admit a grammar-invalid name.
 fn is_valid_identifier(s: &str) -> bool {
-    if s.is_empty() {
-        return false;
-    }
-    let mut chars = s.chars();
-    let first = chars.next().unwrap();
-    if !first.is_alphabetic() && first != '_' && first != '$' {
-        return false;
-    }
-    chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+    is_valid_identifier_name(s) || is_reserved_binding_name(s)
 }
 
 /// Whether `name` occurs as any identifier — binding or reference, at any

--- a/crates/core/tests/un_enum_rule.rs
+++ b/crates/core/tests/un_enum_rule.rs
@@ -365,6 +365,119 @@ var Mode = {
 }
 
 #[test]
+fn collapsed_exported_enum_rejects_surface_method_call() {
+    // A call with the export surface as receiver can observe the property
+    // the fold would remove.
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(exports.hasOwnProperty("Mode"));
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_surface_identity_call() {
+    // `exports.valueOf()` returns the surface itself; the chained read
+    // bypasses static member matching.
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(exports.valueOf().Mode);
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_module_identity_call() {
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(module.valueOf().exports.Mode);
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_optional_surface_call() {
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(exports?.hasOwnProperty("Mode"));
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_surface_tagged_template() {
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(exports.valueOf``.Mode);
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_prototype_mutating_member() {
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(exports.__proto__);
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_direct_eval_reading_exports() {
+    // The eval source never names `Mode`, but it reads the export surface.
+    let input = r#"
+const key = "Mode";
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(eval("exports[key]"));
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn exported_enum_rejects_direct_eval_reading_exports() {
+    // The local-alias path shares the same public-export proof.
+    let input = r#"
+var LocalMode;
+(function (e) {
+  e["Dev"] = "dev";
+})(LocalMode = exports.Mode || (exports.Mode = {}));
+observe(eval("exports.Mode"));
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_allows_unrelated_method_call() {
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(other.hasOwnProperty("Mode"));
+"#;
+    let expected = r#"
+export var Mode = {
+  Dev: "dev"
+};
+observe(other.hasOwnProperty("Mode"));
+"#;
+    assert_eq_normalized(&apply_resolved(input), expected);
+}
+
+#[test]
 fn collapsed_exported_enum_rejects_prior_bare_var() {
     // The collapsed form never assigns the local, so `var Mode` must stay
     // `undefined` — folding into it would change what later reads observe.

--- a/crates/core/tests/un_enum_rule.rs
+++ b/crates/core/tests/un_enum_rule.rs
@@ -176,6 +176,92 @@ observe(Mode);
 }
 
 #[test]
+fn collapsed_exported_enum_rejects_reserved_name() {
+    // `exports.class` is a legal property, but the synthesized binding
+    // `export var class` would be a SyntaxError.
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.class || (exports.class = {}));
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_earlier_public_export_read() {
+    // A function defined before the IIFE can defer its `exports.Mode` read
+    // until after the fold removed the only write.
+    let input = r#"
+function readMode() {
+  return exports.Mode;
+}
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(readMode());
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn exported_enum_rejects_earlier_public_export_read() {
+    // Same deferred-read hazard for the local-alias form: the fold removes
+    // the `exports.Mode` write that `readMode` observes.
+    let input = r#"
+function readMode() {
+  return exports.Mode;
+}
+var LocalMode;
+(function (e) {
+  e["Dev"] = "dev";
+})(LocalMode = exports.Mode || (exports.Mode = {}));
+observe(readMode());
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_direct_eval_mentioning_name() {
+    // Direct eval resolves names lexically; the synthesized module binding
+    // would capture what used to be a global lookup.
+    let input = r#"
+observe(eval("Mode"));
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_unknown_direct_eval() {
+    let input = r#"
+observe(eval(source));
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_allows_unrelated_direct_eval() {
+    let input = r#"
+observe(eval("1 + 1"));
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    let expected = r#"
+observe(eval("1 + 1"));
+export var Mode = {
+  Dev: "dev"
+};
+"#;
+    assert_eq_normalized(&apply_resolved(input), expected);
+}
+
+#[test]
 fn collapsed_exported_enum_rejects_prior_bare_var() {
     // The collapsed form never assigns the local, so `var Mode` must stay
     // `undefined` — folding into it would change what later reads observe.

--- a/crates/core/tests/un_enum_rule.rs
+++ b/crates/core/tests/un_enum_rule.rs
@@ -83,6 +83,113 @@ export { LocalMode as Mode };
 }
 
 #[test]
+fn recovers_collapsed_exported_commonjs_enum() {
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    let expected = r#"
+export var Mode = {
+  Dev: "dev"
+};
+"#;
+    assert_eq_normalized(&apply_resolved(input), expected);
+}
+
+#[test]
+fn recovers_collapsed_exported_numeric_enum() {
+    let input = r#"
+(function (e) {
+  e[e.Dev = 0] = "Dev";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    let expected = r#"
+export var Mode = {
+  Dev: 0,
+  0: "Dev"
+};
+"#;
+    assert_eq_normalized(&apply_resolved(input), expected);
+}
+
+#[test]
+fn recovers_collapsed_exported_enum_mangled_param() {
+    let input = r#"
+(function (t) {
+  t["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    let expected = r#"
+export var Mode = {
+  Dev: "dev"
+};
+"#;
+    assert_eq_normalized(&apply_resolved(input), expected);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_later_public_export_read() {
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(exports.Mode);
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_existing_local_name() {
+    let input = r#"
+var Mode = 1;
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_import_collision() {
+    let input = r#"
+import { Mode } from "./dep.js";
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+use(Mode);
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_global_reference() {
+    // `observe(Mode)` reads a global; a synthesized `var Mode` would
+    // capture it (and throw via TDZ once promoted to `const`).
+    let input = r#"
+observe(Mode);
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_prior_bare_var() {
+    // The collapsed form never assigns the local, so `var Mode` must stay
+    // `undefined` — folding into it would change what later reads observe.
+    let input = r#"
+var Mode;
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+use(Mode);
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
 fn pipeline_promotes_adjacent_exported_enum_to_const() {
     let input = r#"
 export let Mode;
@@ -96,6 +203,64 @@ export const Mode = {
   Dev: "dev"
 };
 use(Mode);
+"#;
+    assert_eq_normalized(&render_pipeline(input), expected);
+}
+
+#[test]
+fn pipeline_recovers_minified_cjs_enum() {
+    let input = r#"
+exports.Mode = void 0;
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    let expected = r#"
+export const Mode = {
+  Dev: "dev"
+};
+"#;
+    assert_eq_normalized(&render_pipeline(input), expected);
+}
+
+#[test]
+fn pipeline_recovers_minified_cjs_numeric_enum() {
+    let input = r#"
+exports.Mode = void 0;
+(function (e) {
+  e[e.Dev = 0] = "Dev";
+  e[e.Prod = 1] = "Prod";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    let expected = r#"
+export const Mode = {
+  Dev: 0,
+  0: "Dev",
+  Prod: 1,
+  1: "Prod"
+};
+"#;
+    assert_eq_normalized(&render_pipeline(input), expected);
+}
+
+#[test]
+fn pipeline_still_recovers_minified_cjs_enum_with_local_alias() {
+    // Same producer, but module-scope compress kept the local alias as a
+    // mangled name instead of collapsing it. This form already recovered
+    // before collapsed-form support; it must keep working.
+    let input = r#"
+exports.Mode = void 0;
+var r;
+(function (t) {
+  t["Dev"] = "dev";
+  t["Prod"] = "prod";
+})(r = exports.Mode || (exports.Mode = {}));
+"#;
+    let expected = r#"
+export const Mode = {
+  Dev: "dev",
+  Prod: "prod"
+};
 "#;
     assert_eq_normalized(&render_pipeline(input), expected);
 }

--- a/crates/core/tests/un_enum_rule.rs
+++ b/crates/core/tests/un_enum_rule.rs
@@ -262,6 +262,109 @@ export var Mode = {
 }
 
 #[test]
+fn collapsed_exported_enum_rejects_invalid_identifier_name() {
+    // `a\u{B2}` (a²) passes a naive alphanumeric check but is not valid
+    // JavaScript identifier grammar; the synthesized binding would be a
+    // SyntaxError.
+    let input = "
+(function (e) {
+  e[\"Dev\"] = \"dev\";
+})(exports[\"a\u{B2}\"] || (exports[\"a\u{B2}\"] = {}));
+";
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_exports_escape() {
+    // The exports object escapes as a value; `publicApi.Mode` observes the
+    // write the fold would remove.
+    let input = r#"
+const publicApi = exports;
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(publicApi.Mode);
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_dynamic_exports_access() {
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(exports[key]);
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_rejects_module_exports_read() {
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+observe(module.exports.Mode);
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_exported_enum_allows_unrelated_static_export_write() {
+    let input = r#"
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+exports.other = 1;
+"#;
+    let expected = r#"
+export var Mode = {
+  Dev: "dev"
+};
+exports.other = 1;
+"#;
+    assert_eq_normalized(&apply_resolved(input), expected);
+}
+
+#[test]
+fn collapsed_exported_enum_allows_indirect_eval() {
+    // Indirect eval runs in global scope and cannot observe module
+    // bindings, so it does not block synthesis.
+    let input = r#"
+observe((0, eval)("Mode"));
+(function (e) {
+  e["Dev"] = "dev";
+})(exports.Mode || (exports.Mode = {}));
+"#;
+    let expected = r#"
+observe((0, eval)("Mode"));
+export var Mode = {
+  Dev: "dev"
+};
+"#;
+    assert_eq_normalized(&apply_resolved(input), expected);
+}
+
+#[test]
+fn enum_member_key_with_invalid_identifier_grammar_stays_string() {
+    // `a\u{B2}` passes a naive alphanumeric check; an ident key would emit
+    // invalid JavaScript.
+    let input = "
+var Mode;
+(function (e) {
+  e[\"a\u{B2}\"] = \"x\";
+})(Mode || (Mode = {}));
+";
+    let expected = "
+var Mode = {
+  \"a\u{B2}\": \"x\"
+};
+";
+    assert_eq_normalized(&apply_resolved(input), expected);
+}
+
+#[test]
 fn collapsed_exported_enum_rejects_prior_bare_var() {
     // The collapsed form never assigns the local, so `var Mode` must stay
     // `undefined` — folding into it would change what later reads observe.


### PR DESCRIPTION
## Summary
- `UnEsm` no longer drops a dummy `exports.X = void 0` when later code still names `exports.X` (typically `exports.X || (exports.X = {})`). It becomes `export let X`, and those later reads/writes are rewritten to the local binding.
- `UnEnum` now accepts the collapsed IIFE argument `exports.Public || (exports.Public = {})` without a prior `var Local`.
- Existing `void_only_export_removed` / `export_dedup_void_init` behavior is unchanged. Nested `exports.X = {}` is still not treated as a top-level `value_writes == 1` proof.

## Why
`tsc --module commonjs` emits:

```js
exports.Mode = void 0;
var Mode;
(function (Mode) {
  Mode["Dev"] = "dev";
})(Mode = exports.Mode || (exports.Mode = {}));
```

Module-scope compress (`terser -c toplevel`, or uglify `sequences` + `collapse_vars`) drops the local binding, leaving:

```js
exports.Mode = void 0;
(function (e) {
  e.Dev = "dev";
})(exports.Mode || (exports.Mode = {}));
```

UnEsm classified the dummy as void-only and deleted it. The IIFE argument is not a top-level `exports.X = value`, so CommonJS self-read recovery (`value_writes == 1`) does not apply. UnEnum only recognized the two local-assignment argument forms, so the export disappeared.

## Reproduce

```bash
cat > mode.ts <<'EOF'
export enum Mode {
  Dev = "dev",
  Prod = "prod",
}
EOF
npx -y -p typescript@4.9.5 tsc --module commonjs --target es5 mode.ts
npx -y terser@5 mode.js -c toplevel -o mode.min.js
wakaru mode.min.js --force -o mode.out.js
```

Numeric enums (`export enum Flag { A = 1, B = 2 }`) follow the same path and keep reverse mappings.

## Before / After

Before (1.9.0):

```js
(function (Mode) {
  Mode.Dev = "dev";
  Mode.Prod = "prod";
})(exports.Mode || (exports.Mode = {}));
```

After:

```js
const Mode = {
  Dev: "dev",
  Prod: "prod"
};
export { Mode };
```

## Tests
- `void_export_kept_when_later_or_assign`
- `void_export_not_promoted_when_local_name_conflicts`
- `recovers_collapsed_exported_commonjs_enum`
- `recovers_collapsed_exported_numeric_enum`
- `recovers_collapsed_exported_enum_mangled_param`
- `collapsed_exported_enum_rejects_later_public_export_read`
- `collapsed_exported_enum_rejects_existing_local_name`
- `pipeline_recovers_minified_cjs_enum`
- `pipeline_recovers_minified_cjs_numeric_enum`

## Test plan
- [x] `cargo test -p wakaru-core --test un_esm_rule`
- [x] `cargo test -p wakaru-core --test un_enum_rule`
- [x] `cargo nextest run -p wakaru-core`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p wakaru-core --all-targets -- -D warnings`