### PR TITLE
fix(systemjs): reconstruct modules when declare has no export param

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -149,7 +149,7 @@ fn parse_register_call(call: &CallExpr) -> Option<SystemRegister> {
     };
 
     let deps = extract_string_array(call.args.get(deps_arg_idx)?.expr.as_ref())?;
-    let declare = extract_function(call.args.get(declare_arg_idx)?.expr.as_ref())?;
+    let declare = extract_declare_function(call.args.get(declare_arg_idx)?.expr.as_ref())?;
 
     Some(SystemRegister {
         name,
@@ -291,18 +291,64 @@ fn extract_function(expr: &Expr) -> Option<Function> {
     }
 }
 
+/// Declare factories may be expression-body arrows (`() => ({ execute() {} })`).
+/// Shared `extract_function` stays block-body-only so setter/execute arrows
+/// that return a value are not rewritten into a top-level `return`.
+fn extract_declare_function(expr: &Expr) -> Option<Function> {
+    match expr {
+        Expr::Fn(FnExpr { function, .. }) => Some(*function.clone()),
+        Expr::Paren(paren) => extract_declare_function(paren.expr.as_ref()),
+        Expr::Arrow(arrow) => {
+            let body = match arrow.body.as_ref() {
+                ArrowFunctionBody::FunctionBody(body) => body.clone(),
+                ArrowFunctionBody::Expr(value) => FunctionBody {
+                    span: DUMMY_SP,
+                    stmts: vec![Stmt::Return(ReturnStmt {
+                        span: DUMMY_SP,
+                        arg: Some(value.clone()),
+                    })],
+                },
+            };
+            let params = arrow
+                .params
+                .iter()
+                .cloned()
+                .map(|pat| swc_core::ecma::ast::Param {
+                    span: DUMMY_SP,
+                    decorators: vec![],
+                    pat,
+                })
+                .collect();
+            Some(Function {
+                params,
+                decorators: vec![],
+                span: DUMMY_SP,
+                ctxt: Default::default(),
+                this_param: None,
+                body: Some(body),
+                is_generator: arrow.is_generator,
+                is_async: arrow.is_async,
+                type_params: None,
+                return_type: None,
+            })
+        }
+        _ => None,
+    }
+}
+
 fn emit_system_module(
     register: &SystemRegister,
     filename: String,
     cm: Lrc<SourceMap>,
 ) -> Option<String> {
-    let export_sym = param_sym(&register.declare, 0)?;
+    // `_export` is optional: unused export params are stripped by minifiers.
+    let export_sym = param_sym(&register.declare, 0);
     let context_sym = param_sym(&register.declare, 1);
     let body = register.declare.body.as_ref()?;
     let descriptor = extract_register_descriptor(body)?;
     let execute_body = descriptor.execute.body.as_ref()?;
 
-    let imports = collect_imports(&register.deps, &descriptor.setters, &export_sym)?;
+    let imports = collect_imports(&register.deps, &descriptor.setters, export_sym.as_ref())?;
     let imported_locals = imports
         .iter()
         .flat_map(|import| import.local_names())
@@ -328,11 +374,20 @@ fn emit_system_module(
 
     let mut module_bound_names = imported_locals.clone();
     collect_lifted_decl_names(&lifted_stmts, &mut module_bound_names);
-    let export_name_usage =
-        collect_export_name_usage(&lifted_stmts, &export_sym, &module_bound_names);
+    let export_name_usage = match export_sym.as_ref() {
+        Some(export_sym) => {
+            collect_export_name_usage(&lifted_stmts, export_sym, &module_bound_names)
+        }
+        None => ExportNameUsageSummary {
+            mutable: Vec::new(),
+            seen: Vec::new(),
+        },
+    };
     let mutable_export_names = export_name_usage.mutable;
-    let mut direct_binding_candidates =
-        collect_member_export_binding_names(&lifted_stmts, &export_sym);
+    let mut direct_binding_candidates = match export_sym.as_ref() {
+        Some(export_sym) => collect_member_export_binding_names(&lifted_stmts, export_sym),
+        None => HashSet::new(),
+    };
     direct_binding_candidates.extend(export_name_usage.seen.into_iter().filter(|name| {
         name.as_ref() != "default"
             && Ident::verify_symbol(name.as_ref()).is_ok()
@@ -384,7 +439,8 @@ fn extract_register_descriptor(body: &FunctionBody) -> Option<RegisterDescriptor
         Stmt::Return(ReturnStmt { arg: Some(arg), .. }) => Some(arg.as_ref()),
         _ => None,
     })?;
-    let Expr::Object(obj) = return_stmt else {
+    // Expression-body arrows keep the grouping paren: `() => ({ execute() {} })`.
+    let Expr::Object(obj) = strip_paren_expr(return_stmt) else {
         return None;
     };
 
@@ -818,7 +874,7 @@ impl ImportParts {
 fn collect_imports(
     deps: &[String],
     setters: &[Option<Function>],
-    export_sym: &Atom,
+    export_sym: Option<&Atom>,
 ) -> Option<Vec<ImportParts>> {
     let mut imports = Vec::new();
     for (idx, dep) in deps.iter().enumerate() {
@@ -871,7 +927,11 @@ enum SetterPart {
     Reexport { exported: Atom, value: Box<Expr> },
 }
 
-fn setter_stmt_parts(stmt: &Stmt, module_sym: &Atom, export_sym: &Atom) -> Option<Vec<SetterPart>> {
+fn setter_stmt_parts(
+    stmt: &Stmt,
+    module_sym: &Atom,
+    export_sym: Option<&Atom>,
+) -> Option<Vec<SetterPart>> {
     let Stmt::Expr(expr_stmt) = stmt else {
         return None;
     };
@@ -885,10 +945,15 @@ fn setter_stmt_parts(stmt: &Stmt, module_sym: &Atom, export_sym: &Atom) -> Optio
     }
 }
 
-fn setter_expr_part(expr: &Expr, module_sym: &Atom, export_sym: &Atom) -> Option<SetterPart> {
+fn setter_expr_part(
+    expr: &Expr,
+    module_sym: &Atom,
+    export_sym: Option<&Atom>,
+) -> Option<SetterPart> {
     if let Some((local, kind)) = setter_assignment_expr(expr, module_sym) {
         return Some(SetterPart::Import(local, kind));
     }
+    let export_sym = export_sym?;
     // A setter parameter that shadows `_export` makes `e(...)` a call on the
     // module namespace, not a re-export. Keep the whole module fail-closed.
     if module_sym == export_sym {
@@ -955,30 +1020,32 @@ fn setter_assignment_expr(expr: &Expr, module_sym: &Atom) -> Option<(Atom, Sette
 }
 
 struct MutableExportRewriter<'a> {
-    export_sym: &'a Atom,
+    export_sym: Option<&'a Atom>,
     bindings: &'a HashMap<Atom, Atom>,
 }
 
 impl VisitMut for MutableExportRewriter<'_> {
     fn visit_mut_expr(&mut self, expr: &mut Expr) {
         let replacement = match expr {
-            Expr::Call(call) => parse_export_call(call, self.export_sym).and_then(|export_call| {
-                let ExportCall::Single {
-                    exported,
-                    mut value,
-                } = export_call
-                else {
-                    return None;
-                };
-                let local = self.bindings.get(&exported)?.clone();
-                value.visit_mut_with(self);
-                // `_export(name, value)` evaluates to `value`. The assignment
-                // has the same result; grouping keeps member/callee precedence.
-                Some(Expr::Paren(ParenExpr {
-                    span: DUMMY_SP,
-                    expr: Box::new(assign_local_expr(local, value)),
-                }))
-            }),
+            Expr::Call(call) => {
+                parse_optional_export_call(call, self.export_sym).and_then(|export_call| {
+                    let ExportCall::Single {
+                        exported,
+                        mut value,
+                    } = export_call
+                    else {
+                        return None;
+                    };
+                    let local = self.bindings.get(&exported)?.clone();
+                    value.visit_mut_with(self);
+                    // `_export(name, value)` evaluates to `value`. The assignment
+                    // has the same result; grouping keeps member/callee precedence.
+                    Some(Expr::Paren(ParenExpr {
+                        span: DUMMY_SP,
+                        expr: Box::new(assign_local_expr(local, value)),
+                    }))
+                })
+            }
             _ => None,
         };
         if let Some(replacement) = replacement {
@@ -990,7 +1057,7 @@ impl VisitMut for MutableExportRewriter<'_> {
 }
 
 struct SystemExecuteTransformer {
-    export_sym: Atom,
+    export_sym: Option<Atom>,
     context_sym: Option<Atom>,
     exports: Vec<ExportBinding>,
     declared_exports: HashSet<(Atom, Atom)>,
@@ -1005,7 +1072,7 @@ struct SystemExecuteTransformer {
 
 impl SystemExecuteTransformer {
     fn new(
-        export_sym: Atom,
+        export_sym: Option<Atom>,
         context_sym: Option<Atom>,
         used_names: HashSet<Atom>,
         module_bound_names: HashSet<Atom>,
@@ -1069,7 +1136,7 @@ impl SystemExecuteTransformer {
 
     fn push_stmt(&mut self, mut stmt: Stmt, items: &mut Vec<ModuleItem>) {
         let mut mutable_export_rewriter = MutableExportRewriter {
-            export_sym: &self.export_sym,
+            export_sym: self.export_sym.as_ref(),
             bindings: &self.mutable_export_bindings,
         };
         stmt.visit_mut_with(&mut mutable_export_rewriter);
@@ -1151,7 +1218,7 @@ impl SystemExecuteTransformer {
         };
         match expr_stmt.expr.as_ref() {
             Expr::Call(call) => {
-                let export_call = parse_export_call(call, &self.export_sym)?;
+                let export_call = parse_optional_export_call(call, self.export_sym.as_ref())?;
                 self.export_call_items(export_call)
             }
             Expr::Assign(assign) => self
@@ -1162,8 +1229,10 @@ impl SystemExecuteTransformer {
                 let mut saw_export = false;
                 for expr in &seq.exprs {
                     let export_items = match expr.as_ref() {
-                        Expr::Call(call) => parse_export_call(call, &self.export_sym)
-                            .and_then(|export_call| self.export_call_items(export_call)),
+                        Expr::Call(call) => {
+                            parse_optional_export_call(call, self.export_sym.as_ref())
+                                .and_then(|export_call| self.export_call_items(export_call))
+                        }
                         Expr::Assign(assign) => self
                             .export_member_assignment_items(assign)
                             .or_else(|| self.take_ident_assign_export(assign)),
@@ -1196,7 +1265,8 @@ impl SystemExecuteTransformer {
         let Expr::Call(call) = member.obj.as_ref() else {
             return None;
         };
-        let ExportCall::Single { exported, value } = parse_export_call(call, &self.export_sym)?
+        let ExportCall::Single { exported, value } =
+            parse_optional_export_call(call, self.export_sym.as_ref())?
         else {
             return None;
         };
@@ -1442,7 +1512,7 @@ impl SystemExecuteTransformer {
         let Expr::Call(call) = strip_paren_expr(assign.right.as_ref()) else {
             return None;
         };
-        let export_call = parse_export_call(call, &self.export_sym)?;
+        let export_call = parse_optional_export_call(call, self.export_sym.as_ref())?;
         let (export_items, result) = self.export_call_result_items(export_call)?;
         let mut items = export_items;
         items.push(assign_ident_item(target, result));
@@ -1459,7 +1529,7 @@ impl SystemExecuteTransformer {
         let mut items = Vec::new();
         for (idx, part) in exprs.iter().enumerate() {
             let export_call = match strip_paren_expr(part) {
-                Expr::Call(call) => parse_export_call(call, &self.export_sym),
+                Expr::Call(call) => parse_optional_export_call(call, self.export_sym.as_ref()),
                 _ => None,
             };
             if idx == last_idx {
@@ -1586,7 +1656,7 @@ impl SystemExecuteTransformer {
                     if let Some(ExportCall::Single {
                         exported,
                         mut value,
-                    }) = parse_export_call(call, &self.export_sym)
+                    }) = parse_optional_export_call(call, self.export_sym.as_ref())
                     {
                         value.visit_mut_with(self);
                         self.add_export(local, exported);
@@ -1618,7 +1688,7 @@ impl SystemExecuteTransformer {
         let has_export = seq.exprs.iter().any(|part| {
             matches!(
                 strip_paren_expr(part),
-                Expr::Call(call) if parse_export_call(call, &self.export_sym).is_some()
+                Expr::Call(call) if parse_optional_export_call(call, self.export_sym.as_ref()).is_some()
             )
         });
         has_export.then_some(seq.exprs.as_slice())
@@ -1636,7 +1706,7 @@ impl SystemExecuteTransformer {
         let mut items = Vec::new();
         for (idx, part) in exprs.iter().enumerate() {
             let export_call = match strip_paren_expr(part) {
-                Expr::Call(call) => parse_export_call(call, &self.export_sym),
+                Expr::Call(call) => parse_optional_export_call(call, self.export_sym.as_ref()),
                 _ => None,
             };
             if idx == last_idx {
@@ -1677,7 +1747,7 @@ impl SystemExecuteTransformer {
                 continue;
             };
             let Some(ExportCall::Single { exported, value }) =
-                parse_export_call(call, &self.export_sym)
+                parse_optional_export_call(call, self.export_sym.as_ref())
             else {
                 continue;
             };
@@ -1731,7 +1801,7 @@ impl VisitMut for SystemExecuteTransformer {
 
         if let Expr::Call(call) = expr {
             if let Some(ExportCall::Single { exported, value }) =
-                parse_export_call(call, &self.export_sym)
+                parse_optional_export_call(call, self.export_sym.as_ref())
             {
                 let mut value = value;
                 value.visit_mut_with(self);
@@ -1884,6 +1954,10 @@ fn export_let_item(name: Atom) -> ModuleItem {
 enum ExportCall {
     Single { exported: Atom, value: Box<Expr> },
     Bulk(Vec<(Atom, Box<Expr>)>),
+}
+
+fn parse_optional_export_call(call: &CallExpr, export_sym: Option<&Atom>) -> Option<ExportCall> {
+    parse_export_call(call, export_sym?)
 }
 
 fn parse_export_call(call: &CallExpr, export_sym: &Atom) -> Option<ExportCall> {

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -341,8 +341,12 @@ fn emit_system_module(
     filename: String,
     cm: Lrc<SourceMap>,
 ) -> Option<String> {
-    // `_export` is optional: unused export params are stripped by minifiers.
-    let export_sym = param_sym(&register.declare, 0);
+    // Missing `_export` is optional. A present but unreadable first param
+    // (rest / destructure / default) stays fail-closed.
+    let export_sym = match register.declare.params.first() {
+        None => None,
+        Some(param) => Some(pat_single_ident(&param.pat).cloned()?),
+    };
     let context_sym = param_sym(&register.declare, 1);
     let body = register.declare.body.as_ref()?;
     let descriptor = extract_register_descriptor(body)?;

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -2407,3 +2407,223 @@ System.register([], function (_export, _context) {
         "must not emit a reserved binding:\n{entry}"
     );
 }
+
+fn assert_no_system_register(code: &str, label: &str) {
+    assert!(
+        !code.contains("System.register"),
+        "{label} must unwrap System.register:\n{code}"
+    );
+}
+
+fn assert_no_invented_export(code: &str, label: &str) {
+    assert!(
+        !code.contains("export "),
+        "{label} must not invent an export:\n{code}"
+    );
+}
+
+#[test]
+fn no_export_param_empty_execute_unwraps_without_export() {
+    let source = r#"
+System.register("entry", [], function () {
+  return {
+    execute: function () {}
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert_no_system_register(entry, "zero-arg function factory");
+    assert_no_invented_export(entry, "zero-arg function factory");
+}
+
+#[test]
+fn no_export_param_expression_arrow_empty_shell_unwraps_without_export() {
+    // Rollup often emits `() => ({ execute() {} })` for empty chunk shells.
+    let source = r#"
+System.register("shell", [], () => ({
+  execute() {}
+}));
+"#;
+    let raw = unpack_source_raw(source);
+    let shell = module_code(&raw, "shell.js");
+    assert_no_system_register(shell, "expression-body arrow factory");
+    assert_no_invented_export(shell, "expression-body arrow factory");
+}
+
+#[test]
+fn no_export_param_null_setter_reconstructs_imports() {
+    let source = r#"
+System.register("entry", ["./side.js", "./dep.js"], function () {
+  var component;
+  return {
+    setters: [
+      null,
+      function (module) {
+        component = module.component;
+      }
+    ],
+    execute: function () {
+      use(component);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert_no_system_register(entry, "zero-arg factory with null setter");
+    assert!(
+        entry.contains(r#"import "./side.js""#) || entry.contains("import \"./side.js\";"),
+        "null setter must become a side-effect import:\n{entry}"
+    );
+    assert!(
+        entry.contains(r#"import { component } from "./dep.js""#)
+            || entry.contains("from \"./dep.js\""),
+        "named setter binding must become an import:\n{entry}"
+    );
+    assert!(
+        entry.contains("use(component)"),
+        "execute must keep using the imported binding:\n{entry}"
+    );
+    assert_no_invented_export(entry, "zero-arg factory with null setter");
+}
+
+#[test]
+fn no_export_param_execute_body_keeps_side_effects() {
+    // Shape reduced from a real module that never calls `_export` so Terser
+    // drops the declare parameter, but still has a non-empty execute body.
+    let source = r#"
+System.register("entry", ["runtime"], function () {
+  var runtime;
+  return {
+    setters: [function (module) {
+      runtime = module.runtime;
+    }],
+    execute: function () {
+      runtime.downloader = runtime.downloader || {};
+      runtime.downloader.maxConcurrency = 6;
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert_no_system_register(entry, "zero-arg factory with execute body");
+    assert!(
+        entry.contains("from \"runtime\"") || entry.contains("from 'runtime'"),
+        "import from the setter must be recovered:\n{entry}"
+    );
+    assert!(
+        entry.contains("maxConcurrency = 6"),
+        "execute side effects must be lifted:\n{entry}"
+    );
+    assert_no_invented_export(entry, "zero-arg factory with execute body");
+}
+
+#[test]
+fn no_export_param_sibling_register_does_not_poison_bundle() {
+    let source = r#"
+System.register("shell", [], function () {
+  return {
+    execute: function () {}
+  };
+});
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("value", 1);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    assert!(
+        raw.len() >= 2,
+        "a zero-arg sibling must not force a whole-file fallback: {:?}",
+        raw.iter().map(|(name, _)| name).collect::<Vec<_>>()
+    );
+    let shell = module_code(&raw, "shell.js");
+    let entry = module_code(&raw, "entry.js");
+    assert_no_system_register(shell, "zero-arg sibling shell");
+    assert_no_invented_export(shell, "zero-arg sibling shell");
+    assert_no_system_register(entry, "exporting sibling");
+    assert!(
+        entry.contains("export") && entry.contains("value"),
+        "the exporting sibling must still reconstruct:\n{entry}"
+    );
+}
+
+#[test]
+fn no_export_param_unknown_setter_preserves_whole_register() {
+    // Unrecognized setter statements stay fail-closed even when declare has
+    // no `_export` parameter. Do not start accepting `e(n)` object re-exports.
+    let source = r#"
+System.register("keep", [], function (_export) {
+  return {
+    execute: function () {
+      _export("value", 1);
+    }
+  };
+});
+System.register("odd", ["dep"], function () {
+  return {
+    setters: [function (module) {
+      const bag = {};
+      bag.Name = module.Name;
+      use(bag);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    let output = unpack_raw(
+        source,
+        &DecompileOptions {
+            filename: "system-bundle.js".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("unrecognized setter must preserve the whole input");
+    assert_eq!(
+        output.modules.len(),
+        1,
+        "unrecognized setter must not emit a partial module set: {:?}",
+        output.modules
+    );
+    assert!(
+        output.modules[0].1.contains(r#"System.register("keep""#)
+            && output.modules[0].1.contains(r#"System.register("odd""#),
+        "fallback module should preserve both register calls:\n{}",
+        output.modules[0].1
+    );
+    assert!(
+        output.detected_formats.is_empty(),
+        "unrecognized setter input should not be reported as a successful split"
+    );
+}
+
+#[test]
+fn no_export_param_does_not_invent_export_from_execute_string() {
+    let source = r#"
+System.register("IBattleRecord", ["cc"], function () {
+  var cclegacy;
+  return {
+    setters: [function (module) {
+      cclegacy = module.cclegacy;
+    }],
+    execute: function () {
+      cclegacy._RF.push({}, "id", "IBattleRecord", undefined);
+      cclegacy._RF.pop();
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "IBattleRecord.js");
+    assert_no_system_register(entry, "filename/_RF string fixture");
+    assert!(
+        entry.contains("IBattleRecord"),
+        "the execute string must stay a string:\n{entry}"
+    );
+    assert_no_invented_export(entry, "filename/_RF string fixture");
+}

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -2477,8 +2477,7 @@ System.register("entry", ["./side.js", "./dep.js"], function () {
         "null setter must become a side-effect import:\n{entry}"
     );
     assert!(
-        entry.contains(r#"import { component } from "./dep.js""#)
-            || entry.contains("from \"./dep.js\""),
+        entry.contains(r#"import { component } from "./dep.js""#),
         "named setter binding must become an import:\n{entry}"
     );
     assert!(
@@ -2556,7 +2555,8 @@ System.register("entry", [], function (_export) {
 #[test]
 fn no_export_param_unknown_setter_preserves_whole_register() {
     // Unrecognized setter statements stay fail-closed even when declare has
-    // no `_export` parameter. Do not start accepting `e(n)` object re-exports.
+    // no `_export` parameter. This locks `const bag = {}` assignment, not
+    // the separate `e(n)` object re-export shape.
     let source = r#"
 System.register("keep", [], function (_export) {
   return {
@@ -2626,4 +2626,97 @@ System.register("IBattleRecord", ["cc"], function () {
         "the execute string must stay a string:\n{entry}"
     );
     assert_no_invented_export(entry, "filename/_RF string fixture");
+}
+
+fn assert_preserves_whole_register(source: &str, label: &str) {
+    let output = unpack_raw(
+        source,
+        &DecompileOptions {
+            filename: "system-bundle.js".to_string(),
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|_| panic!("{label} must preserve the whole input"));
+    assert_eq!(
+        output.modules.len(),
+        1,
+        "{label} must not emit a partial module set: {:?}",
+        output.modules
+    );
+    assert!(
+        output.modules[0].1.contains("System.register"),
+        "{label} must stay fail-closed:\n{}",
+        output.modules[0].1
+    );
+    assert!(
+        output.detected_formats.is_empty(),
+        "{label} should not be reported as a successful split"
+    );
+}
+
+#[test]
+fn unrecognized_declare_rest_param_preserves_whole_register() {
+    // A present but unreadable first param is not "no export param".
+    let source = r#"
+System.register("keep", [], function (_export) {
+  return {
+    execute: function () {
+      _export("value", 1);
+    }
+  };
+});
+System.register("odd", [], function (...args) {
+  return {
+    execute: function () {
+      args[0]("value", 1);
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "rest declare param");
+}
+
+#[test]
+fn unrecognized_declare_destructured_param_preserves_whole_register() {
+    let source = r#"
+System.register("odd", [], function ({ e }) {
+  return {
+    execute: function () {
+      e("value", 1);
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "destructured declare param");
+}
+
+#[test]
+fn unrecognized_declare_default_param_preserves_whole_register() {
+    let source = r#"
+System.register("odd", [], function (e = noop) {
+  return {
+    execute: function () {
+      e("value", 1);
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "defaulted declare param");
+}
+
+#[test]
+fn expression_arrow_setter_stays_fail_closed() {
+    // Expression-body arrows are accepted only on the declare factory.
+    let source = r#"
+System.register("odd", ["./dep.js"], function (_export) {
+  var x;
+  return {
+    setters: [() => (x = m.foo)],
+    execute: function () {
+      _export("value", x);
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "expression-body arrow setter");
 }


### PR DESCRIPTION
## Summary
- Minifiers drop unused `_export`, so declare becomes `function () { … }` or `() => ({ execute() {} })`. `emit_system_module` used `param_sym(..., 0)?`, and `extract_function` rejected expression-body arrows, so the whole input fell back to Plain `System.register`.
- Treat a truly absent first param as optional, same as `_context`. Reconstruct imports and lift `execute`. Do not invent `export`.
- Accept expression-body arrows only on the declare factory (wrap as `return expr`). Shared `extract_function` for setters/execute stays block-body-only.
- A present but unreadable first param (rest / destructure / default) stays fail-closed. Unrecognized setters still fail-closed. A single readable param is still `_export`, never guessed as `_context`. `try_unpack_dynamic_export_bundle` is unchanged.

Related: leftover hole called out as out of scope in #211. Does not recover `e(n)` object re-exports or bare `mod.native` reads.

Please feel free to take it from here if that is easier. Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
System.register("entry", ["./side.js", "./dep.js"], function () {
  var component;
  return {
    setters: [
      null,
      function (module) {
        component = module.component;
      }
    ],
    execute: function () {
      use(component);
    }
  };
});
```

```js
System.register("shell", [], () => ({
  execute() {}
}));
```

`wakaru --unpack` left `System.register` in place. After this change: side-effect + named imports and a lifted `execute`, with no invented `export`. Empty shells unwrap without `export`.

Covered by `no_export_param_*` and the fail-closed rest / destructure / default / expression-arrow-setter cases.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack`
