### PR TITLE
fix(systemjs): recover live setter re-exports without synthesizing locals

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -302,7 +302,7 @@ fn emit_system_module(
     let descriptor = extract_register_descriptor(body)?;
     let execute_body = descriptor.execute.body.as_ref()?;
 
-    let imports = collect_imports(&register.deps, &descriptor.setters)?;
+    let imports = collect_imports(&register.deps, &descriptor.setters, &export_sym)?;
     let imported_locals = imports
         .iter()
         .flat_map(|import| import.local_names())
@@ -708,6 +708,10 @@ struct ImportParts {
     default: Option<Atom>,
     namespace: Option<Atom>,
     named: Vec<(Atom, Atom)>,
+    /// Live `export { local as Name }` from a setter assignment + `_export`.
+    reexports: Vec<(Atom, Atom)>,
+    /// `export { imported as Name } from "dep"` — no synthesized local.
+    reexports_from: Vec<(Atom, Atom)>,
 }
 
 impl ImportParts {
@@ -719,18 +723,27 @@ impl ImportParts {
         names
     }
 
+    fn has_import_bindings(&self) -> bool {
+        self.default.is_some() || self.namespace.is_some() || !self.named.is_empty()
+    }
+
     fn to_module_items(&self) -> Vec<ModuleItem> {
         let mut items = Vec::new();
         let src = make_str(&self.source);
-        if self.default.is_none() && self.namespace.is_none() && self.named.is_empty() {
-            items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-                span: DUMMY_SP,
-                specifiers: vec![],
-                src: Box::new(src),
-                type_only: false,
-                with: None,
-                phase: Default::default(),
-            })));
+        if !self.has_import_bindings() {
+            if self.reexports_from.is_empty() && self.reexports.is_empty() {
+                items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+                    span: DUMMY_SP,
+                    specifiers: vec![],
+                    src: Box::new(src),
+                    type_only: false,
+                    with: None,
+                    phase: Default::default(),
+                })));
+                return items;
+            }
+            items.extend(self.reexport_from_items());
+            items.extend(self.reexport_items());
             return items;
         }
 
@@ -781,11 +794,33 @@ impl ImportParts {
             })));
         }
 
+        items.extend(self.reexport_items());
+        items.extend(self.reexport_from_items());
         items
+    }
+
+    fn reexport_items(&self) -> Vec<ModuleItem> {
+        self.reexports
+            .iter()
+            .map(|(local, exported)| named_reexport_item(local.clone(), exported.clone()))
+            .collect()
+    }
+
+    fn reexport_from_items(&self) -> Vec<ModuleItem> {
+        self.reexports_from
+            .iter()
+            .map(|(imported, exported)| {
+                named_export_from_item(imported.clone(), exported.clone(), &self.source)
+            })
+            .collect()
     }
 }
 
