### PR TITLE
fix(object-rest): sanitize synthetic aliases for string keys

### DIFF
--- a/crates/core/src/rules/un_object_rest.rs
+++ b/crates/core/src/rules/un_object_rest.rs
@@ -3361,8 +3361,10 @@ fn build_rest_destructuring(
                 }));
             }
         } else {
-            // Not in preceding — generate a `_key` alias
-            let base = format!("_{}", key);
+            // Not in preceding — generate a valid `_key` alias. The property
+            // name itself can contain characters such as `:` (Vue event props),
+            // which are valid in a quoted property key but not in a binding.
+            let base = generated_alias_base(key);
             let alias = find_non_conflicting_alias(&base, scope_names, &used_aliases);
             used_aliases.insert(alias.clone());
             props.push(ObjectPatProp::KeyValue(KeyValuePatProp {
@@ -3585,6 +3587,30 @@ fn find_non_conflicting_alias(
         }
     }
     unreachable!()
+}
+
+/// Create a readable, valid binding base for an excluded property without a
+/// preceding local binding. The quoted property key remains unchanged in the
+/// reconstructed pattern; this is only the synthetic local needed to preserve
+/// object-rest semantics.
+fn generated_alias_base(key: &str) -> String {
+    let mut alias = String::from("_");
+    let mut previous_was_separator = false;
+
+    for ch in key.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '$' {
+            alias.push(ch);
+            previous_was_separator = false;
+        } else if !previous_was_separator {
+            alias.push('_');
+            previous_was_separator = true;
+        }
+    }
+
+    if alias == "_" {
+        alias.push_str("property");
+    }
+    alias
 }
 
 /// Collect all binding names from a list of statements (top-level idents only).

--- a/crates/core/src/rules/un_object_rest.rs
+++ b/crates/core/src/rules/un_object_rest.rs
@@ -220,6 +220,13 @@ fn run_un_object_rest(
         return;
     }
 
+    // Synthetic destructuring bindings use an empty SyntaxContext and are emitted
+    // textually, so they must not collide with any existing identifier name. Keep
+    // the original module-wide inventory available while inner and module scopes
+    // are rebuilt; the per-scope prefix scan below also sees aliases synthesized
+    // earlier in the same statement list.
+    let reserved_names = collect_scope_names_module(&module.body);
+
     // Process inner scopes first (function bodies, etc.) with helpers available
     let exclusion_arrays = collect_exclusion_arrays_from_module_items(&module.body);
     let mut processor = ObjectRestProcessor {
@@ -228,6 +235,7 @@ fn run_un_object_rest(
         swc_numeric_helper_namespaces: &swc_numeric_helper_namespaces,
         cross_module_namespaces: &cross_module_helpers.namespaces,
         exclusion_arrays: exclusion_arrays.clone(),
+        reserved_names: &reserved_names,
         unresolved_mark,
     };
     module.visit_mut_children_with(&mut processor);
@@ -302,7 +310,10 @@ fn run_un_object_rest(
                 &source,
                 &excluded_keys,
                 &preceding_accesses,
-                &scope_names,
+                AliasNameConflicts {
+                    scope_names: &scope_names,
+                    reserved_names: &reserved_names,
+                },
             );
             recent_stmts.push(new_stmt.clone());
             new_body.push(ModuleItem::Stmt(new_stmt));
@@ -1666,6 +1677,7 @@ struct ObjectRestProcessor<'a> {
     swc_numeric_helper_namespaces: &'a HashSet<BindingKey>,
     cross_module_namespaces: &'a HashMap<BindingKey, HashMap<String, TranspilerHelperKind>>,
     exclusion_arrays: HashMap<BindingKey, Vec<Atom>>,
+    reserved_names: &'a HashSet<Atom>,
     unresolved_mark: Mark,
 }
 
@@ -1750,7 +1762,10 @@ impl VisitMut for ObjectRestProcessor<'_> {
                     &source,
                     &excluded_keys,
                     &preceding_accesses,
-                    &scope_names,
+                    AliasNameConflicts {
+                        scope_names: &scope_names,
+                        reserved_names: self.reserved_names,
+                    },
                 ));
                 if !after.is_empty() {
                     new_stmts.push(Stmt::Decl(Decl::Var(Box::new(VarDecl {
@@ -3276,7 +3291,7 @@ fn build_rest_destructuring(
     source: &Expr,
     excluded_keys: &[Atom],
     merged: &[PrecedingAccess],
-    scope_names: &std::collections::HashSet<Atom>,
+    alias_conflicts: AliasNameConflicts<'_>,
 ) -> Stmt {
     // Build a map from prop key → (local binding name, SyntaxContext) from preceding accesses.
     // Preserving the original SyntaxContext is critical so that downstream SmartRename
@@ -3365,7 +3380,7 @@ fn build_rest_destructuring(
             // name itself can contain characters such as `:` (Vue event props),
             // which are valid in a quoted property key but not in a binding.
             let base = generated_alias_base(key);
-            let alias = find_non_conflicting_alias(&base, scope_names, &used_aliases);
+            let alias = find_non_conflicting_alias(&base, alias_conflicts, &used_aliases);
             used_aliases.insert(alias.clone());
             props.push(ObjectPatProp::KeyValue(KeyValuePatProp {
                 key: make_prop_name(key),
@@ -3570,19 +3585,32 @@ fn prop_name_atom(key: &PropName) -> Option<Atom> {
     }
 }
 
+/// Existing emitted names that a synthetic alias must not capture or redeclare.
+#[derive(Clone, Copy)]
+struct AliasNameConflicts<'a> {
+    scope_names: &'a HashSet<Atom>,
+    reserved_names: &'a HashSet<Atom>,
+}
+
+impl AliasNameConflicts<'_> {
+    fn contains(self, name: &Atom) -> bool {
+        self.scope_names.contains(name) || self.reserved_names.contains(name)
+    }
+}
+
 /// Find an alias name that doesn't collide with scope names or already-used aliases.
 fn find_non_conflicting_alias(
     base: &str,
-    scope_names: &std::collections::HashSet<Atom>,
+    conflicts: AliasNameConflicts<'_>,
     used_aliases: &std::collections::HashSet<Atom>,
 ) -> Atom {
     let base_atom = Atom::from(base);
-    if !scope_names.contains(&base_atom) && !used_aliases.contains(&base_atom) {
+    if !conflicts.contains(&base_atom) && !used_aliases.contains(&base_atom) {
         return base_atom;
     }
     for i in 1.. {
         let candidate = Atom::from(format!("{}_{}", base, i));
-        if !scope_names.contains(&candidate) && !used_aliases.contains(&candidate) {
+        if !conflicts.contains(&candidate) && !used_aliases.contains(&candidate) {
             return candidate;
         }
     }

--- a/crates/core/tests/un_object_rest_rule.rs
+++ b/crates/core/tests/un_object_rest_rule.rs
@@ -215,6 +215,92 @@ use(rest);
 }
 
 #[test]
+fn generated_string_alias_avoids_later_binding() {
+    let input = r#"
+props["onUpdate:visible"];
+const rest = ((e, t) => {
+    const n = {};
+    for (const r in e) {
+        t.indexOf(r) >= 0 || Object.prototype.hasOwnProperty.call(e, r) && (n[r] = e[r]);
+    }
+    return n;
+})(props, ["onUpdate:visible"]);
+const _onUpdate_visible = sentinel;
+use(rest, _onUpdate_visible);
+"#;
+    let expected = r#"
+const { "onUpdate:visible": _onUpdate_visible_1, ...rest } = props;
+const _onUpdate_visible = sentinel;
+use(rest, _onUpdate_visible);
+"#;
+    assert_eq_normalized(&render_rule(input, UnObjectRest::new), expected);
+}
+
+#[test]
+fn generated_string_alias_avoids_rest_binding() {
+    let input = r#"
+props["onUpdate:visible"];
+const _onUpdate_visible = ((e, t) => {
+    const n = {};
+    for (const r in e) {
+        t.indexOf(r) >= 0 || Object.prototype.hasOwnProperty.call(e, r) && (n[r] = e[r]);
+    }
+    return n;
+})(props, ["onUpdate:visible"]);
+use(_onUpdate_visible);
+"#;
+    let expected = r#"
+const { "onUpdate:visible": _onUpdate_visible_1, ..._onUpdate_visible } = props;
+use(_onUpdate_visible);
+"#;
+    assert_eq_normalized(&render_rule(input, UnObjectRest::new), expected);
+}
+
+#[test]
+fn generated_string_alias_avoids_enclosing_parameter() {
+    let input = r#"
+function renderProps(_onUpdate_visible) {
+    props["onUpdate:visible"];
+    const rest = ((e, t) => {
+        const n = {};
+        for (const r in e) {
+            t.indexOf(r) >= 0 || Object.prototype.hasOwnProperty.call(e, r) && (n[r] = e[r]);
+        }
+        return n;
+    })(props, ["onUpdate:visible"]);
+    use(rest);
+}
+"#;
+    let expected = r#"
+function renderProps(_onUpdate_visible) {
+    const { "onUpdate:visible": _onUpdate_visible_1, ...rest } = props;
+    use(rest);
+}
+"#;
+    assert_eq_normalized(&render_rule(input, UnObjectRest::new), expected);
+}
+
+#[test]
+fn generated_string_alias_avoids_merged_binding() {
+    let input = r#"
+const _onUpdate_visible = props.value;
+const rest = ((e, t) => {
+    const n = {};
+    for (const r in e) {
+        t.indexOf(r) >= 0 || Object.prototype.hasOwnProperty.call(e, r) && (n[r] = e[r]);
+    }
+    return n;
+})(props, ["value", "onUpdate:visible"]);
+use(_onUpdate_visible, rest);
+"#;
+    let expected = r#"
+const { value: _onUpdate_visible, "onUpdate:visible": _onUpdate_visible_1, ...rest } = props;
+use(_onUpdate_visible, rest);
+"#;
+    assert_eq_normalized(&render_rule(input, UnObjectRest::new), expected);
+}
+
+#[test]
 fn multi_declarator_comma_separated() {
     // Babel output: var t = e.to, n = e.exact, d = IIFE(e, ["to","exact"]), p = expr
     let input = r#"

--- a/crates/core/tests/un_object_rest_rule.rs
+++ b/crates/core/tests/un_object_rest_rule.rs
@@ -195,6 +195,26 @@ use(rest);
 }
 
 #[test]
+fn bare_string_key_generates_a_valid_destructuring_binding() {
+    let input = r#"
+props["onUpdate:visible"];
+const rest = ((e, t) => {
+    const n = {};
+    for (const r in e) {
+        t.indexOf(r) >= 0 || Object.prototype.hasOwnProperty.call(e, r) && (n[r] = e[r]);
+    }
+    return n;
+})(props, ["onUpdate:visible"]);
+use(rest);
+"#;
+    let expected = r#"
+const { "onUpdate:visible": _onUpdate_visible, ...rest } = props;
+use(rest);
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
 fn multi_declarator_comma_separated() {
     // Babel output: var t = e.to, n = e.exact, d = IIFE(e, ["to","exact"]), p = expr
     let input = r#"


### PR DESCRIPTION
## Summary

Fix `UnObjectRest` generating invalid JavaScript when an excluded string property has no preceding local binding.

For Vue event props such as `"onUpdate:visible"`, the previous synthetic alias was `_onUpdate:visible`, which is not a valid binding identifier:

```js
const { "onUpdate:visible": _onUpdate:visible, ...rest } = props;
```

This change preserves the quoted property key and sanitizes only the generated binding name:

```js
const { "onUpdate:visible": _onUpdate_visible, ...rest } = props;
```

It also preserves collision avoidance through the existing `find_non_conflicting_alias` path.

## Testing

- `cargo fmt --check`
- `cargo +1.92.0 test -p wakaru-core --test un_object_rest_rule` (74 passed)
- Local CLI on the original SMS JavaScript bundle: 132/132 modules decompiled, 0 failures
- Local CLI on its full `assets` directory: 283/283 files decompiled, 0 failures, 0 warnings

No existing issue is associated with this fix.