### PR TITLE
fix(systemjs): bind member-assignment exports to a free export name

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -316,8 +316,26 @@ fn emit_system_module(
     for stmt in &register.prelude {
         stmt.visit_with(&mut used_names);
     }
-    let mut transformer = SystemExecuteTransformer::new(export_sym, context_sym, used_names.names);
-    for stmt in outer_hoisted_stmts(body, &imported_locals) {
+    // Module-scope bindings only. `used_names` also contains nested IIFE idents,
+    // which must not block `export const Name` when Name is free at module scope.
+    let hoisted = outer_hoisted_stmts(body, &imported_locals);
+    let mut module_bound_names = imported_locals.clone();
+    for stmt in &register.prelude {
+        collect_top_level_decl_names(stmt, &mut module_bound_names);
+    }
+    for stmt in &hoisted {
+        collect_top_level_decl_names(stmt, &mut module_bound_names);
+    }
+    for stmt in &execute_body.stmts {
+        collect_top_level_decl_names(stmt, &mut module_bound_names);
+    }
+    let mut transformer = SystemExecuteTransformer::new(
+        export_sym,
+        context_sym,
+        used_names.names,
+        module_bound_names,
+    );
+    for stmt in hoisted {
         transformer.push_stmt(stmt, &mut items);
     }
 
@@ -415,6 +433,25 @@ fn outer_hoisted_stmts(body: &FunctionBody, imported_locals: &HashSet<Atom>) -> 
         }
     }
     out
+}
+
+fn collect_top_level_decl_names(stmt: &Stmt, names: &mut HashSet<Atom>) {
+    match stmt {
+        Stmt::Decl(Decl::Var(var)) => {
+            for decl in &var.decls {
+                if let Some(name) = pat_single_ident(&decl.name) {
+                    names.insert(name.clone());
+                }
+            }
+        }
+        Stmt::Decl(Decl::Fn(func)) => {
+            names.insert(func.ident.sym.clone());
+        }
+        Stmt::Decl(Decl::Class(class)) => {
+            names.insert(class.ident.sym.clone());
+        }
+        _ => {}
+    }
 }
 
 #[derive(Default)]