-fn collect_imports(deps: &[String], setters: &[Option<Function>]) -> Option<Vec<ImportParts>> {
+fn collect_imports(
+    deps: &[String],
+    setters: &[Option<Function>],
+    export_sym: &Atom,
+) -> Option<Vec<ImportParts>> {
     let mut imports = Vec::new();
     for (idx, dep) in deps.iter().enumerate() {
         let mut parts = ImportParts {
@@ -803,14 +838,23 @@ fn collect_imports(deps: &[String], setters: &[Option<Function>]) -> Option<Vec<
             continue;
         }
         let module_sym = module_sym?;
+        let mut pending_reexports = Vec::new();
         for stmt in &body.stmts {
-            for (local, kind) in setter_assignments(stmt, &module_sym)? {
-                match kind {
-                    SetterImportKind::Default => parts.default = Some(local),
-                    SetterImportKind::Named(imported) => parts.named.push((imported, local)),
-                    SetterImportKind::Namespace => parts.namespace = Some(local),
+            for part in setter_stmt_parts(stmt, &module_sym, export_sym)? {
+                match part {
+                    SetterPart::Import(local, kind) => match kind {
+                        SetterImportKind::Default => parts.default = Some(local),
+                        SetterImportKind::Named(imported) => parts.named.push((imported, local)),
+                        SetterImportKind::Namespace => parts.namespace = Some(local),
+                    },
+                    SetterPart::Reexport { exported, value } => {
+                        pending_reexports.push((exported, value));
+                    }
                 }
             }
+        }
+        for (exported, value) in pending_reexports {
+            apply_setter_reexport(&mut parts, &module_sym, exported, value.as_ref())?;
         }
         imports.push(parts);
     }
@@ -823,7 +867,12 @@ enum SetterImportKind {
     Namespace,
 }
 
-fn setter_assignments(stmt: &Stmt, module_sym: &Atom) -> Option<Vec<(Atom, SetterImportKind)>> {
+enum SetterPart {
+    Import(Atom, SetterImportKind),
+    Reexport { exported: Atom, value: Box<Expr> },
+}
+
+fn setter_stmt_parts(stmt: &Stmt, module_sym: &Atom, export_sym: &Atom) -> Option<Vec<SetterPart>> {
     let Stmt::Expr(expr_stmt) = stmt else {
         return None;
     };
@@ -831,9 +880,59 @@ fn setter_assignments(stmt: &Stmt, module_sym: &Atom) -> Option<Vec<(Atom, Sette
         Expr::Seq(seq) => seq
             .exprs
             .iter()
-            .map(|expr| setter_assignment_expr(expr.as_ref(), module_sym))
+            .map(|expr| setter_expr_part(expr.as_ref(), module_sym, export_sym))
             .collect(),
-        expr => setter_assignment_expr(expr, module_sym).map(|assignment| vec![assignment]),
+        expr => setter_expr_part(expr, module_sym, export_sym).map(|part| vec![part]),
+    }
+}
+
+fn setter_expr_part(expr: &Expr, module_sym: &Atom, export_sym: &Atom) -> Option<SetterPart> {
+    if let Some((local, kind)) = setter_assignment_expr(expr, module_sym) {
+        return Some(SetterPart::Import(local, kind));
+    }
+    // A setter parameter that shadows `_export` makes `e(...)` a call on the
+    // module namespace, not a re-export. Keep the whole module fail-closed.
+    if module_sym == export_sym {
+        return None;
+    }
+    let Expr::Call(call) = expr else {
+        return None;
+    };
+    let ExportCall::Single { exported, value } = parse_export_call(call, export_sym)? else {
+        return None;
+    };
+    Some(SetterPart::Reexport { exported, value })
+}
+
+fn apply_setter_reexport(
+    parts: &mut ImportParts,
+    module_sym: &Atom,
+    exported: Atom,
+    value: &Expr,
+) -> Option<()> {
+    match value {
+        Expr::Ident(id) if parts.local_names().iter().any(|name| name == &id.sym) => {
+            parts.reexports.push((id.sym.clone(), exported));
+            Some(())
+        }
+        Expr::Member(member) if member_obj_ident(member, module_sym) => {
+            let imported = member_prop_name(&member.prop)?;
+            if imported.as_ref() == "default" {
+                if let Some(local) = &parts.default {
+                    parts.reexports.push((local.clone(), exported));
+                } else {
+                    parts.reexports_from.push((Atom::from("default"), exported));
+                }
+                return Some(());
+            }
+            if let Some((_, local)) = parts.named.iter().find(|(name, _)| name == &imported) {
+                parts.reexports.push((local.clone(), exported));
+            } else {
+                parts.reexports_from.push((imported, exported));
+            }
+            Some(())
+        }
+        _ => None,
     }
 }
 
@@ -1674,6 +1773,38 @@ fn named_export_item(local: Atom, exported: Atom) -> ModuleItem {
             is_type_only: false,
         })],
         src: None,
+        type_only: false,
+        with: None,
+    }))
+}
+
+fn named_reexport_item(local: Atom, exported: Atom) -> ModuleItem {
+    ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
+        span: DUMMY_SP,
+        specifiers: vec![ExportSpecifier::Named(ExportNamedSpecifier {
+            span: DUMMY_SP,
+            orig: ModuleExportName::Ident(ident(local.clone())),
+            exported: (local.as_ref() != exported.as_ref())
+                .then(|| ModuleExportName::Ident(ident(exported))),
+            is_type_only: false,
+        })],
+        src: None,
+        type_only: false,
+        with: None,
+    }))
+}
+
+fn named_export_from_item(imported: Atom, exported: Atom, source: &str) -> ModuleItem {
+    ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
+        span: DUMMY_SP,
+        specifiers: vec![ExportSpecifier::Named(ExportNamedSpecifier {
+            span: DUMMY_SP,
+            orig: ModuleExportName::Ident(ident(imported.clone())),
+            exported: (imported.as_ref() != exported.as_ref())
+                .then(|| ModuleExportName::Ident(ident(exported))),
+            is_type_only: false,
+        })],
+        src: Some(Box::new(make_str(source))),
         type_only: false,
         with: None,
     }))

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -1784,8 +1784,7 @@ fn named_reexport_item(local: Atom, exported: Atom) -> ModuleItem {
         specifiers: vec![ExportSpecifier::Named(ExportNamedSpecifier {
             span: DUMMY_SP,
             orig: ModuleExportName::Ident(ident(local.clone())),
-            exported: (local.as_ref() != exported.as_ref())
-                .then(|| ModuleExportName::Ident(ident(exported))),
+            exported: (local.as_ref() != exported.as_ref()).then(|| export_name_node(&exported)),
             is_type_only: false,
         })],
         src: None,
@@ -1799,9 +1798,8 @@ fn named_export_from_item(imported: Atom, exported: Atom, source: &str) -> Modul
         span: DUMMY_SP,
         specifiers: vec![ExportSpecifier::Named(ExportNamedSpecifier {
             span: DUMMY_SP,
-            orig: ModuleExportName::Ident(ident(imported.clone())),
-            exported: (imported.as_ref() != exported.as_ref())
-                .then(|| ModuleExportName::Ident(ident(exported))),
+            orig: export_name_node(&imported),
+            exported: (imported.as_ref() != exported.as_ref()).then(|| export_name_node(&exported)),
             is_type_only: false,
         })],
         src: Some(Box::new(make_str(source))),

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -2007,3 +2007,78 @@ System.register("entry", ["dep"], function (_export) {
         "direct eval in execute must remain:\n{entry}"
     );
 }
+
+#[test]
+fn setter_reexport_preserves_arbitrary_export_name() {
+    // Babel output for `export { foo as "foo-bar" } from "./dep.js";`.
+    let source = r#"
+System.register(["./dep.js"], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [function (_depJs) {
+      _export("foo-bar", _depJs.foo);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+
+    for (stage, modules) in [
+        ("raw", unpack_source_raw(source)),
+        ("decompiled", unpack_source(source)),
+    ] {
+        assert_eq!(modules.len(), 1, "unexpected {stage} modules: {modules:?}");
+        let entry = &modules[0].1;
+        let mut validation_modules = modules.clone();
+        validation_modules.push(("dep.js".to_string(), "export const foo = 1;".to_string()));
+        assert_eq!(
+            validate_output_modules(&validation_modules),
+            vec![],
+            "{stage} output must remain valid ESM:\n{entry}"
+        );
+        assert!(
+            entry.contains(r#"export { foo as "foo-bar" } from "./dep.js";"#),
+            "{stage} output must preserve the arbitrary exported name:\n{entry}"
+        );
+    }
+}
+
+#[test]
+fn setter_reexport_preserves_arbitrary_import_name() {
+    // Babel output for `export { "foo-bar" as fooBar } from "./dep.js";`.
+    let source = r#"
+System.register(["./dep.js"], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [function (_depJs) {
+      _export("fooBar", _depJs["foo-bar"]);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+
+    for (stage, modules) in [
+        ("raw", unpack_source_raw(source)),
+        ("decompiled", unpack_source(source)),
+    ] {
+        assert_eq!(modules.len(), 1, "unexpected {stage} modules: {modules:?}");
+        let entry = &modules[0].1;
+        let mut validation_modules = modules.clone();
+        validation_modules.push((
+            "dep.js".to_string(),
+            r#"const foo = 1; export { foo as "foo-bar" };"#.to_string(),
+        ));
+        assert_eq!(
+            validate_output_modules(&validation_modules),
+            vec![],
+            "{stage} output must remain valid ESM:\n{entry}"
+        );
+        assert!(
+            entry.contains(r#"export { "foo-bar" as fooBar } from "./dep.js";"#),
+            "{stage} output must preserve the arbitrary imported name:\n{entry}"
+        );
+    }
+}

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -1771,3 +1771,239 @@ System.register([], function (_export, _context) {
         "a CJS hasOwnProperty string must not force the alias path:\n{entry}"
     );
 }
+
+#[test]
+fn setter_reexport_of_imported_member_becomes_named_export() {
+    // `local = m.Name, _export("Name", m.Name)` used to fail the setter
+    // parser and leave the whole register untouched.
+    let source = r#"
+System.register("dep", [], function (_export) {
+  return {
+    execute: function () {
+      function AuctionLedgerType() {}
+      _export("AuctionLedgerType", AuctionLedgerType);
+    }
+  };
+});
+System.register("entry", ["dep"], function (_export) {
+  var Type;
+  return {
+    setters: [function (module) {
+      Type = module.AuctionLedgerType, _export("AuctionLedgerType", module.AuctionLedgerType);
+    }],
+    execute: function () {
+      _export("Entry", Type);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        !entry.contains("System.register"),
+        "setter re-export must not fail the whole module:\n{entry}"
+    );
+    assert!(
+        entry.contains("AuctionLedgerType") && entry.contains(r#"from "dep""#),
+        "the imported binding must be recovered:\n{entry}"
+    );
+    assert!(
+        entry.contains("as AuctionLedgerType")
+            || entry.contains("export { Type as AuctionLedgerType }"),
+        "setter `_export` must become a live re-export:\n{entry}"
+    );
+}
+
+#[test]
+fn setter_reexport_of_assigned_local_becomes_named_export() {
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  var Type;
+  return {
+    setters: [function (module) {
+      Type = module.AuctionLedgerType;
+      _export("AuctionLedgerType", Type);
+    }],
+    execute: function () {
+      use(Type);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("export { Type as AuctionLedgerType }")
+            || entry.contains("export {Type as AuctionLedgerType}"),
+        "re-exporting the setter local must stay a live binding:\n{entry}"
+    );
+    assert!(
+        entry.contains("use(Type)"),
+        "the imported local must remain in execute:\n{entry}"
+    );
+}
+
+#[test]
+fn setter_reexport_only_uses_export_from_without_local() {
+    // Re-export without a setter assignment must not invent `import { Name }`.
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      _export("AuctionLedgerType", module.AuctionLedgerType);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        !entry.contains("System.register"),
+        "a proven setter re-export must unpack:\n{entry}"
+    );
+    assert!(
+        entry.contains(r#"export { AuctionLedgerType } from "dep""#)
+            || entry.contains(r#"export {AuctionLedgerType} from "dep""#),
+        "assignment-free re-export must be `export {{ Name }} from`:\n{entry}"
+    );
+    assert!(
+        !entry.contains("import {") && !entry.contains("import AuctionLedgerType"),
+        "must not synthesize a local binding for the re-export:\n{entry}"
+    );
+}
+
+#[test]
+fn setter_unknown_export_value_preserves_whole_register() {
+    let source = r#"
+System.register("keep", [], function (_export) {
+  return {
+    execute: function () {
+      _export("value", 1);
+    }
+  };
+});
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      _export("AuctionLedgerType", module.AuctionLedgerType + 1);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    let output = unpack_raw(
+        source,
+        &DecompileOptions {
+            filename: "system-bundle.js".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("unrecognized setter export must preserve the whole input");
+    assert_eq!(
+        output.modules.len(),
+        1,
+        "unrecognized setter must not emit a partial module set: {:?}",
+        output.modules
+    );
+    assert!(
+        output.modules[0].1.contains(r#"System.register("keep""#)
+            && output.modules[0]
+                .1
+                .contains(r#"_export("AuctionLedgerType", module.AuctionLedgerType + 1)"#),
+        "fallback module should preserve both register calls:\n{}",
+        output.modules[0].1
+    );
+    assert!(
+        output.detected_formats.is_empty(),
+        "unrecognized setter input should not be reported as a successful split"
+    );
+}
+
+#[test]
+fn setter_bulk_export_preserves_whole_register() {
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      _export({ AuctionLedgerType: module.AuctionLedgerType });
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    let output = unpack_raw(
+        source,
+        &DecompileOptions {
+            filename: "system-bundle.js".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("bulk setter export must preserve the whole input");
+    assert_eq!(output.modules.len(), 1);
+    assert!(
+        output.modules[0].1.contains("System.register"),
+        "bulk setter `_export` is not a proven shape:\n{}",
+        output.modules[0].1
+    );
+}
+
+#[test]
+fn setter_param_shadowing_export_preserves_whole_register() {
+    // The setter parameter shadows `_export`, so `e(...)` is a call on the
+    // module namespace, not a re-export.
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  return {
+    setters: [function (_export) {
+      _export("AuctionLedgerType", _export.AuctionLedgerType);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    let output = unpack_raw(
+        source,
+        &DecompileOptions {
+            filename: "system-bundle.js".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("shadowed setter `_export` must preserve the whole input");
+    assert_eq!(output.modules.len(), 1);
+    assert!(
+        output.modules[0].1.contains("System.register"),
+        "a setter that shadows `_export` must stay fail-closed:\n{}",
+        output.modules[0].1
+    );
+}
+
+#[test]
+fn setter_reexport_only_does_not_invent_local_visible_to_eval() {
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      _export("AuctionLedgerType", module.AuctionLedgerType);
+    }],
+    execute: function () {
+      eval("AuctionLedgerType");
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains(r#"from "dep""#),
+        "the re-export must still unpack:\n{entry}"
+    );
+    assert!(
+        !entry.contains("import {") && !entry.contains("import AuctionLedgerType"),
+        "eval must not observe a synthesized import local:\n{entry}"
+    );
+    assert!(
+        entry.contains("eval("),
+        "direct eval in execute must remain:\n{entry}"
+    );
+}


### PR DESCRIPTION
## Summary
- Setter bodies that also call `_export("Name", module.Name)` (or `_export("Name", alreadyBoundLocal)`) used to fail `collect_imports`, so `emit_system_module` dropped the whole register and the file stayed Plain `System.register`.
- Treat a proven member or already-bound setter local as a live re-export (`export { local as Name }`). When there is no setter assignment, emit `export { Name } from "dep"` so execute `eval` / a free global cannot observe a synthesized `import { Name }`.
- Any unrecognized setter statement still fail-closes the whole module (bulk `_export({...})`, `_export("Name", module.Name + 1)`, a setter parameter that shadows `_export`). Does not unpack declare functions with no export parameter, and does not recover `e(n)` object re-exports.

Related: leftover detect/emit hole after #203 / #208. Independent of #207 expression `_export` literals and of UnEnum.

Please feel free to take it from here if that is easier. Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
System.register("entry", ["dep"], function (_export) {
  var Type;
  return {
    setters: [function (module) {
      Type = module.AuctionLedgerType, _export("AuctionLedgerType", module.AuctionLedgerType);
    }],
    execute: function () {
      use(Type);
    }
  };
});
```

`wakaru --unpack` left the whole `System.register` untouched. After this change: `import { AuctionLedgerType as Type } from "dep"; export { Type as AuctionLedgerType };`.

Assignment-free `_export("Name", module.Name)` becomes `export { Name } from "dep"` with no `import { Name }`.

Covered by `setter_reexport_of_imported_member_becomes_named_export`, `setter_reexport_of_assigned_local_becomes_named_export`, `setter_reexport_only_uses_export_from_without_local`, `setter_reexport_only_does_not_invent_local_visible_to_eval`, and the fail-closed bulk / unknown-value / shadowing cases.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack`
