### PR TITLE
fix(systemjs): reconstruct exports from assignment/var of _export seq…

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -3,13 +3,13 @@ use std::collections::HashSet;
 use swc_core::atoms::Atom;
 use swc_core::common::{sync::Lrc, SourceMap, Span, DUMMY_SP};
 use swc_core::ecma::ast::{
-    ArrayLit, ArrowFunctionBody, AssignTarget, BindingIdent, CallExpr, Callee, Decl, EsVersion,
-    ExportDecl, ExportDefaultExpr, ExportNamedSpecifier, ExportSpecifier, Expr, ExprOrSpread,
-    ExprStmt, FnExpr, Function, FunctionBody, Ident, ImportDecl, ImportDefaultSpecifier,
-    ImportNamedSpecifier, ImportSpecifier, ImportStarAsSpecifier, Lit, MemberExpr, MemberProp,
-    MetaPropExpr, MetaPropKind, Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport,
-    ObjectLit, ParenExpr, Pat, Prop, PropName, PropOrSpread, ReturnStmt, SimpleAssignTarget, Stmt,
-    Str, UnaryOp, VarDecl, VarDeclarator,
+    ArrayLit, ArrowFunctionBody, AssignExpr, AssignOp, AssignTarget, BindingIdent, CallExpr,
+    Callee, Decl, EsVersion, ExportDecl, ExportDefaultExpr, ExportNamedSpecifier, ExportSpecifier,
+    Expr, ExprOrSpread, ExprStmt, FnExpr, Function, FunctionBody, Ident, ImportDecl,
+    ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier, ImportStarAsSpecifier, Lit,
+    MemberExpr, MemberProp, MetaPropExpr, MetaPropKind, Module, ModuleDecl, ModuleExportName,
+    ModuleItem, NamedExport, ObjectLit, ParenExpr, Pat, Prop, PropName, PropOrSpread, ReturnStmt,
+    SimpleAssignTarget, Stmt, Str, UnaryOp, VarDecl, VarDeclarator,
 };
 use swc_core::ecma::codegen::{text_writer::JsWriter, Config, Emitter};
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
@@ -595,6 +595,14 @@ impl SystemExecuteTransformer {
             return;
         }
 
+        // `var x = (_export("A", v1), _export("B", v2))`: init is a Seq; the old rewrite only accepts Call.
+        if let Stmt::Decl(Decl::Var(var)) = &stmt {
+            if let Some(export_items) = self.take_var_export_seq_decls(var) {
+                items.extend(export_items);
+                return;
+            }
+        }
+
         if let Stmt::Decl(Decl::Var(var)) = &mut stmt {
             self.rewrite_var_exports(var);
         }
@@ -653,7 +661,9 @@ impl SystemExecuteTransformer {
                 let export_call = parse_export_call(call, &self.export_sym)?;
                 self.export_call_items(export_call)
             }