@@ -577,16 +614,23 @@ struct SystemExecuteTransformer {
     exports: Vec<ExportBinding>,
     declared_exports: HashSet<(Atom, Atom)>,
     used_names: HashSet<Atom>,
+    module_bound_names: HashSet<Atom>,
 }
 
 impl SystemExecuteTransformer {
-    fn new(export_sym: Atom, context_sym: Option<Atom>, used_names: HashSet<Atom>) -> Self {
+    fn new(
+        export_sym: Atom,
+        context_sym: Option<Atom>,
+        used_names: HashSet<Atom>,
+        module_bound_names: HashSet<Atom>,
+    ) -> Self {
         Self {
             export_sym,
             context_sym,
             exports: Vec::new(),
             declared_exports: HashSet::new(),
             used_names,
+            module_bound_names,
         }
     }
 
@@ -715,7 +759,7 @@ impl SystemExecuteTransformer {
         let exported_local = exported_value_local(value.as_ref());
         let local = exported_local
             .clone()
-            .unwrap_or_else(|| self.fresh_export_name());
+            .unwrap_or_else(|| self.bind_member_export_local(&exported, is_default));
 
         let mut assignment = assign.clone();
         let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &mut assignment.left else {
@@ -740,17 +784,22 @@ impl SystemExecuteTransformer {
                 Expr::Ident(_) => Vec::new(),
                 _ => unreachable!("exported_value_local accepted an unsupported expression"),
             }
+        } else if is_default {
+            // Initialize the export before computed keys or the assignment RHS can re-enter.
+            vec![
+                self.binding_item(local.clone(), value),
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(ExportDefaultExpr {
+                    span: DUMMY_SP,
+                    expr: Box::new(Expr::Ident(ident(local.clone()))),
+                })),
+            ]
+        } else if local.as_ref() == exported.as_ref() {
+            vec![self.export_const_item(local.clone(), value)]
         } else {
             let mut items = vec![self.binding_item(local.clone(), value)];
-            if is_default {
-                // Initialize the export before computed keys or the assignment RHS can re-enter.
-                items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
-                    ExportDefaultExpr {
-                        span: DUMMY_SP,
-                        expr: Box::new(Expr::Ident(ident(local.clone()))),
-                    },
-                )));
-            } else {
+            // Name already emitted as `export const` / named export: keep the
+            // second value on a synthetic local, do not repeat the specifier.
+            if !self.export_name_is_declared(&exported) {
                 self.declared_exports
                     .insert((local.clone(), exported.clone()));
                 items.push(named_export_item(local.clone(), exported));
@@ -759,6 +808,54 @@ impl SystemExecuteTransformer {
         };
         items.push(ModuleItem::Stmt(assignment_stmt));
         Some(items)
+    }
+
+    /// Bind a free, legal Identifier to the export name. Reserved words and
+    /// module-scope collisions keep the `__systemjs_export` alias path.
+    fn bind_member_export_local(&mut self, exported: &Atom, is_default: bool) -> Atom {
+        if !is_default && self.can_bind_export_name(exported) {
+            self.module_bound_names.insert(exported.clone());
+            self.used_names.insert(exported.clone());
+            exported.clone()
+        } else {
+            self.fresh_export_name()
+        }
+    }
+
+    fn can_bind_export_name(&self, exported: &Atom) -> bool {
+        Ident::verify_symbol(exported.as_ref()).is_ok()
+            && !self.module_bound_names.contains(exported)
+            && !self.export_name_is_declared(exported)
+    }
+
+    fn export_name_is_declared(&self, exported: &Atom) -> bool {
+        self.declared_exports
+            .iter()
+            .any(|(local, name)| local == exported || name == exported)
+    }
+
+    fn export_const_item(&mut self, name: Atom, value: Box<Expr>) -> ModuleItem {
+        self.declared_exports.insert((name.clone(), name.clone()));
+        self.module_bound_names.insert(name.clone());
+        self.used_names.insert(name.clone());
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+            span: DUMMY_SP,
+            decl: Decl::Var(Box::new(VarDecl {
+                span: DUMMY_SP,
+                ctxt: Default::default(),
+                kind: swc_core::ecma::ast::VarDeclKind::Const,
+                declare: false,
+                decls: vec![VarDeclarator {
+                    span: DUMMY_SP,
+                    name: Pat::Ident(BindingIdent {
+                        id: ident(name),
+                        type_ann: None,
+                    }),
+                    init: Some(value),
+                    definite: false,
+                }],
+            })),
+        }))
     }
 
     fn binding_item(&self, local: Atom, value: Box<Expr>) -> ModuleItem {
@@ -783,12 +880,14 @@ impl SystemExecuteTransformer {
     fn fresh_export_name(&mut self) -> Atom {
         let base = Atom::from("__systemjs_export");
         if self.used_names.insert(base.clone()) {
+            self.module_bound_names.insert(base.clone());
             return base;
         }
         let mut suffix = 2u32;
         loop {
             let candidate = Atom::from(format!("__systemjs_export_{suffix}"));
             if self.used_names.insert(candidate.clone()) {
+                self.module_bound_names.insert(candidate.clone());
                 return candidate;
             }
             suffix += 1;
@@ -819,9 +918,7 @@ impl SystemExecuteTransformer {
                     ))]);
                 }
                 if is_valid_ident_name(exported.as_ref()) {
-                    self.declared_exports
-                        .insert((exported.clone(), exported.clone()));
-                    return Some(vec![named_export_decl_item(exported, value)]);
+                    return Some(vec![self.export_const_item(exported, value)]);
                 }
                 None
             }

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -1,7 +1,9 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use swc_core::atoms::Atom;
-use swc_core::common::{sync::Lrc, SourceMap, Span, DUMMY_SP};
+use swc_core::common::{
+    sync::Lrc, Globals, Mark, SourceMap, Span, SyntaxContext, DUMMY_SP, GLOBALS,
+};
 use swc_core::ecma::ast::{
     ArrayLit, ArrowFunctionBody, AssignExpr, AssignOp, AssignTarget, BindingIdent, CallExpr,
     Callee, Decl, EsVersion, ExportDecl, ExportDefaultExpr, ExportNamedSpecifier, ExportSpecifier,
@@ -12,6 +14,7 @@ use swc_core::ecma::ast::{
     SimpleAssignTarget, Stmt, Str, UnaryOp, VarDecl, VarDeclarator,
 };
 use swc_core::ecma::codegen::{text_writer::JsWriter, Config, Emitter};
+use swc_core::ecma::transforms::base::resolver;
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use crate::js_names::is_reserved_binding_name;
@@ -316,25 +319,44 @@ fn emit_system_module(
     for stmt in &register.prelude {
         stmt.visit_with(&mut used_names);
     }
-    // Module-scope bindings only. `used_names` also contains nested IIFE idents,
-    // which must not block `export const Name` when Name is free at module scope.
     let hoisted = outer_hoisted_stmts(body, &imported_locals);
+    let mut lifted_stmts =
+        Vec::with_capacity(register.prelude.len() + hoisted.len() + execute_body.stmts.len());
+    lifted_stmts.extend(register.prelude.iter().cloned());
+    lifted_stmts.extend(hoisted.iter().cloned());
+    lifted_stmts.extend(execute_body.stmts.iter().cloned());
+
     let mut module_bound_names = imported_locals.clone();
-    for stmt in &register.prelude {
-        collect_top_level_decl_names(stmt, &mut module_bound_names);
-    }
-    for stmt in &hoisted {
-        collect_top_level_decl_names(stmt, &mut module_bound_names);
-    }
-    for stmt in &execute_body.stmts {
-        collect_top_level_decl_names(stmt, &mut module_bound_names);
-    }
+    collect_lifted_decl_names(&lifted_stmts, &mut module_bound_names);
+    let mutable_export_names =
+        collect_mutable_export_names(&lifted_stmts, &export_sym, &module_bound_names);
+    let mut direct_binding_candidates =
+        collect_member_export_binding_names(&lifted_stmts, &export_sym);
+    direct_binding_candidates.extend(mutable_export_names.iter().filter_map(|name| {
+        (name.as_ref() != "default"
+            && Ident::verify_symbol(name.as_ref()).is_ok()
+            && !is_reserved_binding_name(name.as_ref()))
+        .then_some(name.clone())
+    }));
+    let unresolved_analysis = if !direct_binding_candidates.is_empty()
+        && (direct_binding_candidates
+            .iter()
+            .any(|name| used_names.names.contains(name))
+            || used_names.names.iter().any(|name| name.as_ref() == "eval"))
+    {
+        analyze_unresolved_names(&lifted_stmts)
+    } else {
+        UnresolvedNameAnalysis::default()
+    };
     let mut transformer = SystemExecuteTransformer::new(
         export_sym,
         context_sym,
         used_names.names,
         module_bound_names,
+        unresolved_analysis.names,
+        unresolved_analysis.has_direct_eval,
     );
+    items.extend(transformer.prepare_mutable_exports(mutable_export_names));
     for stmt in hoisted {
         transformer.push_stmt(stmt, &mut items);
     }
@@ -435,22 +457,233 @@ fn outer_hoisted_stmts(body: &FunctionBody, imported_locals: &HashSet<Atom>) -> 
     out
 }
 
-fn collect_top_level_decl_names(stmt: &Stmt, names: &mut HashSet<Atom>) {
-    match stmt {
-        Stmt::Decl(Decl::Var(var)) => {
-            for decl in &var.decls {
-                if let Some(name) = pat_single_ident(&decl.name) {
-                    names.insert(name.clone());
-                }
+/// Collect bindings that will share the recovered module's top-level region.
+/// Nested function/class bodies keep their own scopes and are deliberately not
+/// traversed. Block-scoped declarations are conservatively included: choosing
+/// an alias is harmless, while missing a function-scoped `var` is not.
+fn collect_lifted_decl_names(stmts: &[Stmt], names: &mut HashSet<Atom>) {
+    let mut collector = LiftedDeclNameCollector { names };
+    for stmt in stmts {
+        stmt.visit_with(&mut collector);
+    }
+}
+
+struct LiftedDeclNameCollector<'a> {
+    names: &'a mut HashSet<Atom>,
+}
+
+impl Visit for LiftedDeclNameCollector<'_> {
+    fn visit_binding_ident(&mut self, binding: &BindingIdent) {
+        self.names.insert(binding.id.sym.clone());
+    }
+
+    fn visit_fn_decl(&mut self, function: &swc_core::ecma::ast::FnDecl) {
+        self.names.insert(function.ident.sym.clone());
+    }
+
+    fn visit_class_decl(&mut self, class: &swc_core::ecma::ast::ClassDecl) {
+        self.names.insert(class.ident.sym.clone());
+    }
+
+    fn visit_function(&mut self, _function: &Function) {}
+
+    fn visit_arrow_expr(&mut self, _arrow: &swc_core::ecma::ast::ArrowExpr) {}
+
+    fn visit_class(&mut self, _class: &swc_core::ecma::ast::Class) {}
+}
+
+/// Resolve a clone of the statements in the scope they will occupy after
+/// lifting. Any identifier still carrying `unresolved_mark` is a free/global
+/// read that a newly introduced module binding would capture.
+fn analyze_unresolved_names(stmts: &[Stmt]) -> UnresolvedNameAnalysis {
+    let globals = Globals::new();
+    GLOBALS.set(&globals, || {
+        let unresolved_mark = Mark::new();
+        let top_level_mark = Mark::new();
+        let probe_fn = Function {
+            params: Vec::new(),
+            decorators: Vec::new(),
+            span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
+            this_param: None,
+            body: Some(FunctionBody {
+                span: DUMMY_SP,
+                stmts: stmts.to_vec(),
+            }),
+            is_generator: false,
+            is_async: true,
+            type_params: None,
+            return_type: None,
+        };
+        let mut probe = Module {
+            span: DUMMY_SP,
+            body: vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                span: DUMMY_SP,
+                expr: Box::new(Expr::Fn(FnExpr {
+                    ident: None,
+                    function: Box::new(probe_fn),
+                })),
+            }))],
+            shebang: None,
+        };
+        probe.visit_mut_with(&mut resolver(unresolved_mark, top_level_mark, false));
+
+        let mut collector = UnresolvedNameCollector {
+            unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
+            names: HashSet::new(),
+            has_direct_eval: false,
+        };
+        probe.visit_with(&mut collector);
+        UnresolvedNameAnalysis {
+            names: collector.names,
+            has_direct_eval: collector.has_direct_eval,
+        }
+    })
+}
+
+#[derive(Default)]
+struct UnresolvedNameAnalysis {
+    names: HashSet<Atom>,
+    has_direct_eval: bool,
+}
+
+struct UnresolvedNameCollector {
+    unresolved_ctxt: SyntaxContext,
+    names: HashSet<Atom>,
+    has_direct_eval: bool,
+}
+
+impl Visit for UnresolvedNameCollector {
+    fn visit_ident(&mut self, ident: &Ident) {
+        if ident.ctxt == self.unresolved_ctxt {
+            self.names.insert(ident.sym.clone());
+        }
+    }
+
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if matches!(
+            &call.callee,
+            Callee::Expr(callee)
+                if matches!(
+                    callee.as_ref(),
+                    Expr::Ident(ident)
+                        if ident.sym.as_ref() == "eval" && ident.ctxt == self.unresolved_ctxt
+                )
+        ) {
+            self.has_direct_eval = true;
+        }
+        call.visit_children_with(self);
+    }
+}
+
+#[derive(Default)]
+struct ExportNameUse {
+    count: usize,
+    shared_local: Option<Atom>,
+    needs_mutable_binding: bool,
+}
+
+/// A repeated SystemJS export can reuse an existing ESM live binding only
+/// when every update is backed by the same module-scope local. Different,
+/// computed, or free values need one canonical mutable binding instead.
+fn collect_mutable_export_names(
+    stmts: &[Stmt],
+    export_sym: &Atom,
+    module_bound_names: &HashSet<Atom>,
+) -> Vec<Atom> {
+    let mut collector = ExportNameUseCollector {
+        export_sym,
+        uses: HashMap::new(),
+        order: Vec::new(),
+    };
+    for stmt in stmts {
+        stmt.visit_with(&mut collector);
+    }
+    collector
+        .order
+        .into_iter()
+        .filter(|name| {
+            collector.uses.get(name).is_some_and(|usage| {
+                usage.count > 1
+                    && (usage.needs_mutable_binding
+                        || !usage
+                            .shared_local
+                            .as_ref()
+                            .is_some_and(|local| module_bound_names.contains(local)))
+                    && (name.as_ref() == "default" || is_valid_ident_name(name.as_ref()))
+            })
+        })
+        .collect()
+}
+
+struct ExportNameUseCollector<'a> {
+    export_sym: &'a Atom,
+    uses: HashMap<Atom, ExportNameUse>,
+    order: Vec<Atom>,
+}
+
+impl Visit for ExportNameUseCollector<'_> {
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if let Some(ExportCall::Single { exported, value }) =
+            parse_export_call(call, self.export_sym)
+        {
+            let local = exported_value_local(value.as_ref());
+            let usage = self.uses.entry(exported.clone()).or_default();
+            if usage.count == 0 {
+                self.order.push(exported);
+                usage.needs_mutable_binding = local.is_none();
+                usage.shared_local = local;
+            } else if usage.shared_local.as_ref() != local.as_ref() {
+                usage.needs_mutable_binding = true;
             }
+            usage.count += 1;
         }
