### PR TITLE
fix(systemjs): reconstruct named setter object re-exports

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -898,17 +898,15 @@ fn collect_imports(
         }
         let module_sym = module_sym?;
         let mut pending_reexports = Vec::new();
-        for stmt in &body.stmts {
-            for part in setter_stmt_parts(stmt, &module_sym, export_sym)? {
-                match part {
-                    SetterPart::Import(local, kind) => match kind {
-                        SetterImportKind::Default => parts.default = Some(local),
-                        SetterImportKind::Named(imported) => parts.named.push((imported, local)),
-                        SetterImportKind::Namespace => parts.namespace = Some(local),
-                    },
-                    SetterPart::Reexport { exported, value } => {
-                        pending_reexports.push((exported, value));
-                    }
+        for part in collect_setter_parts(&body.stmts, &module_sym, export_sym)? {
+            match part {
+                SetterPart::Import(local, kind) => match kind {
+                    SetterImportKind::Default => parts.default = Some(local),
+                    SetterImportKind::Named(imported) => parts.named.push((imported, local)),
+                    SetterImportKind::Namespace => parts.namespace = Some(local),
+                },
+                SetterPart::Reexport { exported, value } => {
+                    pending_reexports.push((exported, value));
                 }
             }
         }
@@ -931,22 +929,243 @@ enum SetterPart {
     Reexport { exported: Atom, value: Box<Expr> },
 }
 
-fn setter_stmt_parts(
-    stmt: &Stmt,
+fn collect_setter_parts(
+    stmts: &[Stmt],
     module_sym: &Atom,
     export_sym: Option<&Atom>,
 ) -> Option<Vec<SetterPart>> {
-    let Stmt::Expr(expr_stmt) = stmt else {
+    let mut parts = Vec::new();
+    let mut temp_name: Option<Atom> = None;
+    let mut temp_pairs: Vec<(Atom, Box<Expr>)> = Vec::new();
+    let mut temp_exported = false;
+    let mut hoisted_temp: Option<Atom> = None;
+
+    for stmt in stmts {
+        if let Some(name) = empty_object_binding(stmt) {
+            // One empty-object temp per setter. A second decl is not a proven shape.
+            // Reusing the module or `_export` ident makes later member matches lie.
+            if temp_name.is_some()
+                || name == *module_sym
+                || export_sym.is_some_and(|export_sym| name == *export_sym)
+            {
+                return None;
+            }
+            temp_name = Some(name);
+            continue;
+        }
+        if let Some(name) = uninitialized_var_binding(stmt) {
+            // Minifiers hoist `var n;` and then write `(n = {}).Foo = module.Foo`.
+            if hoisted_temp.is_some()
+                || temp_name.is_some()
+                || name == *module_sym
+                || export_sym.is_some_and(|export_sym| name == *export_sym)
+            {
+                return None;
+            }
+            hoisted_temp = Some(name);
+            continue;
+        }
+
+        let exprs: Vec<&Expr> = match stmt {
+            Stmt::Expr(expr_stmt) => match expr_stmt.expr.as_ref() {
+                Expr::Seq(seq) => seq.exprs.iter().map(|expr| expr.as_ref()).collect(),
+                expr => vec![expr],
+            },
+            _ => return None,
+        };
+
+        for expr in exprs {
+            if temp_name.is_none() {
+                if let Some(name) = empty_object_ident_assign(expr) {
+                    if !can_start_named_temp(&name, module_sym, export_sym, hoisted_temp.as_ref()) {
+                        return None;
+                    }
+                    temp_name = Some(name);
+                    continue;
+                }
+                if let Some((name, key, value)) = named_temp_assign_with_empty_init(expr) {
+                    if !can_start_named_temp(&name, module_sym, export_sym, hoisted_temp.as_ref()) {
+                        return None;
+                    }
+                    temp_name = Some(name);
+                    temp_pairs.push((key, value));
+                    continue;
+                }
+            }
+
+            if let Some(name) = &temp_name {
+                if !temp_exported {
+                    if let Some(pair) = named_temp_object_assign(expr, name) {
+                        temp_pairs.push(pair);
+                        continue;
+                    }
+                    if is_export_temp_ident(expr, export_sym, name) {
+                        // Setter param shadowing `_export` is a namespace call, not a re-export.
+                        if export_sym.is_some_and(|export_sym| module_sym == export_sym) {
+                            return None;
+                        }
+                        // An empty temp is `_export({})`, which is not a proven setter shape.
+                        if temp_pairs.is_empty() {
+                            return None;
+                        }
+                        for (exported, value) in temp_pairs.drain(..) {
+                            parts.push(SetterPart::Reexport { exported, value });
+                        }
+                        temp_exported = true;
+                        continue;
+                    }
+                }
+            }
+
+            // Rebinding the temp as a setter import is not the named-object spelling.
+            if let Some(name) = &temp_name {
+                if setter_assignment_expr(expr, module_sym).is_some_and(|(local, _)| local == *name)
+                {
+                    return None;
+                }
+            }
+
+            parts.push(setter_expr_part(expr, module_sym, export_sym)?);
+        }
+    }
+
+    if temp_name.is_some() && !temp_exported {
+        return None;
+    }
+    if hoisted_temp.is_some() && temp_name.is_none() {
+        return None;
+    }
+    Some(parts)
+}
+
+fn can_start_named_temp(
+    name: &Atom,
+    module_sym: &Atom,
+    export_sym: Option<&Atom>,
+    hoisted_temp: Option<&Atom>,
+) -> bool {
+    if name == module_sym || export_sym.is_some_and(|export_sym| name == export_sym) {
+        return false;
+    }
+    match hoisted_temp {
+        None => false,
+        Some(hoisted) => hoisted == name,
+    }
+}
+
+fn uninitialized_var_binding(stmt: &Stmt) -> Option<Atom> {
+    let Stmt::Decl(Decl::Var(var)) = stmt else {
         return None;
     };
-    match expr_stmt.expr.as_ref() {
-        Expr::Seq(seq) => seq
-            .exprs
-            .iter()
-            .map(|expr| setter_expr_part(expr.as_ref(), module_sym, export_sym))
-            .collect(),
-        expr => setter_expr_part(expr, module_sym, export_sym).map(|part| vec![part]),
+    if var.decls.len() != 1 {
+        return None;
     }
+    let decl = &var.decls[0];
+    if decl.init.is_some() {
+        return None;
+    }
+    let Pat::Ident(binding) = &decl.name else {
+        return None;
+    };
+    Some(binding.id.sym.clone())
+}
+
+fn empty_object_ident_assign(expr: &Expr) -> Option<Atom> {
+    let Expr::Assign(assign) = expr else {
+        return None;
+    };
+    if assign.op != AssignOp::Assign {
+        return None;
+    }
+    let AssignTarget::Simple(SimpleAssignTarget::Ident(binding)) = &assign.left else {
+        return None;
+    };
+    let Expr::Object(object) = assign.right.as_ref() else {
+        return None;
+    };
+    object.props.is_empty().then(|| binding.id.sym.clone())
+}
+
+fn named_temp_assign_with_empty_init(expr: &Expr) -> Option<(Atom, Atom, Box<Expr>)> {
+    let Expr::Assign(assign) = expr else {
+        return None;
+    };
+    if assign.op != AssignOp::Assign {
+        return None;
+    }
+    let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &assign.left else {
+        return None;
+    };
+    let Expr::Assign(init) = strip_paren_expr(member.obj.as_ref()) else {
+        return None;
+    };
+    if init.op != AssignOp::Assign {
+        return None;
+    }
+    let AssignTarget::Simple(SimpleAssignTarget::Ident(binding)) = &init.left else {
+        return None;
+    };
+    let Expr::Object(object) = init.right.as_ref() else {
+        return None;
+    };
+    if !object.props.is_empty() {
+        return None;
+    }
+    let key = member_prop_name(&member.prop)?;
+    Some((binding.id.sym.clone(), key, assign.right.clone()))
+}
+
+fn empty_object_binding(stmt: &Stmt) -> Option<Atom> {
+    let Stmt::Decl(Decl::Var(var)) = stmt else {
+        return None;
+    };
+    if var.decls.len() != 1 {
+        return None;
+    }
+    let decl = &var.decls[0];
+    let Pat::Ident(binding) = &decl.name else {
+        return None;
+    };
+    let Expr::Object(object) = decl.init.as_deref()? else {
+        return None;
+    };
+    object.props.is_empty().then(|| binding.id.sym.clone())
+}
+
+fn named_temp_object_assign(expr: &Expr, temp: &Atom) -> Option<(Atom, Box<Expr>)> {
+    let Expr::Assign(assign) = expr else {
+        return None;
+    };
+    if assign.op != AssignOp::Assign {
+        return None;
+    }
+    let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &assign.left else {
+        return None;
+    };
+    if !member_obj_ident(member, temp) {
+        return None;
+    }
+    let key = member_prop_name(&member.prop)?;
+    Some((key, assign.right.clone()))
+}
+
+fn is_export_temp_ident(expr: &Expr, export_sym: Option<&Atom>, temp: &Atom) -> bool {
+    let Some(export_sym) = export_sym else {
+        return false;
+    };
+    let Expr::Call(call) = expr else {
+        return false;
+    };
+    let Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    if !matches!(callee.as_ref(), Expr::Ident(id) if id.sym == *export_sym) {
+        return false;
+    }
+    if call.args.len() != 1 || call.args[0].spread.is_some() {
+        return false;
+    }
+    matches!(call.args[0].expr.as_ref(), Expr::Ident(id) if id.sym == *temp)
 }
 
 fn setter_expr_part(

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -2189,6 +2189,576 @@ System.register(["./dep.js"], function (_export, _context) {
     }
 }
 
+fn unpacked_named_module<'a>(pairs: &'a [(String, String)], name: &str) -> &'a str {
+    if pairs.len() == 1 && pairs[0].1.contains("System.register") {
+        panic!(
+            "named setter object must unwrap, not preserve the register:\n{}",
+            pairs[0].1
+        );
+    }
+    module_code(pairs, name)
+}
+
+fn assert_preserves_whole_system_register(source: &str, needle: &str) {
+    let output = unpack_raw(
+        source,
+        &DecompileOptions {
+            filename: "system-bundle.js".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("unrecognized setter must preserve the whole input");
+    assert_eq!(
+        output.modules.len(),
+        1,
+        "unrecognized setter must not emit a partial module set: {:?}",
+        output.modules
+    );
+    assert!(
+        output.modules[0].1.contains("System.register") && output.modules[0].1.contains(needle),
+        "fallback module should preserve the register:\n{}",
+        output.modules[0].1
+    );
+    assert!(
+        output.detected_formats.is_empty(),
+        "unrecognized setter input should not be reported as a successful split"
+    );
+}
+
+#[test]
+fn named_setter_object_reexport_uses_export_from_without_local() {
+    // Minifiers rewrite `_export("Foo", module.Foo)` into an empty object plus
+    // static-key writes, then `_export(ident)`. That is the same proven named
+    // re-export, not a bulk object literal.
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      n.Foo = module.Foo;
+      n["Bar"] = module.Bar;
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert!(
+        !entry.contains("System.register"),
+        "named setter object re-export must unpack:\n{entry}"
+    );
+    assert!(
+        entry.contains(r#"from "dep""#) && entry.contains("Foo") && entry.contains("Bar"),
+        "each static key must become a named export-from:\n{entry}"
+    );
+    assert!(
+        !entry.contains("import {")
+            && !entry.contains("import Foo")
+            && !entry.contains("import Bar"),
+        "must not synthesize a local binding for the re-export:\n{entry}"
+    );
+}
+
+#[test]
+fn named_setter_object_minified_assign_init_is_named_reexport() {
+    // Minifiers emit `(n = {}).Foo = module.Foo` instead of `const n = {}; n.Foo =`.
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      var n;
+      (n = {}).Foo = module.Foo, n.Bar = module.Bar, _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert!(
+        !entry.contains("System.register"),
+        "minified `(n = {{}}).Foo =` must unpack:\n{entry}"
+    );
+    assert!(
+        entry.contains(r#"from "dep""#) && entry.contains("Foo") && entry.contains("Bar"),
+        "minified static keys must stay named re-exports:\n{entry}"
+    );
+    assert!(
+        !entry.contains("import {") && !entry.contains("import Foo"),
+        "must not synthesize a local binding for the re-export:\n{entry}"
+    );
+}
+
+#[test]
+fn named_setter_object_minified_cjs_assign_init() {
+    let source = r#"
+System.register("entry", ["./dep.js", "./loader.js"], function (_export, _context) {
+  var meta, loader;
+  return {
+    setters: [
+      function (module) {
+        var n;
+        meta = module.__cjsMetaURL;
+        (n = {}).default = module.default, n.__cjsMetaURL = module.__cjsMetaURL, _export(n);
+      },
+      function (module) {
+        loader = module.default;
+      }
+    ],
+    execute: function () {
+      loader.require(meta, _context.meta.url);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert!(
+        !entry.contains("System.register"),
+        "minified CJS static-key wrapper must unpack:\n{entry}"
+    );
+    assert!(
+        entry.contains("default") && entry.contains("__cjsMetaURL"),
+        "CJS static keys must keep their names:\n{entry}"
+    );
+    assert!(
+        entry.contains("import.meta.url"),
+        "execute `_context.meta` must become import.meta:\n{entry}"
+    );
+}
+
+#[test]
+fn named_setter_object_comma_assigns_are_named_reexports() {
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      var n = {};
+      n.Foo = module.Foo, n.Bar = module.Bar;
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert!(
+        !entry.contains("System.register"),
+        "comma-assigned static keys must unpack:\n{entry}"
+    );
+    assert!(
+        entry.contains("Foo") && entry.contains("Bar") && entry.contains(r#"from "dep""#),
+        "comma-assigned keys must stay named re-exports:\n{entry}"
+    );
+}
+
+#[test]
+fn named_setter_object_mixed_with_setter_import() {
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  var Type;
+  return {
+    setters: [function (module) {
+      Type = module.Foo;
+      const n = {};
+      n.Bar = module.Bar;
+      _export(n);
+    }],
+    execute: function () {
+      use(Type);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert!(
+        !entry.contains("System.register"),
+        "mixed import + named object must unpack:\n{entry}"
+    );
+    assert!(
+        entry.contains(r#"import { Foo as Type } from "dep""#)
+            || entry.contains(r#"import {Foo as Type} from "dep""#),
+        "the setter assignment must stay a named import:\n{entry}"
+    );
+    assert!(
+        entry.contains(r#"export { Bar } from "dep""#)
+            || entry.contains(r#"export {Bar} from "dep""#),
+        "the object key must stay `export {{ Name }} from`:\n{entry}"
+    );
+    assert!(
+        entry.contains("use(Type)"),
+        "the imported local must remain in execute:\n{entry}"
+    );
+}
+
+#[test]
+fn named_setter_object_reexport_of_assigned_local() {
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  var Type;
+  return {
+    setters: [function (module) {
+      Type = module.Foo;
+      const n = {};
+      n.Foo = Type;
+      _export(n);
+    }],
+    execute: function () {
+      use(Type);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert!(
+        entry.contains("export { Type as Foo }") || entry.contains("export {Type as Foo}"),
+        "re-exporting the setter local through the temp object must stay live:\n{entry}"
+    );
+    assert!(
+        entry.contains("use(Type)"),
+        "the imported local must remain in execute:\n{entry}"
+    );
+}
+
+#[test]
+fn named_setter_object_cjs_static_keys_and_context_meta() {
+    let source = r#"
+System.register("entry", ["./dep.js", "./loader.js"], function (_export, _context) {
+  var meta, loader;
+  return {
+    setters: [
+      function (module) {
+        meta = module.__cjsMetaURL;
+        const i = {};
+        i.default = module.default;
+        i.__cjsMetaURL = module.__cjsMetaURL;
+        _export(i);
+      },
+      function (module) {
+        loader = module.default;
+      }
+    ],
+    execute: function () {
+      if (!meta) {
+        loader.throwInvalidWrapper("./dep.js", _context.meta.url);
+      }
+      loader.require(meta);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert!(
+        !entry.contains("System.register"),
+        "static-key CJS wrapper must unpack:\n{entry}"
+    );
+    assert!(
+        entry.contains("__cjsMetaURL") && entry.contains("default"),
+        "CJS static keys must be re-exported under their original names:\n{entry}"
+    );
+    assert!(
+        entry.contains("import.meta.url"),
+        "execute `_context.meta` must become import.meta:\n{entry}"
+    );
+    assert!(
+        !entry.contains("_context"),
+        "the declare context param must not leak into execute:\n{entry}"
+    );
+}
+
+#[test]
+fn named_setter_object_and_two_arg_export_unwrap_together() {
+    let source = r#"
+System.register("barrel", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      n.Foo = module.Foo;
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+System.register("plain", [], function (_export) {
+  return {
+    execute: function () {
+      _export("X", 1);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let barrel = unpacked_named_module(&raw, "barrel.js");
+    let plain = unpacked_named_module(&raw, "plain.js");
+    assert!(
+        !barrel.contains("System.register") && !plain.contains("System.register"),
+        "both registers must unwrap:\n{barrel}\n{plain}"
+    );
+    assert!(
+        barrel.contains(r#"export { Foo } from "dep""#)
+            || barrel.contains(r#"export {Foo} from "dep""#),
+        "the named object register must become export-from:\n{barrel}"
+    );
+    assert!(
+        plain.contains("export const X = 1") || plain.contains("export {") && plain.contains("X"),
+        "the two-arg `_export` register must still reconstruct:\n{plain}"
+    );
+}
+
+#[test]
+fn named_setter_object_for_in_preserves_whole_register() {
+    // `for-in` copies are `export *` (minus default), not proven named keys.
+    let source = r#"
+System.register("keep", [], function (_export) {
+  return {
+    execute: function () {
+      _export("value", 1);
+    }
+  };
+});
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      for (const p in module) {
+        if (p !== "default") n[p] = module[p];
+      }
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, r#"System.register("keep""#);
+}
+
+#[test]
+fn named_setter_object_unknown_value_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      n.Foo = module.Foo + 1;
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "module.Foo + 1");
+}
+
+#[test]
+fn named_setter_object_literal_value_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      n.Foo = 1;
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "n.Foo = 1");
+}
+
+#[test]
+fn named_setter_object_without_empty_decl_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      n.Foo = module.Foo;
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "_export(n)");
+}
+
+#[test]
+fn named_setter_object_unused_temp_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      n.Foo = module.Foo;
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "const n");
+}
+
+#[test]
+fn named_setter_object_use_after_export_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      n.Foo = module.Foo;
+      _export(n);
+      use(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "use(n)");
+}
+
+#[test]
+fn named_setter_object_computed_key_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      n[key] = module.Foo;
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "n[key]");
+}
+
+#[test]
+fn named_setter_object_export_spread_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      n.Foo = module.Foo;
+      _export(...n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "_export(...n)");
+}
+
+#[test]
+fn named_setter_object_empty_export_preserves_whole_register() {
+    // `_export({})` is not a proven setter shape. An empty temp is the same call.
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "const n");
+}
+
+#[test]
+fn named_setter_object_rebind_before_export_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      var n = {};
+      n = module;
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "n = module");
+}
+
+#[test]
+fn named_setter_object_rebind_after_export_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      var n = {};
+      n.Foo = module.Foo;
+      _export(n);
+      n = module.Bar;
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "n = module.Bar");
+}
+
+#[test]
+fn named_setter_object_temp_shadows_module_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      var module = {};
+      module.Foo = module.Foo;
+      _export(module);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "var module");
+}
+
+#[test]
+fn named_setter_object_shadowed_export_param_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (_export) {
+      const n = {};
+      n.Foo = _export.Foo;
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "_export(n)");
+}
+
+#[test]
+fn named_setter_object_assign_spread_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      const n = {};
+      Object.assign(n, module);
+      _export(n);
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_system_register(source, "Object.assign");
+}
+
 #[test]
 fn default_iife_export_is_parenthesized() {
     // `_export("default", function () {}())` must stay an expression. Without


### PR DESCRIPTION
## Summary
- Minifiers rewrite proven `_export("Name", module.Name)` into an empty object plus static-key writes (`const n = {}; n.Foo = module.Foo; _export(n)` or the hoisted `(n = {}).Foo = …` spelling). `collect_imports` required every setter statement to be a recognized `ExprStmt`, so the empty-object decl fail-closed the whole input to Plain `System.register`.
- Scan a setter as a sequence. Keep the existing import / two-arg `_export` whitelist. Accept one empty-object temp and static-key writes whose RHS is already valid for `apply_setter_reexport`, then lower `_export(ident)` onto the existing live re-export path.
- Assignment-free keys become `export { Name } from "dep"` (no invented `import { Name }`). Mixed setter imports and already-bound locals still work. CJS static keys (`default` / `__cjsMetaURL`) plus `_context.meta.url` are the same shape.
- Stay fail-closed on `for-in`, computed keys, spreads (`_export(...n)` / `Object.assign`), unknown or literal RHS, empty `_export(n)`, missing decl, unused temp, use-after-export, temp rebind, temp/module/`_export` name collisions, and setter-param shadowing. Do not start accepting literal `_export({...})` (`setter_bulk_export_preserves_whole_register` unchanged).

Related: leftover hole called out as out of scope in #211. Independent of #213 (absent `_export` param). Does not recover `for-in` star copies or unused member reads.

Please feel free to take it from here if that is easier. Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
System.register("entry", ["dep"], function (_export) {
  return {
    setters: [function (module) {
      const n = {};
      n.Foo = module.Foo;
      n.Bar = module.Bar;
      _export(n);
    }],
    execute: function () {}
  };
});
```

`wakaru --unpack` left the whole `System.register` untouched. After this change: `export { Foo, Bar } from "dep"` with no invented `import { Foo`.

The minified spelling `var n; (n = {}).Foo = module.Foo, n.Bar = module.Bar, _export(n)` is the same contract.

Covered by `named_setter_object_reexport_uses_export_from_without_local`, `named_setter_object_minified_assign_init_is_named_reexport`, `named_setter_object_mixed_with_setter_import`, `named_setter_object_reexport_of_assigned_local`, `named_setter_object_cjs_static_keys_and_context_meta`, and the fail-closed for-in / unknown-value / spread / empty / rebind / shadowing cases. Existing `setter_bulk_export_preserves_whole_register` is unchanged.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack`
