### PR TITLE
fix(systemjs): emit exports from assignment and expression `_export` literals

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -901,6 +901,8 @@ struct SystemExecuteTransformer {
     unresolved_names: HashSet<Atom>,
     has_direct_eval: bool,
     mutable_export_bindings: HashMap<Atom, Atom>,
+    /// Exports hoisted out of expression-position `_export` calls.
+    pending_expr_exports: Vec<ModuleItem>,
 }
 
 impl SystemExecuteTransformer {
@@ -922,6 +924,7 @@ impl SystemExecuteTransformer {
             unresolved_names,
             has_direct_eval,
             mutable_export_bindings: HashMap::new(),
+            pending_expr_exports: Vec::new(),
         }
     }
 
@@ -963,6 +966,7 @@ impl SystemExecuteTransformer {
 
         if let Some(export_items) = self.take_export_stmt(&stmt) {
             items.extend(export_items);
+            items.extend(self.take_pending_expr_exports());
             return;
         }
 
@@ -979,7 +983,12 @@ impl SystemExecuteTransformer {
         }
 
         stmt.visit_mut_with(self);
+        items.extend(self.take_pending_expr_exports());
         items.push(ModuleItem::Stmt(stmt));
+    }
+
+    fn take_pending_expr_exports(&mut self) -> Vec<ModuleItem> {
+        std::mem::take(&mut self.pending_expr_exports)
     }
 
     fn export_items(self) -> Vec<ModuleItem> {
@@ -1034,7 +1043,7 @@ impl SystemExecuteTransformer {
             }
             Expr::Assign(assign) => self
                 .export_member_assignment_items(assign)
-                .or_else(|| self.take_ident_assign_export_seq(assign)),
+                .or_else(|| self.take_ident_assign_export(assign)),
             Expr::Seq(seq) => {
                 let mut items = Vec::new();
                 let mut saw_export = false;
@@ -1044,7 +1053,7 @@ impl SystemExecuteTransformer {
                             .and_then(|export_call| self.export_call_items(export_call)),
                         Expr::Assign(assign) => self
                             .export_member_assignment_items(assign)
-                            .or_else(|| self.take_ident_assign_export_seq(assign)),
+                            .or_else(|| self.take_ident_assign_export(assign)),
                         _ => None,
                     };
                     if let Some(export_items) = export_items {
@@ -1056,6 +1065,7 @@ impl SystemExecuteTransformer {
                             expr: expr.clone(),
                         });
                         stmt.visit_mut_with(self);
+                        items.extend(self.take_pending_expr_exports());
                         items.push(ModuleItem::Stmt(stmt));
                     }
                 }
@@ -1281,6 +1291,26 @@ impl SystemExecuteTransformer {
                 Some(assignment_items)
             }
         }
+    }
+
+    fn take_ident_assign_export(&mut self, assign: &AssignExpr) -> Option<Vec<ModuleItem>> {
+        self.take_ident_assign_export_seq(assign)
+            .or_else(|| self.take_ident_assign_single_export(assign))
+    }
+
+    fn take_ident_assign_single_export(&mut self, assign: &AssignExpr) -> Option<Vec<ModuleItem>> {
+        if assign.op != AssignOp::Assign {
+            return None;
+        }
+        let target = assign.left.as_simple()?.as_ident()?.clone();
+        let Expr::Call(call) = strip_paren_expr(assign.right.as_ref()) else {
+            return None;
+        };
+        let export_call = parse_export_call(call, &self.export_sym)?;
+        let (export_items, result) = self.export_call_result_items(export_call)?;
+        let mut items = export_items;
+        items.push(assign_ident_item(target, result));
+        Some(items)
     }
 
     fn take_ident_assign_export_seq(&mut self, assign: &AssignExpr) -> Option<Vec<ModuleItem>> {
@@ -1570,8 +1600,22 @@ impl VisitMut for SystemExecuteTransformer {
             if let Some(ExportCall::Single { exported, value }) =
                 parse_export_call(call, &self.export_sym)
             {
+                // Ident / assign values stay in place: hoisting
+                // `Namespace || _export("N", Namespace = {})` would drop the
+                // assignment from the `||` operand.
                 if let Some(local) = exported_value_local(value.as_ref()) {
                     self.add_export(local, exported);
+                    *expr = export_replacement_expr(value);
+                    expr.visit_mut_children_with(self);
+                    return;
+                }
+                if let Some((items, result)) = self.export_call_result_items(ExportCall::Single {
+                    exported,
+                    value: value.clone(),
+                }) {
+                    self.pending_expr_exports.extend(items);
+                    *expr = *result;
+                    return;
                 }
                 *expr = export_replacement_expr(value);
                 expr.visit_mut_children_with(self);

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -1009,10 +1009,12 @@ impl SystemExecuteTransformer {
                 ExportSpecifier::Named(ExportNamedSpecifier {
                     span: DUMMY_SP,
                     orig: ModuleExportName::Ident(ident(local.clone())),
-                    exported: if exported.as_ref() == local.as_ref() {
+                    exported: if exported.as_ref() == local.as_ref()
+                        && is_valid_ident_name(exported.as_ref())
+                    {
                         None
                     } else {
-                        Some(ModuleExportName::Ident(ident(exported)))
+                        Some(export_name_node(&exported))
                     },
                     is_type_only: false,
                 })
@@ -1260,21 +1262,20 @@ impl SystemExecuteTransformer {
                         },
                     ))]);
                 }