-            Expr::Assign(assign) => self.export_member_assignment_items(assign),
+            Expr::Assign(assign) => self
+                .export_member_assignment_items(assign)
+                .or_else(|| self.take_ident_assign_export_seq(assign)),
             Expr::Seq(seq) => {
                 let mut items = Vec::new();
                 let mut saw_export = false;
@@ -661,7 +671,9 @@ impl SystemExecuteTransformer {
                     let export_items = match expr.as_ref() {
                         Expr::Call(call) => parse_export_call(call, &self.export_sym)
                             .and_then(|export_call| self.export_call_items(export_call)),
-                        Expr::Assign(assign) => self.export_member_assignment_items(assign),
+                        Expr::Assign(assign) => self
+                            .export_member_assignment_items(assign)
+                            .or_else(|| self.take_ident_assign_export_seq(assign)),
                         _ => None,
                     };
                     if let Some(export_items) = export_items {
@@ -846,6 +858,192 @@ impl SystemExecuteTransformer {
                 Some(assignment_items)
             }
         }
+    }
+
+    fn take_ident_assign_export_seq(&mut self, assign: &AssignExpr) -> Option<Vec<ModuleItem>> {
+        if assign.op != AssignOp::Assign {
+            return None;
+        }
+        let local = assign.left.as_simple()?.as_ident()?.id.sym.clone();
+        let exprs = self.as_export_seq(assign.right.as_ref())?;
+        let last_idx = exprs.len().checked_sub(1)?;
+        let mut items = Vec::new();
+        for (idx, part) in exprs.iter().enumerate() {
+            let export_call = match strip_paren_expr(part) {
+                Expr::Call(call) => parse_export_call(call, &self.export_sym),
+                _ => None,
+            };
+            if idx == last_idx {
+                // The assign target is often not a declared binding, so
+                // `export { h as Name }` is dropped by the decompile pipeline.
+                // Emit `export const Name = value` and `h = Name` to keep object identity.
+                let alias = match &export_call {
+                    Some(ExportCall::Single { exported, .. })
+                        if exported.as_ref() != "default" && is_valid_ident_name(exported) =>
+                    {
+                        Some(exported.clone())
+                    }
+                    _ => None,
+                };
+                if let Some(export_call) = export_call {
+                    if let Some(export_items) = self.export_call_items(export_call) {
+                        items.extend(export_items);
+                        if let Some(exported) = alias {
+                            items.push(assign_ident_item(
+                                local,
+                                Box::new(Expr::Ident(ident(exported))),
+                            ));
+                            return Some(items);
+                        }
+                    }
+                }
+                let mut last = part.clone();
+                last.visit_mut_with(self);
+                items.push(assign_ident_item(local, last));
+                return Some(items);
+            }
+            if let Some(export_call) = export_call {
+                if let Some(export_items) = self.export_call_items(export_call) {
+                    items.extend(export_items);
+                    continue;
+                }
+            }
+            let mut stmt = Stmt::Expr(ExprStmt {
+                span: DUMMY_SP,
+                expr: part.clone(),
+            });
+            stmt.visit_mut_with(self);
+            items.push(ModuleItem::Stmt(stmt));
+        }
+        None
+    }
+
+    fn take_var_export_seq_decls(&mut self, var: &VarDecl) -> Option<Vec<ModuleItem>> {
+        let has_seq = var.decls.iter().any(|decl| {
+            decl.init
+                .as_ref()
+                .is_some_and(|init| self.as_export_seq(init).is_some())
+        });
+        if !has_seq {
+            return None;
+        }
+
+        let mut items = Vec::new();
+        let mut kept = Vec::new();
+        for decl in &var.decls {
+            let Some(local) = pat_single_ident(&decl.name).cloned() else {
+                let mut leftover = decl.clone();
+                leftover.visit_mut_with(self);
+                kept.push(leftover);
+                continue;
+            };
+            let Some(init) = &decl.init else {
+                kept.push(decl.clone());
+                continue;
+            };
+
+            if let Some((prefix, value)) =
+                self.take_bound_export_seq(init.as_ref(), Some(local.clone()))
+            {
+                items.extend(prefix);
+                kept.push(VarDeclarator {
+                    span: decl.span,
+                    name: decl.name.clone(),
+                    init: Some(value),
+                    definite: decl.definite,
+                });
+                continue;
+            }
+
+            if let Expr::Call(call) = strip_paren_expr(init.as_ref()) {
+                if let Some(ExportCall::Single { exported, value }) =
+                    parse_export_call(call, &self.export_sym)
+                {
+                    let mut value = value;
+                    value.visit_mut_with(self);
+                    self.add_export(local, exported);
+                    kept.push(VarDeclarator {
+                        span: decl.span,
+                        name: decl.name.clone(),
+                        init: Some(value),
+                        definite: decl.definite,
+                    });
+                    continue;
+                }
+            }
+
+            let mut leftover = decl.clone();
+            leftover.visit_mut_with(self);
+            kept.push(leftover);
+        }
+
+        if !kept.is_empty() {
+            items.push(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+                span: var.span,
+                ctxt: var.ctxt,
+                kind: var.kind,
+                declare: var.declare,
+                decls: kept,
+            })))));
+        }
+        Some(items)
+    }
+
+    fn as_export_seq<'a>(&self, expr: &'a Expr) -> Option<&'a [Box<Expr>]> {
+        let Expr::Seq(seq) = strip_paren_expr(expr) else {
+            return None;
+        };
+        let has_export = seq.exprs.iter().any(|part| {
+            matches!(
+                strip_paren_expr(part),
+                Expr::Call(call) if parse_export_call(call, &self.export_sym).is_some()
+            )
+        });
+        has_export.then_some(seq.exprs.as_slice())
+    }
+
+    /// Split an `_export` comma sequence into prefix export items plus the last value.
+    /// When the last item is `_export(name, v)` and `bind` is set, `add_export(bind, name)` and return `v`.
+    fn take_bound_export_seq(
+        &mut self,
+        expr: &Expr,
+        bind: Option<Atom>,
+    ) -> Option<(Vec<ModuleItem>, Box<Expr>)> {
+        let exprs = self.as_export_seq(expr)?;
+        let last_idx = exprs.len().checked_sub(1)?;
+        let mut items = Vec::new();
+        for (idx, part) in exprs.iter().enumerate() {
+            let export_call = match strip_paren_expr(part) {
+                Expr::Call(call) => parse_export_call(call, &self.export_sym),
+                _ => None,
+            };
+            if idx == last_idx {
+                if let (Some(local), Some(ExportCall::Single { exported, value })) =
+                    (bind.as_ref(), export_call)
+                {
+                    let mut value = value;
+                    value.visit_mut_with(self);
+                    self.add_export(local.clone(), exported);
+                    return Some((items, value));
+                }
+                let mut last = part.clone();
+                last.visit_mut_with(self);
+                return Some((items, last));
+            }
+            if let Some(export_call) = export_call {
+                if let Some(export_items) = self.export_call_items(export_call) {
+                    items.extend(export_items);
+                    continue;
+                }
+            }
+            let mut stmt = Stmt::Expr(ExprStmt {
+                span: DUMMY_SP,
+                expr: part.clone(),
+            });
+            stmt.visit_mut_with(self);
+            items.push(ModuleItem::Stmt(stmt));
+        }
+        None
     }
 
     fn rewrite_var_exports(&mut self, var: &mut Box<VarDecl>) {
@@ -1069,6 +1267,28 @@ fn string_lit_arg(arg: &ExprOrSpread) -> Option<Atom> {
 fn param_sym(function: &Function, idx: usize) -> Option<Atom> {
     let param = function.params.get(idx)?;
     pat_single_ident(&param.pat).cloned()
+}
+
+fn assign_ident_item(local: Atom, value: Box<Expr>) -> ModuleItem {
+    ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+        span: DUMMY_SP,
+        expr: Box::new(Expr::Assign(AssignExpr {
+            span: DUMMY_SP,
+            op: AssignOp::Assign,
+            left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                id: ident(local),
+                type_ann: None,
+            })),
+            right: value,
+        })),
+    }))
+}
+
+fn strip_paren_expr(expr: &Expr) -> &Expr {
+    match expr {
+        Expr::Paren(paren) => strip_paren_expr(paren.expr.as_ref()),
+        other => other,
+    }
 }
 
 fn pat_single_ident(pat: &Pat) -> Option<&Atom> {

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -14,6 +14,7 @@ use swc_core::ecma::ast::{
 use swc_core::ecma::codegen::{text_writer::JsWriter, Config, Emitter};
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
+use crate::js_names::is_reserved_binding_name;
 use crate::unpacker::{span_byte_range, BundleFormat, UnpackResult, UnpackedModule};
 
 pub(super) fn detect_from_module(module: &Module, cm: Lrc<SourceMap>) -> Option<UnpackResult> {
@@ -820,26 +821,7 @@ impl SystemExecuteTransformer {
                 if is_valid_ident_name(exported.as_ref()) {
                     self.declared_exports
                         .insert((exported.clone(), exported.clone()));
-                    return Some(vec![ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(
-                        ExportDecl {
-                            span: DUMMY_SP,
-                            decl: Decl::Var(Box::new(VarDecl {
-                                span: DUMMY_SP,
-                                ctxt: Default::default(),
-                                kind: swc_core::ecma::ast::VarDeclKind::Const,
-                                declare: false,
-                                decls: vec![VarDeclarator {
-                                    span: DUMMY_SP,
-                                    name: Pat::Ident(BindingIdent {
-                                        id: ident(exported),
-                                        type_ann: None,
-                                    }),
-                                    init: Some(value),
-                                    definite: false,
-                                }],
-                            })),
-                        },
-                    ))]);
+                    return Some(vec![named_export_decl_item(exported, value)]);
                 }
                 None
             }
@@ -864,7 +846,7 @@ impl SystemExecuteTransformer {
         if assign.op != AssignOp::Assign {
             return None;
         }
-        let local = assign.left.as_simple()?.as_ident()?.id.sym.clone();
+        let target = assign.left.as_simple()?.as_ident()?.clone();
         let exprs = self.as_export_seq(assign.right.as_ref())?;
         let last_idx = exprs.len().checked_sub(1)?;
         let mut items = Vec::new();
@@ -874,36 +856,21 @@ impl SystemExecuteTransformer {
                 _ => None,
             };
             if idx == last_idx {
-                // The assign target is often not a declared binding, so
-                // `export { h as Name }` is dropped by the decompile pipeline.
-                // Emit `export const Name = value` and `h = Name` to keep object identity.
-                let alias = match &export_call {
-                    Some(ExportCall::Single { exported, .. })
-                        if exported.as_ref() != "default" && is_valid_ident_name(exported) =>
-                    {
-                        Some(exported.clone())
-                    }
-                    _ => None,
-                };
                 if let Some(export_call) = export_call {
-                    if let Some(export_items) = self.export_call_items(export_call) {
+                    if let Some((export_items, result)) = self.export_call_result_items(export_call)
+                    {
                         items.extend(export_items);
-                        if let Some(exported) = alias {
-                            items.push(assign_ident_item(
-                                local,
-                                Box::new(Expr::Ident(ident(exported))),
-                            ));
-                            return Some(items);
-                        }
+                        items.push(assign_ident_item(target, result));
+                        return Some(items);
                     }
                 }
                 let mut last = part.clone();
                 last.visit_mut_with(self);
-                items.push(assign_ident_item(local, last));
+                items.push(assign_ident_item(target, last));
                 return Some(items);
             }
             if let Some(export_call) = export_call {
-                if let Some(export_items) = self.export_call_items(export_call) {
+                if let Some(export_items) = self.export_sequence_prefix_items(export_call) {
                     items.extend(export_items);
                     continue;
                 }
@@ -918,6 +885,73 @@ impl SystemExecuteTransformer {
         None
     }
 
+    fn export_sequence_prefix_items(&mut self, export_call: ExportCall) -> Option<Vec<ModuleItem>> {
+        match export_call {
+            single @ ExportCall::Single { .. } => self
+                .export_call_result_items(single)
+                .map(|(items, _)| items),
+            bulk @ ExportCall::Bulk(_) => self.export_call_items(bulk),
+        }
+    }
+
+    fn export_call_result_items(
+        &mut self,
+        export_call: ExportCall,
+    ) -> Option<(Vec<ModuleItem>, Box<Expr>)> {
+        let ExportCall::Single {
+            exported,
+            mut value,
+        } = export_call
+        else {
+            return None;
+        };
+        value.visit_mut_with(self);
+
+        if let Some(local) = exported_value_local(value.as_ref()) {
+            self.add_export(local.clone(), exported);
+            let result = Box::new(Expr::Ident(ident(local)));
+            let items = if matches!(value.as_ref(), Expr::Assign(_)) {
+                vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                    span: DUMMY_SP,
+                    expr: value,
+                }))]
+            } else {
+                Vec::new()
+            };
+            return Some((items, result));
+        }
+
+        let is_default = exported.as_ref() == "default";
+        if !is_default && !is_valid_ident_name(exported.as_ref()) {
+            return None;
+        }
+        let can_use_exported_name = !is_default
+            && !is_reserved_binding_name(exported.as_ref())
+            && self.used_names.insert(exported.clone());
+        if can_use_exported_name {
+            self.declared_exports
+                .insert((exported.clone(), exported.clone()));
+            let result = Box::new(Expr::Ident(ident(exported.clone())));
+            return Some((vec![named_export_decl_item(exported, value)], result));
+        }
+
+        let local = self.fresh_export_name();
+        let mut items = vec![self.binding_item(local.clone(), value)];
+        if is_default {
+            items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
+                ExportDefaultExpr {
+                    span: DUMMY_SP,
+                    expr: Box::new(Expr::Ident(ident(local.clone()))),
+                },
+            )));
+        } else {
+            self.declared_exports
+                .insert((local.clone(), exported.clone()));
+            items.push(named_export_item(local.clone(), exported));
+        }
+        Some((items, Box::new(Expr::Ident(ident(local)))))
+    }
+
     fn take_var_export_seq_decls(&mut self, var: &VarDecl) -> Option<Vec<ModuleItem>> {
         let has_seq = var.decls.iter().any(|decl| {
             decl.init
@@ -929,62 +963,51 @@ impl SystemExecuteTransformer {
         }
 
         let mut items = Vec::new();
-        let mut kept = Vec::new();
         for decl in &var.decls {
-            let Some(local) = pat_single_ident(&decl.name).cloned() else {
-                let mut leftover = decl.clone();
-                leftover.visit_mut_with(self);
-                kept.push(leftover);
-                continue;
-            };
-            let Some(init) = &decl.init else {
-                kept.push(decl.clone());
-                continue;
-            };
-
-            if let Some((prefix, value)) =
-                self.take_bound_export_seq(init.as_ref(), Some(local.clone()))
+            if let (Some(local), Some(init)) =
+                (pat_single_ident(&decl.name).cloned(), decl.init.as_ref())
             {
-                items.extend(prefix);
-                kept.push(VarDeclarator {
-                    span: decl.span,
-                    name: decl.name.clone(),
-                    init: Some(value),
-                    definite: decl.definite,
-                });
-                continue;
-            }
-
-            if let Expr::Call(call) = strip_paren_expr(init.as_ref()) {
-                if let Some(ExportCall::Single { exported, value }) =
-                    parse_export_call(call, &self.export_sym)
+                if let Some((prefix, value)) =
+                    self.take_bound_export_seq(init.as_ref(), Some(local.clone()))
                 {
-                    let mut value = value;
-                    value.visit_mut_with(self);
-                    self.add_export(local, exported);
-                    kept.push(VarDeclarator {
-                        span: decl.span,
-                        name: decl.name.clone(),
-                        init: Some(value),
-                        definite: decl.definite,
-                    });
+                    items.extend(prefix);
+                    items.push(var_declarator_item(
+                        var,
+                        VarDeclarator {
+                            span: decl.span,
+                            name: decl.name.clone(),
+                            init: Some(value),
+                            definite: decl.definite,
+                        },
+                    ));
                     continue;
+                }
+
+                if let Expr::Call(call) = strip_paren_expr(init.as_ref()) {
+                    if let Some(ExportCall::Single {
+                        exported,
+                        mut value,
+                    }) = parse_export_call(call, &self.export_sym)
+                    {
+                        value.visit_mut_with(self);
+                        self.add_export(local, exported);
+                        items.push(var_declarator_item(
+                            var,
+                            VarDeclarator {
+                                span: decl.span,
+                                name: decl.name.clone(),
+                                init: Some(value),
+                                definite: decl.definite,
+                            },
+                        ));
+                        continue;
+                    }
                 }
             }
 
             let mut leftover = decl.clone();
             leftover.visit_mut_with(self);
-            kept.push(leftover);
-        }
-
-        if !kept.is_empty() {
-            items.push(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
-                span: var.span,
-                ctxt: var.ctxt,
-                kind: var.kind,
-                declare: var.declare,
-                decls: kept,
-            })))));
+            items.push(var_declarator_item(var, leftover));
         }
         Some(items)
     }
