### PR TITLE
fix(systemjs): parenthesize function-callee IIFEs on every export emit path

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -1295,7 +1295,7 @@ impl SystemExecuteTransformer {
                         id: ident(name),
                         type_ann: None,
                     }),
-                    init: Some(value),
+                    init: Some(emit_exported_value(value)),
                     definite: false,
                 }],
             })),
@@ -1314,7 +1314,7 @@ impl SystemExecuteTransformer {
                     id: ident(local),
                     type_ann: None,
                 }),
-                init: Some(value),
+                init: Some(emit_exported_value(value)),
                 definite: false,
             }],
         }));
@@ -1354,10 +1354,12 @@ impl SystemExecuteTransformer {
                     return Some(Vec::new());
                 }
                 if exported.as_ref() == "default" {
+                    // Function-callee IIFEs must stay expressions. Bare
+                    // `export default function () {}()` is a SyntaxError.
                     return Some(vec![ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
                         ExportDefaultExpr {
                             span: DUMMY_SP,
-                            expr: value,
+                            expr: emit_exported_value(value),
                         },
                     ))]);
                 }
@@ -1559,7 +1561,7 @@ impl SystemExecuteTransformer {
                             VarDeclarator {
                                 span: decl.span,
                                 name: decl.name.clone(),
-                                init: Some(value),
+                                init: Some(emit_exported_value(value)),
                                 definite: decl.definite,
                             },
                         ));
@@ -1897,6 +1899,10 @@ fn exported_value_local(expr: &Expr) -> Option<Atom> {
         Expr::Assign(assign) => assign.left.as_simple()?.as_ident().map(|id| id.sym.clone()),
         _ => None,
     }