-        Stmt::Decl(Decl::Fn(func)) => {
-            names.insert(func.ident.sym.clone());
+        call.visit_children_with(self);
+    }
+}
+
+fn collect_member_export_binding_names(stmts: &[Stmt], export_sym: &Atom) -> HashSet<Atom> {
+    let mut collector = MemberExportBindingNameCollector {
+        export_sym,
+        names: HashSet::new(),
+    };
+    for stmt in stmts {
+        stmt.visit_with(&mut collector);
+    }
+    collector.names
+}
+
+struct MemberExportBindingNameCollector<'a> {
+    export_sym: &'a Atom,
+    names: HashSet<Atom>,
+}
+
+impl Visit for MemberExportBindingNameCollector<'_> {
+    fn visit_assign_expr(&mut self, assign: &AssignExpr) {
+        let exported = assign
+            .left
+            .as_simple()
+            .and_then(SimpleAssignTarget::as_member)
+            .and_then(|member| match member.obj.as_ref() {
+                Expr::Call(call) => Some(call),
+                _ => None,
+            })
+            .and_then(|call| parse_export_call(call, self.export_sym))
+            .and_then(|export_call| match export_call {
+                ExportCall::Single { exported, value }
+                    if exported.as_ref() != "default"
+                        && exported_value_local(value.as_ref()).is_none()
+                        && Ident::verify_symbol(exported.as_ref()).is_ok()
+                        && !is_reserved_binding_name(exported.as_ref()) =>
+                {
+                    Some(exported)
+                }
+                _ => None,
+            });
+        if let Some(exported) = exported {
+            self.names.insert(exported);
         }
-        Stmt::Decl(Decl::Class(class)) => {
-            names.insert(class.ident.sym.clone());
-        }
-        _ => {}
+        assign.visit_children_with(self);
     }
 }
 