-                if is_valid_ident_name(exported.as_ref()) {
-                    if self.can_bind_export_name(&exported) {
-                        return Some(vec![self.export_const_item(exported, value)]);
-                    }
-                    // Reserved, already taken, or observable elsewhere (free
-                    // reference or direct eval): keep the alias path.
-                    let local = self.fresh_export_name();
-                    self.declared_exports
-                        .insert((local.clone(), exported.clone()));
-                    return Some(vec![
-                        self.binding_item(local.clone(), value),
-                        named_export_item(local, exported),
-                    ]);
+                if is_valid_ident_name(exported.as_ref()) && self.can_bind_export_name(&exported) {
+                    return Some(vec![self.export_const_item(exported, value)]);
                 }
-                None
+                // Reserved, already taken, not an Identifier, or observable
+                // elsewhere: keep the alias path. Illegal ident names still
+                // become `export { local as "foo-bar" }` so the public name
+                // is not dropped by peeling `_export`.
+                let local = self.fresh_export_name();
+                self.declared_exports
+                    .insert((local.clone(), exported.clone()));
+                Some(vec![
+                    self.binding_item(local.clone(), value),
+                    named_export_item(local, exported),
+                ])
             }
             ExportCall::Bulk(exports) => {
                 let mut assignment_items = Vec::new();
@@ -1393,9 +1394,6 @@ impl SystemExecuteTransformer {
         }
 
         let is_default = exported.as_ref() == "default";
-        if !is_default && !is_valid_ident_name(exported.as_ref()) {
-            return None;
-        }
         if !is_default && self.can_bind_export_name(&exported) {
             let result = Box::new(Expr::Ident(ident(exported.clone())));
             return Some((vec![self.export_const_item(exported, value)], result));
@@ -1617,7 +1615,8 @@ impl VisitMut for SystemExecuteTransformer {
                     *expr = *result;
                     return;
                 }
-                *expr = export_replacement_expr(value);
+                // Bulk / unrepresentable calls stay in place. Peeling would
+                // drop the export name while leaving only the value.
                 expr.visit_mut_children_with(self);
                 return;
             }
@@ -1657,13 +1656,21 @@ struct ExportBinding {
     exported: Atom,
 }
 
+fn export_name_node(name: &Atom) -> ModuleExportName {
+    if is_valid_ident_name(name.as_ref()) {
+        ModuleExportName::Ident(ident(name.clone()))
+    } else {
+        ModuleExportName::Str(make_str(name.as_ref()))
+    }
+}
+
 fn named_export_item(local: Atom, exported: Atom) -> ModuleItem {
     ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
         span: DUMMY_SP,
         specifiers: vec![ExportSpecifier::Named(ExportNamedSpecifier {
             span: DUMMY_SP,
             orig: ModuleExportName::Ident(ident(local)),
-            exported: Some(ModuleExportName::Ident(ident(exported))),
+            exported: Some(export_name_node(&exported)),
             is_type_only: false,
         })],
         src: None,

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -1554,3 +1554,122 @@ System.register([], function (_export, _context) {
         "must not bind a name a direct eval could observe:\n{entry}"
     );
 }
+
+#[test]
+fn assign_of_export_literal_keeps_name_and_return_value() {
+    // `S = _export("TodayShow", "TodayShow")` must emit the export and keep
+    // `_export`'s return value for the assignment (not drop the name).
+    let source = r#"
+System.register([], function (_export, _context) {
+  var S;
+  return { setters: [], execute: function () {
+    S = _export("TodayShow", "TodayShow");
+    use(S);
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export const TodayShow = \"TodayShow\"")
+            || entry.contains("export const TodayShow = 'TodayShow'"),
+        "literal UNIQUE export must be emitted:\n{entry}"
+    );
+    assert!(
+        entry.contains("S = TodayShow") || entry.contains("S=TodayShow"),
+        "assignment must keep `_export`'s return value:\n{entry}"
+    );
+}
+
+#[test]
+fn seq_assign_export_literal_then_named_export_keeps_both_names() {
+    // Activity51Popup shape: `S = _export("TodayShow", "TodayShow"), _export("Popup", ctor)`.
+    let source = r#"
+System.register([], function (_export, _context) {
+  var S;
+  return { setters: [], execute: function () {
+    S = _export("TodayShow", "TodayShow"), _export("Popup", function Popup() {});
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("TodayShow"),
+        "string UNIQUE export must survive the comma sequence:\n{entry}"
+    );
+    assert!(
+        entry.contains("export const Popup")
+            || entry.contains("export {") && entry.contains("Popup"),
+        "following named export must survive:\n{entry}"
+    );
+    assert!(
+        entry.contains("export const TodayShow")
+            || entry.contains("export {") && entry.contains("TodayShow"),
+        "TodayShow must be an export, not only a local:\n{entry}"
+    );
+}
+
+#[test]
+fn assign_of_export_literal_respects_freedom_proof() {
+    let source = r#"
+System.register([], function (_export, _context) {
+  var S;
+  return { setters: [], execute: function () {
+    eval("TodayShow");
+    S = _export("TodayShow", "TodayShow");
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export { __systemjs_export as TodayShow }"),
+        "direct eval must force the alias path:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const TodayShow"),
+        "must not bind a name a direct eval could observe:\n{entry}"
+    );
+}
+
+#[test]
+fn assign_of_export_literal_rejects_reserved_name() {
+    let source = r#"
+System.register([], function (_export, _context) {
+  var S;
+  return { setters: [], execute: function () {
+    S = _export("class", "class");
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export { __systemjs_export as class }"),
+        "reserved export names must stay on the alias path:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const class"),
+        "must not emit a reserved binding:\n{entry}"
+    );
+}
+
+#[test]
+fn nested_export_literal_expression_keeps_name() {
+    // Expression-position `_export` (not a statement) still has to emit.
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    use(_export("TodayShow", "TodayShow"));
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export const TodayShow")
+            || entry.contains("export {") && entry.contains("TodayShow"),
+        "nested `_export` literal must still emit the name:\n{entry}"
+    );
+}

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -1595,18 +1595,14 @@ System.register([], function (_export, _context) {
     let raw = unpack_source_raw(source);
     let entry = module_code(&raw, "entry.js");
     assert!(
-        entry.contains("TodayShow"),
-        "string UNIQUE export must survive the comma sequence:\n{entry}"
+        entry.contains("export const TodayShow = \"TodayShow\"")
+            || entry.contains("export const TodayShow = 'TodayShow'"),
+        "TodayShow must be a bound export, not only a local mention:\n{entry}"
     );
     assert!(
         entry.contains("export const Popup")
-            || entry.contains("export {") && entry.contains("Popup"),
+            || (entry.contains("export {") && entry.contains("Popup")),
         "following named export must survive:\n{entry}"
-    );
-    assert!(
-        entry.contains("export const TodayShow")
-            || entry.contains("export {") && entry.contains("TodayShow"),
-        "TodayShow must be an export, not only a local:\n{entry}"
     );
 }
 
@@ -1671,5 +1667,107 @@ System.register([], function (_export, _context) {
         entry.contains("export const TodayShow")
             || entry.contains("export {") && entry.contains("TodayShow"),
         "nested `_export` literal must still emit the name:\n{entry}"
+    );
+}
+
+fn has_string_export_alias(code: &str, exported: &str) -> bool {
+    code.contains(&format!("as \"{exported}\"")) || code.contains(&format!("as '{exported}'"))
+}
+
+#[test]
+fn expr_export_invalid_ident_name_uses_string_alias() {
+    // A name that cannot be an Identifier must still appear on the export
+    // list. Peeling `_export` and leaving only the value drops the name.
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    use(_export("foo-bar", "x"));
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        has_string_export_alias(entry, "foo-bar") && entry.contains("__systemjs_export"),
+        "invalid ident export names must use a string alias:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const foo"),
+        "must not invent a legal binding from an illegal export name:\n{entry}"
+    );
+    assert!(
+        !entry.contains("_export("),
+        "the SystemJS helper must not remain after a successful alias:\n{entry}"
+    );
+}
+
+#[test]
+fn statement_export_invalid_ident_name_uses_string_alias() {
+    let source = r#"
+System.register([], function (_export, _context) {
+  return { setters: [], execute: function () {
+    _export("foo-bar", "x");
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        has_string_export_alias(entry, "foo-bar") && entry.contains("__systemjs_export"),
+        "statement `_export` with an illegal ident must still alias:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const foo"),
+        "must not invent a legal binding from an illegal export name:\n{entry}"
+    );
+    assert!(
+        !entry.contains("_export("),
+        "the SystemJS helper must not remain after a successful alias:\n{entry}"
+    );
+}
+
+#[test]
+fn assign_of_export_literal_rejects_existing_local() {
+    let source = r#"
+System.register([], function (_export, _context) {
+  var S;
+  return { setters: [], execute: function () {
+    const TodayShow = 1;
+    S = _export("TodayShow", "TodayShow");
+    use(S, TodayShow);
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export { __systemjs_export as TodayShow }"),
+        "an existing local must force the alias path:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const TodayShow"),
+        "must not rebind an existing local as the export:\n{entry}"
+    );
+}
+
+#[test]
+fn assign_of_export_literal_ignores_cjs_hasownproperty_string() {
+    // `exports.hasOwnProperty("TodayShow")` is a CJS surface read. SystemJS
+    // `_export` does not own that object; a string key must not block a free name.
+    let source = r#"
+System.register([], function (_export, _context) {
+  var S;
+  return { setters: [], execute: function () {
+    exports.hasOwnProperty("TodayShow");
+    S = _export("TodayShow", "TodayShow");
+  } };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export const TodayShow = \"TodayShow\"")
+            || entry.contains("export const TodayShow = 'TodayShow'"),
+        "a CJS hasOwnProperty string must not force the alias path:\n{entry}"
     );
 }


### PR DESCRIPTION
## Summary
- Expression-position peel of `_export("Name", literal)` did not emit the export: `exported_value_local` is `None` for literals, so `visit_mut_expr` dropped the name. The statement path already emitted `export const`.
- Treat assignment of an `_export` call the same as a sequence of `_export` calls (`take_ident_assign_export` via `export_call_result_items`). Flush pending expression exports in `push_stmt` / leftover sequence items.
- Leave `Ident` / `Assign` operands in place (`Namespace || _export("N", Namespace = {})` must not hoist).
- Shared name invariant: free Identifier -> `export const`; else shared alias; illegal Identifier -> `export { __systemjs_export as "foo-bar" }`. Never peel after `None` (bulk `_export` stays fail-closed).
- `export_name_node` is used by both `named_export_item` and `export_items`, so unrepresentable names cannot drop on either path.

Related: leftover emit hole after #207. Does not touch stillRegister leftovers or UnEnum.

Please feel free to take it from here if that is easier. Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
System.register([], function (_export) {
  return { setters: [], execute: function () {
    S = _export("TodayShow", "TodayShow");
    use(_export("TodayShow", "TodayShow"));
  } };
});
```

`wakaru --unpack` printed `S = "TodayShow"` / `use("TodayShow")` and dropped the export name. After this change: `export const TodayShow = "TodayShow"` and `S = TodayShow` / `use(TodayShow)`.

Illegal Identifier names (`_export("foo-bar", "x")`) go through the shared alias: `export { __systemjs_export as "foo-bar" }`, not a peeled literal.

Covered by `assign_of_export_literal_keeps_name_and_return_value`, `seq_assign_export_literal_then_named_export_keeps_both_names`, `expr_export_invalid_ident_name_uses_string_alias`, and `statement_export_invalid_ident_name_uses_string_alias`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack`