@@ -1031,7 +1054,7 @@ impl SystemExecuteTransformer {
                 return Some((items, last));
             }
             if let Some(export_call) = export_call {
-                if let Some(export_items) = self.export_call_items(export_call) {
+                if let Some(export_items) = self.export_sequence_prefix_items(export_call) {
                     items.extend(export_items);
                     continue;
                 }
@@ -1169,6 +1192,27 @@ fn named_export_item(local: Atom, exported: Atom) -> ModuleItem {
     }))
 }
 
+fn named_export_decl_item(exported: Atom, value: Box<Expr>) -> ModuleItem {
+    ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+        span: DUMMY_SP,
+        decl: Decl::Var(Box::new(VarDecl {
+            span: DUMMY_SP,
+            ctxt: Default::default(),
+            kind: swc_core::ecma::ast::VarDeclKind::Const,
+            declare: false,
+            decls: vec![VarDeclarator {
+                span: DUMMY_SP,
+                name: Pat::Ident(BindingIdent {
+                    id: ident(exported),
+                    type_ann: None,
+                }),
+                init: Some(value),
+                definite: false,
+            }],
+        })),
+    }))
+}
+
 enum ExportCall {
     Single { exported: Atom, value: Box<Expr> },
     Bulk(Vec<(Atom, Box<Expr>)>),
@@ -1269,19 +1313,26 @@ fn param_sym(function: &Function, idx: usize) -> Option<Atom> {
     pat_single_ident(&param.pat).cloned()
 }
 
-fn assign_ident_item(local: Atom, value: Box<Expr>) -> ModuleItem {
+fn assign_ident_item(target: BindingIdent, value: Box<Expr>) -> ModuleItem {
     ModuleItem::Stmt(Stmt::Expr(ExprStmt {
         span: DUMMY_SP,
         expr: Box::new(Expr::Assign(AssignExpr {
             span: DUMMY_SP,
             op: AssignOp::Assign,
-            left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
-                id: ident(local),
-                type_ann: None,
-            })),
+            left: AssignTarget::Simple(SimpleAssignTarget::Ident(target)),
             right: value,
         })),
     }))