@@ -608,6 +841,41 @@ fn setter_assignment_expr(expr: &Expr, module_sym: &Atom) -> Option<(Atom, Sette
     }
 }
 
+struct MutableExportRewriter<'a> {
+    export_sym: &'a Atom,
+    bindings: &'a HashMap<Atom, Atom>,
+}
+
+impl VisitMut for MutableExportRewriter<'_> {
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        let replacement = match expr {
+            Expr::Call(call) => parse_export_call(call, self.export_sym).and_then(|export_call| {
+                let ExportCall::Single {
+                    exported,
+                    mut value,
+                } = export_call
+                else {
+                    return None;
+                };
+                let local = self.bindings.get(&exported)?.clone();
+                value.visit_mut_with(self);
+                // `_export(name, value)` evaluates to `value`. The assignment
+                // has the same result; grouping keeps member/callee precedence.
+                Some(Expr::Paren(ParenExpr {
+                    span: DUMMY_SP,
+                    expr: Box::new(assign_local_expr(local, value)),
+                }))
+            }),
+            _ => None,
+        };
+        if let Some(replacement) = replacement {
+            *expr = replacement;
+            return;
+        }
+        expr.visit_mut_children_with(self);
+    }
+}
+
 struct SystemExecuteTransformer {
     export_sym: Atom,
     context_sym: Option<Atom>,
@@ -615,6 +883,9 @@ struct SystemExecuteTransformer {
     declared_exports: HashSet<(Atom, Atom)>,
     used_names: HashSet<Atom>,
     module_bound_names: HashSet<Atom>,
+    unresolved_names: HashSet<Atom>,
+    has_direct_eval: bool,
+    mutable_export_bindings: HashMap<Atom, Atom>,
 }
 
 impl SystemExecuteTransformer {
@@ -623,6 +894,8 @@ impl SystemExecuteTransformer {
         context_sym: Option<Atom>,
         used_names: HashSet<Atom>,
         module_bound_names: HashSet<Atom>,
+        unresolved_names: HashSet<Atom>,
+        has_direct_eval: bool,
     ) -> Self {
         Self {
             export_sym,
@@ -631,10 +904,48 @@ impl SystemExecuteTransformer {
             declared_exports: HashSet::new(),
             used_names,
             module_bound_names,
+            unresolved_names,
+            has_direct_eval,
+            mutable_export_bindings: HashMap::new(),
         }
     }
 
+    fn prepare_mutable_exports(&mut self, exported_names: Vec<Atom>) -> Vec<ModuleItem> {
+        let mut items = Vec::new();
+        for exported in exported_names {
+            let use_direct_binding =
+                exported.as_ref() != "default" && self.can_bind_export_name(&exported);
+            let local = if use_direct_binding {
+                self.module_bound_names.insert(exported.clone());
+                self.used_names.insert(exported.clone());
+                exported.clone()
+            } else {
+                self.fresh_export_name()
+            };
+
+            self.mutable_export_bindings
+                .insert(exported.clone(), local.clone());
+            self.declared_exports
+                .insert((local.clone(), exported.clone()));
+            // The declaration is side-effect free. Original `_export` call
+            // positions become assignments to this live binding in push_stmt.
+            if use_direct_binding {
+                items.push(export_let_item(local));
+            } else {
+                items.push(let_binding_item(local.clone()));
+                items.push(named_export_item(local, exported));
+            }
+        }
+        items
+    }
+
     fn push_stmt(&mut self, mut stmt: Stmt, items: &mut Vec<ModuleItem>) {
+        let mut mutable_export_rewriter = MutableExportRewriter {
+            export_sym: &self.export_sym,
+            bindings: &self.mutable_export_bindings,
+        };
+        stmt.visit_mut_with(&mut mutable_export_rewriter);
+
         if let Some(export_items) = self.take_export_stmt(&stmt) {
             items.extend(export_items);
             return;
@@ -824,14 +1135,21 @@ impl SystemExecuteTransformer {
 
     fn can_bind_export_name(&self, exported: &Atom) -> bool {
         Ident::verify_symbol(exported.as_ref()).is_ok()
+            && !is_reserved_binding_name(exported.as_ref())
             && !self.module_bound_names.contains(exported)
+            && !self.unresolved_names.contains(exported)
+            && !self.has_direct_eval
             && !self.export_name_is_declared(exported)
     }
 
     fn export_name_is_declared(&self, exported: &Atom) -> bool {
         self.declared_exports
             .iter()
-            .any(|(local, name)| local == exported || name == exported)
+            .any(|(_, name)| name == exported)
+            || self
+                .exports
+                .iter()
+                .any(|binding| &binding.exported == exported)
     }
 
     fn export_const_item(&mut self, name: Atom, value: Box<Expr>) -> ModuleItem {
@@ -1289,6 +1607,45 @@ fn named_export_item(local: Atom, exported: Atom) -> ModuleItem {
     }))
 }
 
+fn let_binding_item(local: Atom) -> ModuleItem {
+    ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+        span: DUMMY_SP,
+        ctxt: Default::default(),
+        kind: swc_core::ecma::ast::VarDeclKind::Let,
+        declare: false,
+        decls: vec![VarDeclarator {
+            span: DUMMY_SP,
+            name: Pat::Ident(BindingIdent {
+                id: ident(local),
+                type_ann: None,
+            }),
+            init: None,
+            definite: false,
+        }],
+    }))))
+}
+
+fn export_let_item(name: Atom) -> ModuleItem {
+    ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+        span: DUMMY_SP,
+        decl: Decl::Var(Box::new(VarDecl {
+            span: DUMMY_SP,
+            ctxt: Default::default(),
+            kind: swc_core::ecma::ast::VarDeclKind::Let,
+            declare: false,
+            decls: vec![VarDeclarator {
+                span: DUMMY_SP,
+                name: Pat::Ident(BindingIdent {
+                    id: ident(name),
+                    type_ann: None,
+                }),
+                init: None,
+                definite: false,
+            }],
+        })),
+    }))
+}
+
 fn named_export_decl_item(exported: Atom, value: Box<Expr>) -> ModuleItem {
     ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
         span: DUMMY_SP,
@@ -1420,6 +1777,18 @@ fn assign_ident_item(target: BindingIdent, value: Box<Expr>) -> ModuleItem {
             right: value,
         })),
     }))