+}
+
+fn emit_exported_value(value: Box<Expr>) -> Box<Expr> {
+    Box::new(export_replacement_expr(value))
 }
 
 fn export_replacement_expr(value: Box<Expr>) -> Expr {

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -10,8 +10,8 @@ use swc_core::ecma::ast::{
     Expr, ExprOrSpread, ExprStmt, FnExpr, Function, FunctionBody, Ident, ImportDecl,
     ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier, ImportStarAsSpecifier, Lit,
     MemberExpr, MemberProp, MetaPropExpr, MetaPropKind, Module, ModuleDecl, ModuleExportName,
-    ModuleItem, NamedExport, ObjectLit, ParenExpr, Pat, Prop, PropName, PropOrSpread, ReturnStmt,
-    SimpleAssignTarget, Stmt, Str, UnaryOp, VarDecl, VarDeclarator,
+    ModuleItem, NamedExport, ObjectLit, OptChainBase, ParenExpr, Pat, Prop, PropName, PropOrSpread,
+    ReturnStmt, SimpleAssignTarget, Stmt, Str, UnaryOp, VarDecl, VarDeclarator,
 };
 use swc_core::ecma::codegen::{text_writer::JsWriter, Config, Emitter};
 use swc_core::ecma::transforms::base::resolver;
@@ -1354,6 +1354,21 @@ impl SystemExecuteTransformer {
                     return Some(Vec::new());
                 }
                 if exported.as_ref() == "default" {
+                    if default_export_needs_binding(value.as_ref()) {
+                        // SWC's fixer can remove the only parens that distinguish
+                        // these values from a default function/class declaration.
+                        // A local initializer is unambiguously expression context.
+                        let local = self.fresh_export_name();
+                        return Some(vec![
+                            self.binding_item(local.clone(), value),
+                            ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
+                                ExportDefaultExpr {
+                                    span: DUMMY_SP,
+                                    expr: Box::new(Expr::Ident(ident(local))),
+                                },
+                            )),
+                        ]);
+                    }
                     // Function-callee IIFEs must stay expressions. Bare
                     // `export default function () {}()` is a SyntaxError.
                     return Some(vec![ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
@@ -1903,6 +1918,45 @@ fn exported_value_local(expr: &Expr) -> Option<Atom> {
 
 fn emit_exported_value(value: Box<Expr>) -> Box<Expr> {
     Box::new(export_replacement_expr(value))
+}
+
+fn default_export_needs_binding(value: &Expr) -> bool {
+    let value = strip_paren_expr(value);
+    match value {
+        // Reprinting these as declarations would hoist their names into module
+        // scope instead of keeping the names local to the expressions.
+        Expr::Fn(function) => function.ident.is_some(),
+        Expr::Class(class) => class.ident.is_some(),
+        // The direct IIFE case is safely handled by emit_exported_value. Once
+        // another operation is appended, SWC can discard the outer parens.
+        _ => starts_with_function_or_class(value) && !is_function_callee_iife(value),
+    }
+}
+
+fn starts_with_function_or_class(expr: &Expr) -> bool {
+    match expr {
+        Expr::Fn(_) | Expr::Class(_) => true,
+        Expr::Bin(binary) => starts_with_function_or_class(binary.left.as_ref()),
+        Expr::Call(call) => matches!(
+            &call.callee,
+            Callee::Expr(callee) if starts_with_function_or_class(callee.as_ref())
+        ),
+        Expr::Member(member) => starts_with_function_or_class(member.obj.as_ref()),
+        Expr::Cond(condition) => starts_with_function_or_class(condition.test.as_ref()),
+        Expr::TaggedTpl(tagged) => starts_with_function_or_class(tagged.tag.as_ref()),
+        Expr::Paren(paren) => starts_with_function_or_class(paren.expr.as_ref()),
+        Expr::OptChain(chain) => match chain.base.as_ref() {
+            OptChainBase::Member(member) => starts_with_function_or_class(member.obj.as_ref()),
+            OptChainBase::Call(call) => starts_with_function_or_class(call.callee.as_ref()),
+        },
+        Expr::TsAs(as_expr) => starts_with_function_or_class(as_expr.expr.as_ref()),
+        Expr::TsNonNull(non_null) => starts_with_function_or_class(non_null.expr.as_ref()),
+        Expr::TsInstantiation(instantiation) => {
+            starts_with_function_or_class(instantiation.expr.as_ref())
+        }
+        Expr::TsSatisfies(satisfies) => starts_with_function_or_class(satisfies.expr.as_ref()),
+        _ => false,
+    }
 }
 
 fn export_replacement_expr(value: Box<Expr>) -> Expr {

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -2082,3 +2082,110 @@ System.register(["./dep.js"], function (_export, _context) {
         );
     }
 }
+
+#[test]
+fn default_iife_export_is_parenthesized() {
+    // `_export("default", function () {}())` must stay an expression. Without
+    // parens, codegen prints `export default function () {}()`, which is a
+    // SyntaxError (function declaration + call).
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    _export("default", function () {
+      function Util() {}
+      Util.ready = true;
+      return Util;
+    }());
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export default ("),
+        "default IIFE must be parenthesized:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export default function"),
+        "must not print a default function declaration that is immediately called:\n{entry}"
+    );
+}
+
+#[test]
+fn named_iife_export_init_is_parenthesized() {
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    _export("Util", function () {
+      function Util() {}
+      return Util;
+    }());
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    // `const X = function () {}()` is already a Call of a function
+    // expression; codegen may drop redundant parens. The hole is default
+    // exports, which parse as a declaration.
+    assert!(
+        entry.contains("export const Util ="),
+        "named IIFE must bind the export:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export default function"),
+        "named IIFE must not fall through to a default function declaration:\n{entry}"
+    );
+}
+
+#[test]
+fn named_default_function_declaration_is_not_parenthesized() {
+    // A default function *declaration* is already legal. Wrapping it would
+    // change `export default function Named()` into an expression.
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    _export("default", function Named() {
+      return 1;
+    });
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export default function Named") || entry.contains("function Named()"),
+        "named default function should stay a declaration or equivalent binding:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export default (function Named"),
+        "must not wrap a non-IIFE default function declaration:\n{entry}"
+    );
+}
+
+#[test]
+fn leftover_statement_iife_after_export_is_parenthesized() {
+    // Side-effect IIFE left after a named export must stay an expression
+    // statement: `function () {}()` is illegal at statement position.
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    _export("sdk", getInstance());
+    (function () {
+      globalThis.__SDK_STORE = globalThis.__SDK_STORE || {};
+    })();
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export const sdk = getInstance();")
+            || (entry.contains("export {") && entry.contains("sdk")),
+        "named export should survive:\n{entry}"
+    );
+    assert!(
+        !entry.contains("\nfunction ()") && !entry.contains("\nfunction()"),
+        "leftover IIFE must not print as a function declaration:\n{entry}"
+    );
+}

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -2115,6 +2115,43 @@ System.register([], function (_export, _context) {
 }
 
 #[test]
+fn default_iife_member_value_keeps_expression_context() {
+    // Babel 7/8 removes the source parens in `_export`'s argument because the
+    // argument is already an expression context. Keep the complete value in
+    // an initializer so a member suffix cannot expose a declaration-like head.
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    _export("default", function () {
+      return { value: 1 };
+    }().value);
+  } };
+});
+"#;
+
+    for (label, modules) in [
+        ("raw", unpack_source_raw(source)),
+        ("decompiled", unpack_source(source)),
+    ] {
+        let entry = module_code(&modules, "entry.js");
+        assert_eq!(
+            validate_output_modules(&modules),
+            vec![],
+            "{label} output must remain parseable:\n{entry}"
+        );
+        assert!(
+            entry.contains("const __systemjs_export =")
+                && entry.contains("export default __systemjs_export;"),
+            "{label} output must evaluate the member value in an initializer:\n{entry}"
+        );
+        assert!(
+            !entry.contains("export default function"),
+            "{label} output must not reinterpret the IIFE as a declaration:\n{entry}"
+        );
+    }
+}
+
+#[test]
 fn named_iife_export_binds_const_not_default_declaration() {
     // Named IIFE goes through `export const` (expression context). Parens are
     // required only for `export default`; codegen may drop them on const init.
@@ -2145,28 +2182,78 @@ System.register([], function (_export, _context) {
 }
 
 #[test]
-fn named_default_function_declaration_is_not_parenthesized() {
-    // A default function *declaration* is already legal. Wrapping it would
-    // change `export default function Named()` into an expression.
+fn named_default_function_expression_stays_local() {
+    // Babel 7/8 emits this shape from `export default (function Named() {})`.
+    // The name belongs only to the function expression; emitting a declaration
+    // would introduce and hoist a new module-scope `Named` binding.
     let source = r#"
 System.register([], function (_export, _context) {
   return { setters: [], execute: function () {
+    observe(typeof Named);
+    observe(eval("typeof Named"));
     _export("default", function Named() {
       return 1;
     });
   } };
 });
 "#;
-    let raw = unpack_source_raw(source);
-    let entry = module_code(&raw, "entry.js");
-    assert!(
-        entry.contains("export default function Named") || entry.contains("function Named()"),
-        "named default function should stay a declaration or equivalent binding:\n{entry}"
-    );
-    assert!(
-        !entry.contains("export default (function Named"),
-        "must not wrap a non-IIFE default function declaration:\n{entry}"
-    );
+
+    for (label, modules) in [
+        ("raw", unpack_source_raw(source)),
+        ("decompiled", unpack_source(source)),
+    ] {
+        let entry = module_code(&modules, "entry.js");
+        assert_eq!(
+            validate_output_modules(&modules),
+            vec![],
+            "{label} output must remain parseable:\n{entry}"
+        );
+        assert!(
+            entry.contains("const __systemjs_export = function Named")
+                && entry.contains("export default __systemjs_export;"),
+            "{label} output must keep the named function in an initializer:\n{entry}"
+        );
+        assert!(
+            !entry.contains("export default function Named"),
+            "{label} output must not hoist the expression name into module scope:\n{entry}"
+        );
+    }
+}
+
+#[test]
+fn named_default_class_expression_stays_local() {
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    observe(typeof Named);
+    observe(eval("typeof Named"));
+    _export("default", class Named {
+      static value = 1;
+    });
+  } };
+});
+"#;
+
+    for (label, modules) in [
+        ("raw", unpack_source_raw(source)),
+        ("decompiled", unpack_source(source)),
+    ] {
+        let entry = module_code(&modules, "entry.js");
+        assert_eq!(
+            validate_output_modules(&modules),
+            vec![],
+            "{label} output must remain parseable:\n{entry}"
+        );
+        assert!(
+            entry.contains("const __systemjs_export = class Named")
+                && entry.contains("export default __systemjs_export;"),
+            "{label} output must keep the named class in an initializer:\n{entry}"
+        );
+        assert!(
+            !entry.contains("export default class Named"),
+            "{label} output must not hoist the expression name into module scope:\n{entry}"
+        );
+    }
 }
 
 #[test]

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -791,9 +791,12 @@ System.register("entry", [], function (_export) {
         1,
         "default export value should be evaluated once:\n{entry}"
     );
+    // Member-assigned `_export("default", IIFE).prop =` must bind once and
+    // `export default` that binding. `export default (` is the bare default
+    // IIFE path (`default_iife_export_is_parenthesized`), not this shape.
     assert!(
         !entry.contains("export default function") && !entry.contains("export default ("),
-        "default export must not apply the member assignment to the IIFE result:\n{entry}"
+        "member-assigned default must export the binding, not the IIFE:\n{entry}"
     );
 }
 