+}
+
+fn var_declarator_item(var: &VarDecl, decl: VarDeclarator) -> ModuleItem {
+    ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+        span: var.span,
+        ctxt: var.ctxt,
+        kind: var.kind,
+        declare: var.declare,
+        decls: vec![decl],
+    }))))
 }
 
 fn strip_paren_expr(expr: &Expr) -> &Expr {

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -878,6 +878,237 @@ System.register("entry", [], function (_export) {
 }
 
 #[test]
+fn var_export_sequence_preserves_declarator_evaluation_order() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      var first = before(), middle = (_export("Named", during()), finish()), last = after();
+      use(first, middle, last);
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    let before = entry
+        .find("before()")
+        .unwrap_or_else(|| panic!("first declarator should survive:\n{entry}"));
+    let during = entry
+        .find("during()")
+        .unwrap_or_else(|| panic!("export value should survive:\n{entry}"));
+    let finish = entry
+        .find("finish()")
+        .unwrap_or_else(|| panic!("sequence result should survive:\n{entry}"));
+    let after = entry
+        .find("after()")
+        .unwrap_or_else(|| panic!("last declarator should survive:\n{entry}"));
+
+    assert!(
+        before < during && during < finish && finish < after,
+        "splitting a sequence initializer must preserve declarator evaluation order:\n{entry}"
+    );
+    for call in ["before()", "during()", "finish()", "after()"] {
+        assert_eq!(
+            entry.matches(call).count(),
+            1,
+            "{call} should be evaluated exactly once:\n{entry}"
+        );
+    }
+}
+
+#[test]
+fn assign_export_sequence_uses_last_identifier_value() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  var result, value;
+  return {
+    execute: function () {
+      result = (_export("First", first()), _export("Named", value));
+      use(result);
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("result = value;") && !entry.contains("result = Named;"),
+        "assignment must use the exported call's local value, not its public name:\n{entry}"
+    );
+    assert!(
+        exports_name(entry, "First") && exports_name(entry, "Named"),
+        "both exports should survive:\n{entry}"
+    );
+}
+
+#[test]
+fn assign_export_sequence_uses_last_assignment_value() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  var result, value;
+  return {
+    execute: function () {
+      result = (_export("First", first()), _export("Named", value = makeValue()));
+      use(result);
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    let first = entry
+        .find("first()")
+        .unwrap_or_else(|| panic!("prefix export should survive:\n{entry}"));
+    let value = entry
+        .find("value = makeValue();")
+        .unwrap_or_else(|| panic!("exported assignment should survive:\n{entry}"));
+    let result = entry
+        .find("result = value;")
+        .unwrap_or_else(|| panic!("outer assignment should use the assigned value:\n{entry}"));
+    let use_result = entry
+        .find("use(result);")
+        .unwrap_or_else(|| panic!("following use should survive:\n{entry}"));
+
+    assert!(
+        first < value && value < result && result < use_result,
+        "nested and outer assignments must preserve evaluation order:\n{entry}"
+    );
+    assert_eq!(
+        entry.matches("makeValue()").count(),
+        1,
+        "the assigned export value should be evaluated exactly once:\n{entry}"
+    );
+    assert!(
+        exports_name(entry, "First") && exports_name(entry, "Named"),
+        "both exports should survive:\n{entry}"
+    );
+}
+
+#[test]
+fn assign_export_sequence_default_value_is_evaluated_once() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  var result;
+  return {
+    execute: function () {
+      result = (_export("First", first()), _export("default", makeValue()));
+      use(result);
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert_eq!(
+        entry.matches("makeValue()").count(),
+        1,
+        "the default export and assignment must share one evaluated value:\n{entry}"
+    );
+    assert!(
+        entry.contains("export default") && !entry.contains("_export("),
+        "the default export should be reconstructed without leaking the runtime helper:\n{entry}"
+    );
+}
+
+#[test]
+fn assign_export_sequence_avoids_local_and_reserved_name_collisions() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  var Named, namedResult, reservedResult;
+  return {
+    execute: function () {
+      namedResult = (_export("First", first()), _export("Named", makeNamed()));
+      reservedResult = (_export("Second", second()), _export("class", makeReserved()));
+      use(namedResult, reservedResult);
+    }
+  };
+});
+"#;
+    let modules = unpack_source(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert_eq!(
+        validate_output_modules(&modules),
+        vec![],
+        "sequence exports must not introduce duplicate or reserved declarations:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const Named =") && !entry.contains("export const class ="),
+        "colliding and reserved export names should use local aliases:\n{entry}"
+    );
+    assert!(
+        exports_name(entry, "Named") && exports_name(entry, "class"),
+        "both public export names should survive through aliases:\n{entry}"
+    );
+}
+
+#[test]
+fn assign_export_sequence_prefix_avoids_local_and_reserved_name_collisions() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  var PrefixName, namedResult, reservedResult;
+  return {
+    execute: function () {
+      namedResult = (_export("PrefixName", makeNamed()), _export("NamedTail", namedTail()));
+      reservedResult = (_export("while", makeReserved()), _export("ReservedTail", reservedTail()));
+      use(namedResult, reservedResult);
+    }
+  };
+});
+"#;
+    let modules = unpack_source(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert_eq!(
+        validate_output_modules(&modules),
+        vec![],
+        "prefix sequence exports must not introduce duplicate or reserved declarations:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const PrefixName =") && !entry.contains("export const while ="),
+        "colliding and reserved prefix names should use local aliases:\n{entry}"
+    );
+    for name in ["PrefixName", "NamedTail", "while", "ReservedTail"] {
+        assert!(
+            exports_name(entry, name),
+            "public export {name} should survive through an alias:\n{entry}"
+        );
+    }
+}
+
+#[test]
+fn assign_export_sequence_prefix_rewrites_context_values() {
+    let source = r#"
+System.register("entry", [], function (_export, _context) {
+  var result;
+  return {
+    execute: function () {
+      result = (_export("Named", makeValue(
+        _context.import("./dep.js"),
+        _context.meta.url
+      )), finish());
+      use(result);
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains(r#"import("./dep.js")"#) && entry.contains("import.meta.url"),
+        "prefix export values should rewrite SystemJS context expressions:\n{entry}"
+    );
+    assert!(
+        !entry.contains("_context"),
+        "the SystemJS context binding must not leak from a sequence export:\n{entry}"
+    );
+}
+
+#[test]
 fn assign_export_sequence_trailing_iife_keeps_prefix_name() {
     let source = r#"
 System.register("entry", [], function (_export) {

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -753,3 +753,176 @@ System.register("entry", [], function (_export) {
         "nested IIFE replacement should remain parseable without leaking the helper:\n{entry}"
     );
 }
+
+fn exports_name(entry: &str, name: &str) -> bool {
+    entry.contains(&format!("export const {name}"))
+        || entry.contains(&format!("export let {name}"))
+        || entry.contains(&format!("export var {name}"))
+        || entry.contains(&format!("export function {name}"))
+        || entry.contains(&format!("export class {name}"))
+        || entry.contains(&format!("export {{ {name} }}"))
+        || entry.contains(&format!(" as {name}"))
+        || entry.contains(&format!("export {{ {name},"))
+        || entry.contains(&format!(", {name} }}"))
+        || entry.contains(&format!(", {name},"))
+}
+
+#[test]
+fn var_init_export_sequence_keeps_all_names() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      var last = (_export("Alpha", 1), _export("Beta", ["x"]), _export("Gamma", 2));
+      use(last);
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        exports_name(entry, "Alpha") && exports_name(entry, "Beta") && exports_name(entry, "Gamma"),
+        "all sequence export names must survive:\n{entry}"
+    );
+    assert!(
+        entry.contains("2") && entry.contains("last"),
+        "local should keep the last value:\n{entry}"
+    );
+}
+
+#[test]
+fn assign_export_sequence_literal_and_iife_keeps_names() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      h = (_export("Root", "ok"), _export("Widget", function () {
+        function Widget() {}
+        return Widget;
+      }()));
+    }
+  };
+});
+"#;
+    let raw_modules = unpack_source_raw(source);
+    let raw = module_code(&raw_modules, "entry.js");
+    assert!(
+        exports_name(raw, "Root") && exports_name(raw, "Widget"),
+        "literal + IIFE sequence export names must survive:\n{raw}"
+    );
+    assert!(
+        !raw.lines()
+            .any(|line| line.trim_start().starts_with("function (")),
+        "top-level anonymous function should not be emitted:\n{raw}"
+    );
+
+    let modules = unpack_source(source);
+    assert_eq!(
+        validate_output_modules(&modules),
+        vec![],
+        "decompiled sequence export should stay parseable:\n{}",
+        module_code(&modules, "entry.js")
+    );
+    let decompiled = module_code(&modules, "entry.js");
+    assert!(
+        exports_name(decompiled, "Root") && exports_name(decompiled, "Widget"),
+        "pipeline must keep sequence export names:\n{decompiled}"
+    );
+}
+
+#[test]
+fn assign_export_sequence_uninvoked_ctors_keeps_names() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      w = (_export("First", function (a, b) {
+        this.a = a;
+        this.b = b;
+      }), _export("Second", function (i) {
+        this.i = i;
+      }));
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        exports_name(entry, "First") && exports_name(entry, "Second"),
+        "uninvoked ctor sequence export names must survive:\n{entry}"
+    );
+}
+
+#[test]
+fn mixed_var_call_and_seq_export_keeps_names() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      var c = _export("one", "left"), h = (_export("two", "right"), _export("Box", function () {
+        function Box() {}
+        return Box;
+      }()));
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        exports_name(entry, "one") && exports_name(entry, "two") && exports_name(entry, "Box"),
+        "mixed Call + Seq declarators must keep all export names:\n{entry}"
+    );
+}
+
+#[test]
+fn assign_export_sequence_trailing_iife_keeps_prefix_name() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      last = (_export("Kind", function (e) {
+        return e[e.Left = 1] = "Left", e;
+      }({})), function (Base) {
+        function Derived() {
+          return Base.apply(this, arguments) || this;
+        }
+        return Derived;
+      }(Base));
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        exports_name(entry, "Kind"),
+        "prefix _export in a sequence must survive when the last item is a plain IIFE:\n{entry}"
+    );
+    assert!(
+        entry.contains("last") && (entry.contains("Derived") || entry.contains("Base.apply")),
+        "trailing IIFE should remain bound to the assign target:\n{entry}"
+    );
+}
+
+#[test]
+fn unrelated_comma_assign_is_not_an_export() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      var h = (1, 2, 3);
+      use(h);
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        !entry.contains("export"),
+        "plain comma values must not invent exports:\n{entry}"
+    );
+}


### PR DESCRIPTION
## Summary
- Reconstruct `h = (_export("A", v1), _export("B", v2))` and `var x = (_export(...), _export(...))` so every named export survives, not just the last value.
- Keep prefix export names when the last sequence item is not itself `_export`.
- For undeclared assignment targets, emit `export const Name = value` plus `h = Name` so the decompile pipeline does not drop `export { h as Name }`.
- Leave unrelated comma expressions alone; do not invent exports.
- Add `systemjs_unpack` regressions for var / assign / mixed / trailing-IIFE / negative cases.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack`

Related: follows #203 (member-assigned IIFE). This covers the remaining assignment / var-init `_export` sequence shape.