+}
+
+fn assign_local_expr(local: Atom, value: Box<Expr>) -> Expr {
+    Expr::Assign(AssignExpr {
+        span: DUMMY_SP,
+        op: AssignOp::Assign,
+        left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+            id: ident(local),
+            type_ann: None,
+        })),
+        right: value,
+    })
 }
 
 fn var_declarator_item(var: &VarDecl, decl: VarDeclarator) -> ModuleItem {

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -328,15 +328,15 @@ fn emit_system_module(
 
     let mut module_bound_names = imported_locals.clone();
     collect_lifted_decl_names(&lifted_stmts, &mut module_bound_names);
-    let mutable_export_names =
-        collect_mutable_export_names(&lifted_stmts, &export_sym, &module_bound_names);
+    let export_name_usage =
+        collect_export_name_usage(&lifted_stmts, &export_sym, &module_bound_names);
+    let mutable_export_names = export_name_usage.mutable;
     let mut direct_binding_candidates =
         collect_member_export_binding_names(&lifted_stmts, &export_sym);
-    direct_binding_candidates.extend(mutable_export_names.iter().filter_map(|name| {
-        (name.as_ref() != "default"
+    direct_binding_candidates.extend(export_name_usage.seen.into_iter().filter(|name| {
+        name.as_ref() != "default"
             && Ident::verify_symbol(name.as_ref()).is_ok()
-            && !is_reserved_binding_name(name.as_ref()))
-        .then_some(name.clone())
+            && !is_reserved_binding_name(name.as_ref())
     }));
     let unresolved_analysis = if !direct_binding_candidates.is_empty()
         && (direct_binding_candidates
@@ -561,11 +561,13 @@ impl Visit for UnresolvedNameCollector {
     }
 
     fn visit_call_expr(&mut self, call: &CallExpr) {
+        // `(eval)(x)` is still a direct eval; only aliasing or optional
+        // calls make it indirect.
         if matches!(
             &call.callee,
             Callee::Expr(callee)
                 if matches!(
-                    callee.as_ref(),
+                    strip_paren_expr(callee),
                     Expr::Ident(ident)
                         if ident.sym.as_ref() == "eval" && ident.ctxt == self.unresolved_ctxt
                 )
@@ -583,14 +585,22 @@ struct ExportNameUse {
     needs_mutable_binding: bool,
 }
 
+struct ExportNameUsageSummary {
+    mutable: Vec<Atom>,
+    /// Every single-exported name in first-seen order. Each of these may
+    /// become a direct `export const <Name>` binding, so each is a
+    /// candidate for the free-name analysis.
+    seen: Vec<Atom>,
+}
+
 /// A repeated SystemJS export can reuse an existing ESM live binding only
 /// when every update is backed by the same module-scope local. Different,
 /// computed, or free values need one canonical mutable binding instead.
-fn collect_mutable_export_names(
+fn collect_export_name_usage(
     stmts: &[Stmt],
     export_sym: &Atom,
     module_bound_names: &HashSet<Atom>,
-) -> Vec<Atom> {
+) -> ExportNameUsageSummary {
     let mut collector = ExportNameUseCollector {
         export_sym,
         uses: HashMap::new(),
@@ -599,11 +609,11 @@ fn collect_mutable_export_names(
     for stmt in stmts {
         stmt.visit_with(&mut collector);
     }
-    collector
+    let mutable = collector
         .order
-        .into_iter()
+        .iter()
         .filter(|name| {
-            collector.uses.get(name).is_some_and(|usage| {
+            collector.uses.get(*name).is_some_and(|usage| {
                 usage.count > 1
                     && (usage.needs_mutable_binding
                         || !usage
@@ -613,7 +623,12 @@ fn collect_mutable_export_names(
                     && (name.as_ref() == "default" || is_valid_ident_name(name.as_ref()))
             })
         })
-        .collect()
+        .cloned()
+        .collect();
+    ExportNameUsageSummary {
+        mutable,
+        seen: collector.order,
+    }
 }
 
 struct ExportNameUseCollector<'a> {
@@ -1236,7 +1251,18 @@ impl SystemExecuteTransformer {
                     ))]);
                 }
                 if is_valid_ident_name(exported.as_ref()) {
-                    return Some(vec![self.export_const_item(exported, value)]);
+                    if self.can_bind_export_name(&exported) {
+                        return Some(vec![self.export_const_item(exported, value)]);
+                    }
+                    // Reserved, already taken, or observable elsewhere (free
+                    // reference or direct eval): keep the alias path.
+                    let local = self.fresh_export_name();
+                    self.declared_exports
+                        .insert((local.clone(), exported.clone()));
+                    return Some(vec![
+                        self.binding_item(local.clone(), value),
+                        named_export_item(local, exported),
+                    ]);
                 }
                 None
             }
@@ -1340,14 +1366,9 @@ impl SystemExecuteTransformer {
         if !is_default && !is_valid_ident_name(exported.as_ref()) {
             return None;
         }
-        let can_use_exported_name = !is_default
-            && !is_reserved_binding_name(exported.as_ref())
-            && self.used_names.insert(exported.clone());
-        if can_use_exported_name {
-            self.declared_exports
-                .insert((exported.clone(), exported.clone()));
+        if !is_default && self.can_bind_export_name(&exported) {
             let result = Box::new(Expr::Ident(ident(exported.clone())));
-            return Some((vec![named_export_decl_item(exported, value)], result));
+            return Some((vec![self.export_const_item(exported, value)], result));
         }
 
         let local = self.fresh_export_name();
@@ -1640,27 +1661,6 @@ fn export_let_item(name: Atom) -> ModuleItem {
                     type_ann: None,
                 }),
                 init: None,
-                definite: false,
-            }],
-        })),
-    }))
-}
-
-fn named_export_decl_item(exported: Atom, value: Box<Expr>) -> ModuleItem {
-    ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-        span: DUMMY_SP,
-        decl: Decl::Var(Box::new(VarDecl {
-            span: DUMMY_SP,
-            ctxt: Default::default(),
-            kind: swc_core::ecma::ast::VarDeclKind::Const,
-            declare: false,
-            decls: vec![VarDeclarator {
-                span: DUMMY_SP,
-                name: Pat::Ident(BindingIdent {
-                    id: ident(exported),
-                    type_ann: None,
-                }),
-                init: Some(value),
                 definite: false,
             }],
         })),

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -1423,3 +1423,134 @@ System.register("entry", [], function (_export) {
         "plain comma values must not invent exports:\n{entry}"
     );
 }
+
+#[test]
+fn statement_export_rejects_free_global_reference() {
+    // `observe(Widget)` reads a global; `export const Widget` would
+    // capture it. The alias path keeps the global read intact.
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    observe(Widget);
+    _export("Widget", make());
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export { __systemjs_export as Widget };"),
+        "captured name must export through an alias:\n{entry}"
+    );
+    assert!(
+        entry.contains("observe(Widget)"),
+        "the global read must stay untouched:\n{entry}"
+    );
+}
+
+#[test]
+fn statement_export_rejects_reserved_name_binding() {
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    _export("class", make());
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export { __systemjs_export as class };"),
+        "reserved export names must use an alias binding:\n{entry}"
+    );
+    assert!(
+        !entry.contains("const class"),
+        "must not declare a reserved-word binding:\n{entry}"
+    );
+}
+
+#[test]
+fn statement_export_rejects_existing_local_collision() {
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    var Widget = 1;
+    _export("Widget", make());
+    use(Widget);
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export { __systemjs_export as Widget };"),
+        "colliding name must export through an alias:\n{entry}"
+    );
+    assert!(
+        entry.contains("use(Widget)"),
+        "the existing local must keep its uses:\n{entry}"
+    );
+}
+
+#[test]
+fn statement_export_binds_free_name_directly() {
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    _export("Widget", make());
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export const Widget = make();"),
+        "a provably free name binds directly:\n{entry}"
+    );
+}
+
+#[test]
+fn parenthesized_direct_eval_blocks_direct_binding() {
+    // `(eval)(code)` is still a direct eval; the exported name must not
+    // become a module binding it could observe.
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    (eval)(code);
+    _export("Widget", make());
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export { __systemjs_export as Widget };"),
+        "direct eval must force the alias path:\n{entry}"
+    );
+}
+
+#[test]
+fn sequence_result_export_respects_freedom_proof() {
+    // The sequence path keeps `_export`'s return value; the name it binds
+    // must pass the same freedom proof as every other direct binding.
+    let source = r#"
+System.register([], function (_export, _context) {
+  var result;
+  return { setters: [], execute: function () {
+    eval("Widget");
+    result = (_export("Widget", make()), finish());
+    use(result);
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export { __systemjs_export as Widget };"),
+        "direct eval must force the alias path in sequences too:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const Widget"),
+        "must not bind a name a direct eval could observe:\n{entry}"
+    );
+}

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -419,25 +419,101 @@ System.register("entry", ["utils"], function (_export) {
     let modules = unpack_source_raw(source);
     let entry = module_code(&modules, "entry.js");
     let binding = entry
-        .find("const __systemjs_export =")
-        .unwrap_or_else(|| panic!("named export binding should be recovered:\n{entry}"));
-    let named_export = entry
-        .find("export { __systemjs_export as DerivedClass };")
-        .unwrap_or_else(|| panic!("named export alias should be recovered:\n{entry}"));
+        .find("export const DerivedClass =")
+        .unwrap_or_else(|| panic!("named IIFE should bind the export name directly:\n{entry}"));
     let member_assignment = entry
-        .find("__systemjs_export.marker = \"derived\";")
-        .unwrap_or_else(|| panic!("member assignment should be preserved:\n{entry}"));
+        .find("DerivedClass.marker = \"derived\";")
+        .unwrap_or_else(|| panic!("member assignment should use the export name:\n{entry}"));
     let after = entry
         .find("after();")
         .unwrap_or_else(|| panic!("sequence side effect should be preserved:\n{entry}"));
 
     assert!(
-        binding < named_export && named_export < member_assignment && member_assignment < after,
-        "binding, named export, member assignment, and sequence side effect should preserve order:\n{entry}"
+        binding < member_assignment && member_assignment < after,
+        "export binding, member assignment, and sequence side effect should preserve order:\n{entry}"
+    );
+    assert!(
+        !entry.contains("__systemjs_export"),
+        "free export name should not use a synthetic alias:\n{entry}"
     );
     assert!(
         !entry.lines().any(|line| line.starts_with("function (")),
         "top-level anonymous function should not be emitted:\n{entry}"
+    );
+}
+
+#[test]
+fn nested_inner_function_iife_member_export_uses_export_name() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("WidgetUtils", function () {
+        function Inner() {}
+        return Inner;
+      }()).tag = "WidgetUtils";
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("export const WidgetUtils =")
+            && entry.contains("WidgetUtils.tag = \"WidgetUtils\";"),
+        "nested IIFE member export should bind the export name directly:\n{entry}"
+    );
+    assert!(
+        !entry.contains("__systemjs_export"),
+        "free export name should not use a synthetic alias:\n{entry}"
+    );
+}
+
+#[test]
+fn member_export_does_not_redeclare_existing_export_const() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("HelperUtils", makeValue());
+      _export("HelperUtils", makeOther()).tag = "HelperUtils";
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert_eq!(
+        entry.matches("export const HelperUtils =").count(),
+        1,
+        "plain export should remain the only HelperUtils binding:\n{entry}"
+    );
+    assert!(
+        entry.contains("export const HelperUtils = makeValue();"),
+        "first export should keep the original value:\n{entry}"
+    );
+    assert!(
+        entry.contains("const __systemjs_export = makeOther();")
+            && entry.contains("__systemjs_export.tag = \"HelperUtils\";"),
+        "member export should evaluate the second value on a synthetic binding:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export { __systemjs_export as HelperUtils }"),
+        "already-declared export must not be repeated as an alias:\n{entry}"
+    );
+    assert_eq!(
+        entry.matches("makeValue()").count(),
+        1,
+        "makeValue should be evaluated once:\n{entry}"
+    );
+    assert_eq!(
+        entry.matches("makeOther()").count(),
+        1,
+        "makeOther should be evaluated once:\n{entry}"
     );
 }
 