@@ -2112,7 +2115,9 @@ System.register([], function (_export, _context) {
 }
 
 #[test]
-fn named_iife_export_init_is_parenthesized() {
+fn named_iife_export_binds_const_not_default_declaration() {
+    // Named IIFE goes through `export const` (expression context). Parens are
+    // required only for `export default`; codegen may drop them on const init.
     let source = r#"
 System.register([], function (_export, _context) {
   return { setters: [], execute: function () {
@@ -2125,12 +2130,13 @@ System.register([], function (_export, _context) {
 "#;
     let raw = unpack_source_raw(source);
     let entry = module_code(&raw, "entry.js");
-    // `const X = function () {}()` is already a Call of a function
-    // expression; codegen may drop redundant parens. The hole is default
-    // exports, which parse as a declaration.
     assert!(
         entry.contains("export const Util ="),
         "named IIFE must bind the export:\n{entry}"
+    );
+    assert!(
+        entry.contains("= function") || entry.contains("= (function"),
+        "named IIFE must stay a function expression:\n{entry}"
     );
     assert!(
         !entry.contains("export default function"),
@@ -2164,28 +2170,50 @@ System.register([], function (_export, _context) {
 }
 
 #[test]
-fn leftover_statement_iife_after_export_is_parenthesized() {
-    // Side-effect IIFE left after a named export must stay an expression
-    // statement: `function () {}()` is illegal at statement position.
+fn named_iife_export_respects_direct_eval_freedom_proof() {
+    // Parenthesizing the IIFE must not bypass the #208 freedom proof.
     let source = r#"
 System.register([], function (_export, _context) {
   return { setters: [], execute: function () {
-    _export("sdk", getInstance());
-    (function () {
-      globalThis.__SDK_STORE = globalThis.__SDK_STORE || {};
-    })();
+    eval("Util");
+    _export("Util", function () {
+      function Util() {}
+      return Util;
+    }());
   } };
 });
 "#;
     let raw = unpack_source_raw(source);
     let entry = module_code(&raw, "entry.js");
     assert!(
-        entry.contains("export const sdk = getInstance();")
-            || (entry.contains("export {") && entry.contains("sdk")),
-        "named export should survive:\n{entry}"
+        entry.contains("export { __systemjs_export as Util }"),
+        "direct eval must force the alias path:\n{entry}"
     );
     assert!(
-        !entry.contains("\nfunction ()") && !entry.contains("\nfunction()"),
-        "leftover IIFE must not print as a function declaration:\n{entry}"
+        !entry.contains("export const Util"),
+        "must not bind a name a direct eval could observe:\n{entry}"
+    );
+}
+
+#[test]
+fn named_iife_export_rejects_reserved_name_binding() {
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    _export("class", function () {
+      return 1;
+    }());
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export { __systemjs_export as class }"),
+        "reserved export names must stay on the alias path:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const class"),
+        "must not emit a reserved binding:\n{entry}"
     );
 }


### PR DESCRIPTION
## Summary
- `_export("default", function () {}())` was emitted as `ExportDefaultExpr` without going through `export_replacement_expr`. Codegen prints `export default function () {}()`, which is a SyntaxError (function declaration + call).
- Route every exported value through `emit_exported_value` → the existing `export_replacement_expr` helper (`export_const_item`, alias `binding_item`, default `export_call_items`, var-seq init). `visit_mut_expr` already used that helper.
- Named `export default function Named()` is not wrapped. Parenthesizing the IIFE does not bypass `#208` name-freedom (`eval`, reserved words stay on `__systemjs_export`).

Related: leftover emit hole after #203. Independent of #207 / #208 binding proofs.

Please feel free to take it from here if that is easier. Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
System.register([], function (_export) {
  return { setters: [], execute: function () {
    _export("default", function () { return 1; }());
  } };
});
```

`wakaru --unpack` printed `export default function(){}()` (SyntaxError). After this change: `export default (function () { return 1; }())`.

Covered by `default_iife_export_is_parenthesized`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack`