@@ -701,21 +777,18 @@ System.register("entry", [], function (_export) {
     let modules = unpack_source_raw(source);
     let entry = module_code(&modules, "entry.js");
     let binding = entry
-        .find("const __systemjs_export = makeValue();")
-        .unwrap_or_else(|| panic!("VALUE binding should be recovered:\n{entry}"));
-    let named_export = entry
-        .find("export { __systemjs_export as DerivedClass };")
-        .unwrap_or_else(|| panic!("named export alias should be recovered:\n{entry}"));
+        .find("export const DerivedClass = makeValue();")
+        .unwrap_or_else(|| panic!("VALUE binding should use the export name:\n{entry}"));
     let assignment = entry
-        .find("__systemjs_export[getKey()] += rhs();")
-        .unwrap_or_else(|| panic!("computed assignment should be preserved:\n{entry}"));
+        .find("DerivedClass[getKey()] += rhs();")
+        .unwrap_or_else(|| panic!("computed assignment should use the export name:\n{entry}"));
     let rest = entry
         .find("after();")
         .unwrap_or_else(|| panic!("sequence rest should be preserved:\n{entry}"));
 
     assert!(
-        binding < named_export && named_export < assignment && assignment < rest,
-        "VALUE binding, named export, computed assignment, and sequence rest should preserve order:\n{entry}"
+        binding < assignment && assignment < rest,
+        "export binding, computed assignment, and sequence rest should preserve order:\n{entry}"
     );
     for call in ["makeValue()", "getKey()", "rhs()", "after()"] {
         assert_eq!(
@@ -725,8 +798,8 @@ System.register("entry", [], function (_export) {
         );
     }
     assert!(
-        entry.contains("__systemjs_export[getKey()] += rhs();"),
-        "assignment operator and computed member should be preserved:\n{entry}"
+        !entry.contains("__systemjs_export"),
+        "free export name should not use a synthetic alias:\n{entry}"
     );
 }
 

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -472,7 +472,7 @@ System.register("entry", [], function (_export) {
 }
 
 #[test]
-fn member_export_does_not_redeclare_existing_export_const() {
+fn repeated_member_export_updates_one_live_binding() {
     let source = r#"
 System.register("entry", [], function (_export) {
   return {
@@ -487,23 +487,17 @@ System.register("entry", [], function (_export) {
     let modules = unpack_source_raw(source);
     let entry = module_code(&modules, "entry.js");
 
-    assert_eq!(
-        entry.matches("export const HelperUtils =").count(),
-        1,
-        "plain export should remain the only HelperUtils binding:\n{entry}"
+    assert!(
+        entry.contains("export let HelperUtils;") && entry.contains("HelperUtils = makeValue()"),
+        "the first value should initialize one mutable live export:\n{entry}"
     );
     assert!(
-        entry.contains("export const HelperUtils = makeValue();"),
-        "first export should keep the original value:\n{entry}"
+        entry.contains("(HelperUtils = makeOther()).tag = \"HelperUtils\";"),
+        "the member export should update that same live binding before mutation:\n{entry}"
     );
     assert!(
-        entry.contains("const __systemjs_export = makeOther();")
-            && entry.contains("__systemjs_export.tag = \"HelperUtils\";"),
-        "member export should evaluate the second value on a synthetic binding:\n{entry}"
-    );
-    assert!(
-        !entry.contains("export { __systemjs_export as HelperUtils }"),
-        "already-declared export must not be repeated as an alias:\n{entry}"
+        !entry.contains("export const HelperUtils =") && !entry.contains("__systemjs_export"),
+        "a repeated public name must not leave the export on a stale value:\n{entry}"
     );
     assert_eq!(
         entry.matches("makeValue()").count(),
@@ -514,6 +508,138 @@ System.register("entry", [], function (_export) {
         entry.matches("makeOther()").count(),
         1,
         "makeOther should be evaluated once:\n{entry}"
+    );
+    assert_eq!(
+        validate_output_modules(&modules),
+        vec![],
+        "the reconstructed live export should remain parseable:\n{entry}"
+    );
+}
+
+#[test]
+fn member_export_does_not_capture_a_free_reference() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("Widget", function () {
+        return Widget;
+      }()).ready = true;
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("export { __systemjs_export as Widget };")
+            && entry.contains("return Widget;")
+            && entry.contains("__systemjs_export.ready = true;"),
+        "a free Widget read must keep resolving outside the recovered module binding:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const Widget ="),
+        "binding Widget around its own initializer would introduce a TDZ capture:\n{entry}"
+    );
+}
+
+#[test]
+fn member_export_does_not_change_direct_eval_scope() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("Widget", function () {
+        return eval("Widget");
+      }()).ready = true;
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("export { __systemjs_export as Widget };")
+            && entry.contains("return eval(\"Widget\");"),
+        "a direct eval must not see a newly introduced Widget binding:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const Widget ="),
+        "direct eval makes otherwise-free export names capture-sensitive:\n{entry}"
+    );
+}
+
+#[test]
+fn member_export_avoids_lifted_binding_collisions() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      const { Widget } = source;
+      for (var Gadget of gadgets) {
+        consume(Gadget);
+      }
+      _export("Widget", makeValue()).ready = true;
+      _export("Gadget", makeGadget()).ready = true;
+      consume(Widget);
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("const { Widget } = source;")
+            && entry.contains("export { __systemjs_export as Widget };")
+            && entry.contains("__systemjs_export.ready = true;")
+            && entry.contains("export { __systemjs_export_2 as Gadget };")
+            && entry.contains("__systemjs_export_2.ready = true;"),
+        "destructured and nested var bindings should force collision-free export aliases:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const Widget =") && !entry.contains("export const Gadget ="),
+        "recovered exports must not redeclare lifted bindings:\n{entry}"
+    );
+    assert_eq!(
+        validate_output_modules(&modules),
+        vec![],
+        "the destructuring collision fallback should remain parseable:\n{entry}"
+    );
+}
+
+#[test]
+fn generated_local_name_does_not_hide_same_named_public_export() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  var X;
+  return {
+    execute: function () {
+      _export("X", makeFirst()).a = 1;
+      _export("__systemjs_export", makeSecond()).b = 2;
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("export { __systemjs_export as X };")
+            && entry.contains("export { __systemjs_export_2 as __systemjs_export };")
+            && entry.contains("__systemjs_export_2.b = 2;"),
+        "local aliases and public export names must use separate namespaces:\n{entry}"
+    );
+    assert_eq!(
+        validate_output_modules(&modules),
+        vec![],
+        "both public exports should remain parseable:\n{entry}"
     );
 }
 
@@ -701,7 +827,7 @@ fn default_iife_member_export_avoids_module_prelude_names() {
 }
 
 #[test]
-fn direct_declaration_export_is_not_repeated_in_trailing_export_list() {
+fn repeated_exports_with_different_values_share_one_live_binding() {
     let source = r#"
 System.register("entry", [], function (_export) {
   return {
@@ -716,19 +842,86 @@ System.register("entry", [], function (_export) {
     let modules = unpack_source_raw(source);
     let entry = module_code(&modules, "entry.js");
 
-    assert_eq!(
-        entry.matches("export const Utils =").count(),
-        1,
-        "Utils should have exactly one export declaration:\n{entry}"
-    );
     assert!(
-        !entry.contains("export { Utils"),
-        "trailing named export list must not repeat Utils:\n{entry}"
+        entry.contains("let __systemjs_export;")
+            && entry.contains("export { __systemjs_export as Utils };")
+            && entry.contains("__systemjs_export = makeUtils()")
+            && entry.contains("__systemjs_export = Utils"),
+        "different values should update one mutable public export without capturing global Utils:\n{entry}"
     );
     assert_eq!(
         entry.matches("export {").count(),
-        0,
-        "fully filtered trailing exports must not emit an empty export declaration:\n{entry}"
+        1,
+        "Utils should have exactly one ESM export specifier:\n{entry}"
+    );
+    assert_eq!(
+        validate_output_modules(&modules),
+        vec![],
+        "the mutable alias path should remain parseable:\n{entry}"
+    );
+}
+
+#[test]
+fn repeated_exports_of_free_value_get_a_declared_live_binding() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("Value", external);
+      _export("Value", external);
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("export let Value;")
+            && entry.matches("Value = external").count() == 2
+            && !entry.contains("export { external as Value }"),
+        "a free value cannot serve as an ESM local export binding:\n{entry}"
+    );
+    assert_eq!(
+        validate_output_modules(&modules),
+        vec![],
+        "the synthesized live binding should remain parseable:\n{entry}"
+    );
+}
+
+#[test]
+fn repeated_default_member_exports_share_one_live_binding() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("default", makeFirst()).a = 1;
+      _export("default", makeSecond()).b = 2;
+    }
+  };
+});
+"#;
+
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+
+    assert!(
+        entry.contains("let __systemjs_export;")
+            && entry.contains("export { __systemjs_export as default };")
+            && entry.contains("(__systemjs_export = makeFirst()).a = 1;")
+            && entry.contains("(__systemjs_export = makeSecond()).b = 2;"),
+        "default updates should share one mutable live export:\n{entry}"
+    );
+    assert_eq!(
+        entry.matches(" as default").count(),
+        1,
+        "default should be exported exactly once:\n{entry}"
+    );
+    assert_eq!(
+        validate_output_modules(&modules),
+        vec![],
+        "the live default export should remain parseable:\n{entry}"
     );
 }
 


### PR DESCRIPTION
## Summary
- After #203, `_export("Name", IIFE()).prop =` is reconstructed, but a free legal `Name` still becomes `const __systemjs_export` plus `export { __systemjs_export as Name }`.
- When `Name` is a free Identifier (not reserved, not module-bound, not already a declared export), emit `export const Name = IIFE; Name.prop = …`.
- Keep the alias path for reserved words, outer/import collisions, `default`, and a later member `_export` of the same public name (reuse the live binding; do not emit a second `export { as Name }`).
- Add `systemjs_unpack` regressions for named IIFE, reserved/collision aliases, and the same-name follow-up member export.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack`

Related: leftover from #203 (member-assigned IIFE). Independent of #207 (assignment / var-init `_export` sequences).