### PR TITLE
fix(systemjs): reconstruct execute object exports or keep the register

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -5,14 +5,14 @@ use swc_core::common::{
     sync::Lrc, Globals, Mark, SourceMap, Span, SyntaxContext, DUMMY_SP, GLOBALS,
 };
 use swc_core::ecma::ast::{
-    ArrayLit, ArrowExpr, ArrowFunctionBody, AssignExpr, AssignOp, AssignTarget, BindingIdent,
-    CallExpr, Callee, ClassExpr, Decl, EsVersion, ExportDecl, ExportDefaultExpr,
-    ExportNamedSpecifier, ExportSpecifier, Expr, ExprOrSpread, ExprStmt, FnExpr, Function,
-    FunctionBody, Ident, ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier,
-    ImportStarAsSpecifier, Lit, MemberExpr, MemberProp, MetaPropExpr, MetaPropKind, Module,
-    ModuleDecl, ModuleExportName, ModuleItem, NamedExport, ObjectLit, OptChainBase, ParenExpr, Pat,
-    Prop, PropName, PropOrSpread, ReturnStmt, SimpleAssignTarget, Stmt, Str, UnaryOp, VarDecl,
-    VarDeclarator,
+    ArrayLit, ArrowFunctionBody, AssignExpr, AssignOp, AssignTarget, BindingIdent, CallExpr,
+    Callee, ComputedPropName, Decl, EsVersion, ExportDecl, ExportDefaultExpr, ExportNamedSpecifier,
+    ExportSpecifier, Expr, ExprOrSpread, ExprStmt, FnExpr, Function, FunctionBody, Ident,
+    ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier,
+    ImportStarAsSpecifier, KeyValueProp, Lit, MemberExpr, MemberProp, MetaPropExpr, MetaPropKind,
+    Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport, ObjectLit, OptChainBase,
+    ParenExpr, Pat, Prop, PropName, PropOrSpread, ReturnStmt, SimpleAssignTarget, Stmt, Str,
+    UnaryOp, VarDecl, VarDeclarator,
 };
 use swc_core::ecma::codegen::{text_writer::JsWriter, Config, Emitter};
 use swc_core::ecma::transforms::base::resolver;
@@ -353,6 +353,10 @@ fn emit_system_module(
     let body = register.declare.body.as_ref()?;
     let descriptor = extract_register_descriptor(body)?;
     let execute_body = descriptor.execute.body.as_ref()?;
+    let export_call_spans = export_sym
+        .as_ref()
+        .map(|export_sym| collect_export_call_spans(&register.declare, export_sym))
+        .unwrap_or_default();
 
     let imports = collect_imports(&register.deps, &descriptor.setters, export_sym.as_ref())?;
     let imported_locals = imports
@@ -381,20 +385,28 @@ fn emit_system_module(
     let mut module_bound_names = imported_locals.clone();
     collect_lifted_decl_names(&lifted_stmts, &mut module_bound_names);
     let export_name_usage = match export_sym.as_ref() {
-        Some(export_sym) => {
-            collect_export_name_usage(&lifted_stmts, export_sym, &module_bound_names)
-        }
+        Some(export_sym) => collect_export_name_usage(
+            &lifted_stmts,
+            export_sym,
+            &export_call_spans,
+            &module_bound_names,
+        ),
         None => ExportNameUsageSummary {
             mutable: Vec::new(),
             seen: Vec::new(),
         },
     };
-    let mutable_export_names = export_name_usage.mutable;
+    let ExportNameUsageSummary {
+        mutable: mutable_export_names,
+        seen: seen_export_names,
+    } = export_name_usage;
     let mut direct_binding_candidates = match export_sym.as_ref() {
-        Some(export_sym) => collect_member_export_binding_names(&lifted_stmts, export_sym),
+        Some(export_sym) => {
+            collect_member_export_binding_names(&lifted_stmts, export_sym, &export_call_spans)
+        }
         None => HashSet::new(),
     };
-    direct_binding_candidates.extend(export_name_usage.seen.into_iter().filter(|name| {
+    direct_binding_candidates.extend(seen_export_names.into_iter().filter(|name| {
         name.as_ref() != "default"
             && Ident::verify_symbol(name.as_ref()).is_ok()
             && !is_reserved_binding_name(name.as_ref())
@@ -416,6 +428,7 @@ fn emit_system_module(
         module_bound_names,
         unresolved_analysis.names,
         unresolved_analysis.has_direct_eval,
+        export_call_spans,
     );
     items.extend(transformer.prepare_mutable_exports(mutable_export_names));
     for stmt in hoisted {
@@ -433,15 +446,11 @@ fn emit_system_module(
         }
         return None;
     }
-    // Unlowerable top-level object `_export` is dropped, not left as a
-    // free call. A module that still has no *export* surface stays
-    // fail-closed: import alone is not enough (#206 dual). Lone register
-    // → None (Plain fallback); a sibling → original text so
-    // `detect_from_module` does not `?` the rest of the bundle.
-    let unlowerable = transformer.unlowerable_export;
-    let has_export_surface =
-        !transformer.exports.is_empty() || items.iter().any(module_item_is_export);
-    if unlowerable && !has_export_surface {
+    // Any unlowerable top-level object export keeps the register whole. A
+    // reconstructable sibling does not make it safe to drop public names from
+    // the object call. Lone register → None (Plain fallback); a sibling →
+    // original text so `detect_from_module` does not `?` the rest of the bundle.
+    if transformer.unlowerable_export {
         if multiple {
             return original_register_code(register, &cm);
         }
@@ -455,19 +464,6 @@ fn emit_system_module(
         shebang: None,
     };
     emit_module(&module, filename, cm).ok()
-}
-
-fn module_item_is_export(item: &ModuleItem) -> bool {
-    matches!(
-        item,
-        ModuleItem::ModuleDecl(
-            ModuleDecl::ExportDecl(_)
-                | ModuleDecl::ExportNamed(_)
-                | ModuleDecl::ExportDefaultDecl(_)
-                | ModuleDecl::ExportDefaultExpr(_)
-                | ModuleDecl::ExportAll(_)
-        )
-    )
 }
 
 fn original_register_code(register: &SystemRegister, cm: &SourceMap) -> Option<String> {
@@ -698,16 +694,83 @@ struct ExportNameUsageSummary {
     seen: Vec<Atom>,
 }
 
+/// Resolve the original declare function and retain only calls whose callee is
+/// the callback parameter binding. Resolving before lifting the execute body is
+/// important: its locals belong to a nested function in the source and can
+/// shadow the outer callback even though they later become module statements.
+fn collect_export_call_spans(declare: &Function, export_sym: &Atom) -> HashSet<Span> {
+    let globals = Globals::new();
+    GLOBALS.set(&globals, || {
+        let unresolved_mark = Mark::new();
+        let top_level_mark = Mark::new();
+        let mut probe = Module {
+            span: DUMMY_SP,
+            body: vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                span: DUMMY_SP,
+                expr: Box::new(Expr::Fn(FnExpr {
+                    ident: None,
+                    function: Box::new(declare.clone()),
+                })),
+            }))],
+            shebang: None,
+        };
+        probe.visit_mut_with(&mut resolver(unresolved_mark, top_level_mark, false));
+
+        let export_ctxt = match &probe.body[0] {
+            ModuleItem::Stmt(Stmt::Expr(expr_stmt)) => match expr_stmt.expr.as_ref() {
+                Expr::Fn(function) => match &function.function.params[0].pat {
+                    Pat::Ident(binding) => binding.id.ctxt,
+                    _ => unreachable!("the export callback is always an identifier parameter"),
+                },
+                _ => unreachable!("the export probe is always a function expression"),
+            },
+            _ => unreachable!("the export probe always contains one expression statement"),
+        };
+        let mut collector = ExportCallSpanCollector {
+            export_sym,
+            export_ctxt,
+            spans: HashSet::new(),
+        };
+        probe.visit_with(&mut collector);
+        collector.spans
+    })
+}
+
+struct ExportCallSpanCollector<'a> {
+    export_sym: &'a Atom,
+    export_ctxt: SyntaxContext,
+    spans: HashSet<Span>,
+}
+
+impl Visit for ExportCallSpanCollector<'_> {
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if matches!(
+            &call.callee,
+            Callee::Expr(callee)
+                if matches!(
+                    callee.as_ref(),
+                    Expr::Ident(ident)
+                        if ident.sym == *self.export_sym && ident.ctxt == self.export_ctxt
+                )
+        ) {
+            self.spans.insert(call.span);
+        }
+        call.visit_children_with(self);
+    }
+}
+
 /// A repeated SystemJS export can reuse an existing ESM live binding only
 /// when every update is backed by the same module-scope local. Different,
 /// computed, or free values need one canonical mutable binding instead.
 fn collect_export_name_usage(
     stmts: &[Stmt],
     export_sym: &Atom,
+    export_call_spans: &HashSet<Span>,
     module_bound_names: &HashSet<Atom>,
 ) -> ExportNameUsageSummary {
     let mut collector = ExportNameUseCollector {
         export_sym,
+        export_call_spans,
         uses: HashMap::new(),
         order: Vec::new(),
     };
@@ -737,6 +800,7 @@ fn collect_export_name_usage(
 
 struct ExportNameUseCollector<'a> {
     export_sym: &'a Atom,
+    export_call_spans: &'a HashSet<Span>,
     uses: HashMap<Atom, ExportNameUse>,
     order: Vec<Atom>,
 }
@@ -757,24 +821,31 @@ impl ExportNameUseCollector<'_> {
 
 impl Visit for ExportNameUseCollector<'_> {
     fn visit_call_expr(&mut self, call: &CallExpr) {
-        match parse_export_call(call, self.export_sym) {
-            Some(ExportCall::Single { exported, value }) => {
-                self.record(exported, exported_value_local(value.as_ref()));
-            }
-            Some(ExportCall::Bulk(exports)) => {
-                for (exported, value) in exports {
+        if self.export_call_spans.contains(&call.span) {
+            match parse_export_call(call, self.export_sym) {
+                Some(ExportCall::Single { exported, value }) => {
                     self.record(exported, exported_value_local(value.as_ref()));
                 }
+                Some(ExportCall::Bulk(exports)) => {
+                    for (exported, value) in exports {
+                        self.record(exported, exported_value_local(value.as_ref()));
+                    }
+                }
+                None => {}
             }
-            None => {}
         }
         call.visit_children_with(self);
     }
 }
 
-fn collect_member_export_binding_names(stmts: &[Stmt], export_sym: &Atom) -> HashSet<Atom> {
+fn collect_member_export_binding_names(
+    stmts: &[Stmt],
+    export_sym: &Atom,
+    export_call_spans: &HashSet<Span>,
+) -> HashSet<Atom> {
     let mut collector = MemberExportBindingNameCollector {
         export_sym,
+        export_call_spans,
         names: HashSet::new(),
     };
     for stmt in stmts {
@@ -785,6 +856,7 @@ fn collect_member_export_binding_names(stmts: &[Stmt], export_sym: &Atom) -> Has
 
 struct MemberExportBindingNameCollector<'a> {
     export_sym: &'a Atom,
+    export_call_spans: &'a HashSet<Span>,
     names: HashSet<Atom>,
 }
 
@@ -798,6 +870,7 @@ impl Visit for MemberExportBindingNameCollector<'_> {
                 Expr::Call(call) => Some(call),
                 _ => None,
             })
+            .filter(|call| self.export_call_spans.contains(&call.span))
             .and_then(|call| parse_export_call(call, self.export_sym))
             .and_then(|export_call| match export_call {
                 ExportCall::Single { exported, value }
@@ -1301,12 +1374,13 @@ fn setter_assignment_expr(expr: &Expr, module_sym: &Atom) -> Option<(Atom, Sette
 struct MutableExportRewriter<'a> {
     export_sym: Option<&'a Atom>,
     bindings: &'a HashMap<Atom, Atom>,
+    export_call_spans: &'a HashSet<Span>,
 }
 
 impl VisitMut for MutableExportRewriter<'_> {
     fn visit_mut_expr(&mut self, expr: &mut Expr) {
         let replacement = match expr {
-            Expr::Call(call) => {
+            Expr::Call(call) if self.export_call_spans.contains(&call.span) => {
                 parse_optional_export_call(call, self.export_sym).and_then(|export_call| {
                     let ExportCall::Single {
                         exported,
@@ -1344,6 +1418,9 @@ struct SystemExecuteTransformer {
     module_bound_names: HashSet<Atom>,
     unresolved_names: HashSet<Atom>,
     has_direct_eval: bool,
+    /// Calls proven by resolver to target the declare callback, rather than a
+    /// nested binding that happens to have the same minified name.
+    export_call_spans: HashSet<Span>,
     mutable_export_bindings: HashMap<Atom, Atom>,
     /// Side-effect-free live-binding declarations needed by expression-position exports.
     pending_expr_export_decls: Vec<ModuleItem>,
@@ -1352,9 +1429,6 @@ struct SystemExecuteTransformer {
     /// Expression-position object `_export` left in place; the module must
     /// stay fail-closed so the free call is not emitted as ESM.
     leftover_export_call: bool,
-    /// Nested functions that bind the declare `_export` ident. Inner
-    /// `e({` recursive calls must not look like leftover exports (#209).
-    export_shadow_depth: usize,
 }
 
 impl SystemExecuteTransformer {
@@ -1365,6 +1439,7 @@ impl SystemExecuteTransformer {
         module_bound_names: HashSet<Atom>,
         unresolved_names: HashSet<Atom>,
         has_direct_eval: bool,
+        export_call_spans: HashSet<Span>,
     ) -> Self {
         Self {
             export_sym,
@@ -1375,11 +1450,11 @@ impl SystemExecuteTransformer {
             module_bound_names,
             unresolved_names,
             has_direct_eval,
+            export_call_spans,
             mutable_export_bindings: HashMap::new(),
             pending_expr_export_decls: Vec::new(),
             unlowerable_export: false,
             leftover_export_call: false,
-            export_shadow_depth: 0,
         }
     }
 
@@ -1428,6 +1503,7 @@ impl SystemExecuteTransformer {
         let mut mutable_export_rewriter = MutableExportRewriter {
             export_sym: self.export_sym.as_ref(),
             bindings: &self.mutable_export_bindings,
+            export_call_spans: &self.export_call_spans,
         };
         stmt.visit_mut_with(&mut mutable_export_rewriter);
 
@@ -1503,28 +1579,35 @@ impl SystemExecuteTransformer {
     }
 
     fn is_export_callee(&self, call: &CallExpr) -> bool {
-        if self.export_shadow_depth > 0 {
-            return false;
-        }
         let Some(export_sym) = self.export_sym.as_ref() else {
             return false;
         };
-        matches!(
-            &call.callee,
-            Callee::Expr(callee) if matches!(callee.as_ref(), Expr::Ident(id) if id.sym == *export_sym)
-        )
+        self.export_call_spans.contains(&call.span)
+            && matches!(
+                &call.callee,
+                Callee::Expr(callee)
+                    if matches!(callee.as_ref(), Expr::Ident(id) if id.sym == *export_sym)
+            )
+    }
+
+    fn parse_execute_export_call(&self, call: &CallExpr) -> Option<ExportCall> {
+        if !self.is_export_callee(call) {
+            return None;
+        }
+        parse_optional_export_call(call, self.export_sym.as_ref())
     }
 
     /// Lower a top-level `_export(...)`. An unlowerable Bulk / unreadable
-    /// object is dropped (not left as a free call). `_export(n)` and other
-    /// unparsed execute shapes are left in place (`for-in` / `export *`
-    /// stay out of scope). A Single that `export_call_items` cannot take
-    /// is left for `visit_mut_expr`.
+    /// object is consumed and marks the module fail-closed, so the partial ESM
+    /// output is discarded rather than leaving a free call. `_export(n)` and
+    /// other unparsed execute shapes are left in place (`for-in` / `export *`
+    /// stay out of scope). A Single that `export_call_items` cannot take is
+    /// left for `visit_mut_expr`.
     fn take_parsed_export_call(&mut self, call: &CallExpr) -> Option<Vec<ModuleItem>> {
         if !self.is_export_callee(call) {
             return None;
         }
-        match parse_optional_export_call(call, self.export_sym.as_ref()) {
+        match self.parse_execute_export_call(call) {
             Some(ExportCall::Bulk(exports)) => {
                 match self.export_call_items(ExportCall::Bulk(exports)) {
                     Some(items) => Some(items),
@@ -1593,9 +1676,7 @@ impl SystemExecuteTransformer {
         let Expr::Call(call) = member.obj.as_ref() else {
             return None;
         };
-        let ExportCall::Single { exported, value } =
-            parse_optional_export_call(call, self.export_sym.as_ref())?
-        else {
+        let ExportCall::Single { exported, value } = self.parse_execute_export_call(call)? else {
             return None;
         };
 
@@ -1858,7 +1939,7 @@ impl SystemExecuteTransformer {
         let Expr::Call(call) = strip_paren_expr(assign.right.as_ref()) else {
             return None;
         };
-        let export_call = parse_optional_export_call(call, self.export_sym.as_ref())?;
+        let export_call = self.parse_execute_export_call(call)?;
         let (export_items, result) = self.export_call_result_items(export_call)?;
         let mut items = export_items;
         items.push(assign_ident_item(target, result));
@@ -1875,7 +1956,7 @@ impl SystemExecuteTransformer {
         let mut items = Vec::new();
         for (idx, part) in exprs.iter().enumerate() {
             let export_call = match strip_paren_expr(part) {
-                Expr::Call(call) => parse_optional_export_call(call, self.export_sym.as_ref()),
+                Expr::Call(call) => self.parse_execute_export_call(call),
                 _ => None,
             };
             if idx == last_idx {
@@ -2008,7 +2089,7 @@ impl SystemExecuteTransformer {
                     if let Some(ExportCall::Single {
                         exported,
                         mut value,
-                    }) = parse_optional_export_call(call, self.export_sym.as_ref())
+                    }) = self.parse_execute_export_call(call)
                     {
                         value.visit_mut_with(self);
                         self.add_export(local, exported);
@@ -2040,7 +2121,7 @@ impl SystemExecuteTransformer {
         let has_export = seq.exprs.iter().any(|part| {
             matches!(
                 strip_paren_expr(part),
-                Expr::Call(call) if parse_optional_export_call(call, self.export_sym.as_ref()).is_some()
+                Expr::Call(call) if self.parse_execute_export_call(call).is_some()
             )
         });
         has_export.then_some(seq.exprs.as_slice())
@@ -2058,7 +2139,7 @@ impl SystemExecuteTransformer {
         let mut items = Vec::new();
         for (idx, part) in exprs.iter().enumerate() {
             let export_call = match strip_paren_expr(part) {
-                Expr::Call(call) => parse_optional_export_call(call, self.export_sym.as_ref()),
+                Expr::Call(call) => self.parse_execute_export_call(call),
                 _ => None,
             };
             if idx == last_idx {
@@ -2098,8 +2179,7 @@ impl SystemExecuteTransformer {
             let Expr::Call(call) = init.as_ref() else {
                 continue;
             };
-            let Some(ExportCall::Single { exported, value }) =
-                parse_optional_export_call(call, self.export_sym.as_ref())
+            let Some(ExportCall::Single { exported, value }) = self.parse_execute_export_call(call)
             else {
                 continue;
             };
@@ -2160,6 +2240,9 @@ impl SystemExecuteTransformer {
     ) -> Option<Vec<ModuleItem>> {
         value.visit_mut_with(self);
         if let Some(local) = self.mutable_export_bindings.get(&exported).cloned() {
+            if local != exported {
+                value = preserve_bulk_export_inferred_name(&exported, value);
+            }
             return Some(vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
                 span: DUMMY_SP,
                 expr: Box::new(assign_local_expr(local, value)),
@@ -2187,6 +2270,7 @@ impl SystemExecuteTransformer {
             return Some(vec![self.export_const_item(exported, value)]);
         }
         let local = self.fresh_export_name();
+        value = preserve_bulk_export_inferred_name(&exported, value);
         self.declared_exports
             .insert((local.clone(), exported.clone()));
         Some(vec![
@@ -2197,35 +2281,6 @@ impl SystemExecuteTransformer {
 }
 
 impl VisitMut for SystemExecuteTransformer {
-    fn visit_mut_fn_expr(&mut self, node: &mut FnExpr) {
-        let shadows = node
-            .ident
-            .as_ref()
-            .is_some_and(|id| self.is_export_sym(&id.sym));
-        self.with_export_shadow(shadows, |this| node.visit_mut_children_with(this));
-    }
-
-    fn visit_mut_function(&mut self, node: &mut Function) {
-        let shadows = node
-            .params
-            .iter()
-            .any(|param| self.pat_binds_export(&param.pat));
-        self.with_export_shadow(shadows, |this| node.visit_mut_children_with(this));
-    }
-
-    fn visit_mut_arrow_expr(&mut self, node: &mut ArrowExpr) {
-        let shadows = node.params.iter().any(|pat| self.pat_binds_export(pat));
-        self.with_export_shadow(shadows, |this| node.visit_mut_children_with(this));
-    }
-
-    fn visit_mut_class_expr(&mut self, node: &mut ClassExpr) {
-        let shadows = node
-            .ident
-            .as_ref()
-            .is_some_and(|id| self.is_export_sym(&id.sym));
-        self.with_export_shadow(shadows, |this| node.visit_mut_children_with(this));
-    }
-
     fn visit_mut_call_expr(&mut self, call: &mut CallExpr) {
         if self.is_context_import(call) {
             call.callee = Callee::Import(swc_core::ecma::ast::Import {
@@ -2285,27 +2340,6 @@ impl VisitMut for SystemExecuteTransformer {
 }
 
 impl SystemExecuteTransformer {
-    fn is_export_sym(&self, sym: &Atom) -> bool {
-        self.export_sym.as_ref().is_some_and(|export| export == sym)
-    }
-
-    fn pat_binds_export(&self, pat: &Pat) -> bool {
-        let Some(export_sym) = self.export_sym.as_ref() else {
-            return false;
-        };
-        pat_binds_ident(pat, export_sym)
-    }
-
-    fn with_export_shadow(&mut self, shadows: bool, f: impl FnOnce(&mut Self)) {
-        if shadows {
-            self.export_shadow_depth += 1;
-        }
-        f(self);
-        if shadows {
-            self.export_shadow_depth -= 1;
-        }
-    }
-
     fn is_expression_unlowerable_export(&self, call: &CallExpr) -> bool {
         if !self.is_export_callee(call) {
             return false;
@@ -2518,6 +2552,38 @@ fn is_function_or_class_expr(expr: &Expr) -> bool {
     )
 }
 
+/// Object-literal properties perform NamedEvaluation for anonymous functions,
+/// arrows, and classes. When a public export name cannot be used as the local
+/// ESM binding, retain that observable `.name` by evaluating the value through
+/// a computed property with the original key.
+fn preserve_bulk_export_inferred_name(exported: &Atom, value: Box<Expr>) -> Box<Expr> {
+    let is_anonymous = match strip_paren_expr(value.as_ref()) {
+        Expr::Fn(function) => function.ident.is_none(),
+        Expr::Arrow(_) => true,
+        Expr::Class(class) => class.ident.is_none(),
+        _ => false,
+    };
+    if !is_anonymous {
+        return value;
+    }
+
+    let property_key = || ComputedPropName {
+        span: DUMMY_SP,
+        expr: Box::new(Expr::Lit(Lit::Str(make_str(exported.as_ref())))),
+    };
+    Box::new(Expr::Member(MemberExpr {
+        span: DUMMY_SP,
+        obj: Box::new(Expr::Object(ObjectLit {
+            span: DUMMY_SP,
+            props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                key: PropName::Computed(property_key()),
+                value,
+            })))],
+        })),
+        prop: MemberProp::Computed(property_key()),
+    }))
+}
+
 fn emit_exported_value(value: Box<Expr>) -> Box<Expr> {
     Box::new(export_replacement_expr(value))
 }
@@ -2645,14 +2711,6 @@ fn var_declarator_item(var: &VarDecl, decl: VarDeclarator) -> ModuleItem {
         declare: var.declare,
         decls: vec![decl],
     }))))
-}
-
-fn pat_binds_ident(pat: &Pat, sym: &Atom) -> bool {
-    match pat {
-        Pat::Ident(binding) => binding.id.sym == *sym,
-        Pat::Assign(assign) => pat_binds_ident(&assign.left, sym),
-        _ => false,
-    }
 }
 
 fn strip_paren_expr(expr: &Expr) -> &Expr {

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -5,13 +5,14 @@ use swc_core::common::{
     sync::Lrc, Globals, Mark, SourceMap, Span, SyntaxContext, DUMMY_SP, GLOBALS,
 };
 use swc_core::ecma::ast::{
-    ArrayLit, ArrowFunctionBody, AssignExpr, AssignOp, AssignTarget, BindingIdent, CallExpr,
-    Callee, Decl, EsVersion, ExportDecl, ExportDefaultExpr, ExportNamedSpecifier, ExportSpecifier,
-    Expr, ExprOrSpread, ExprStmt, FnExpr, Function, FunctionBody, Ident, ImportDecl,
-    ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier, ImportStarAsSpecifier, Lit,
-    MemberExpr, MemberProp, MetaPropExpr, MetaPropKind, Module, ModuleDecl, ModuleExportName,
-    ModuleItem, NamedExport, ObjectLit, OptChainBase, ParenExpr, Pat, Prop, PropName, PropOrSpread,
-    ReturnStmt, SimpleAssignTarget, Stmt, Str, UnaryOp, VarDecl, VarDeclarator,
+    ArrayLit, ArrowExpr, ArrowFunctionBody, AssignExpr, AssignOp, AssignTarget, BindingIdent,
+    CallExpr, Callee, ClassExpr, Decl, EsVersion, ExportDecl, ExportDefaultExpr,
+    ExportNamedSpecifier, ExportSpecifier, Expr, ExprOrSpread, ExprStmt, FnExpr, Function,
+    FunctionBody, Ident, ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier,
+    ImportStarAsSpecifier, Lit, MemberExpr, MemberProp, MetaPropExpr, MetaPropKind, Module,
+    ModuleDecl, ModuleExportName, ModuleItem, NamedExport, ObjectLit, OptChainBase, ParenExpr, Pat,
+    Prop, PropName, PropOrSpread, ReturnStmt, SimpleAssignTarget, Stmt, Str, UnaryOp, VarDecl,
+    VarDeclarator,
 };
 use swc_core::ecma::codegen::{text_writer::JsWriter, Config, Emitter};
 use swc_core::ecma::transforms::base::resolver;
@@ -64,7 +65,7 @@ pub(super) fn detect_from_module(module: &Module, cm: Lrc<SourceMap>) -> Option<
         }
 
         let filename = filename_for_register(register.name.as_deref(), idx, multiple, &mut seen);
-        let code = emit_system_module(&register, filename.clone(), cm.clone())?;
+        let code = emit_system_module(&register, filename.clone(), cm.clone(), multiple)?;
         let is_entry = idx == 0;
         modules.push(UnpackedModule {
             id: register.name.unwrap_or_else(|| idx.to_string()),
@@ -340,6 +341,7 @@ fn emit_system_module(
     register: &SystemRegister,
     filename: String,
     cm: Lrc<SourceMap>,
+    multiple: bool,
 ) -> Option<String> {
     // Missing `_export` is optional. A present but unreadable first param
     // (rest / destructure / default) stays fail-closed.
@@ -423,6 +425,28 @@ fn emit_system_module(
     for stmt in &execute_body.stmts {
         transformer.push_stmt(stmt.clone(), &mut items);
     }
+    // Expression-position object `_export` cannot be dropped without
+    // changing the value. Keep the register rather than leftover `e({`.
+    if transformer.leftover_export_call {
+        if multiple {
+            return original_register_code(register, &cm);
+        }
+        return None;
+    }
+    // Unlowerable top-level object `_export` is dropped, not left as a
+    // free call. A module that still has no *export* surface stays
+    // fail-closed: import alone is not enough (#206 dual). Lone register
+    // → None (Plain fallback); a sibling → original text so
+    // `detect_from_module` does not `?` the rest of the bundle.
+    let unlowerable = transformer.unlowerable_export;
+    let has_export_surface =
+        !transformer.exports.is_empty() || items.iter().any(module_item_is_export);
+    if unlowerable && !has_export_surface {
+        if multiple {
+            return original_register_code(register, &cm);
+        }
+        return None;
+    }
     items.extend(transformer.export_items());
 
     let module = Module {
@@ -431,6 +455,27 @@ fn emit_system_module(
         shebang: None,
     };
     emit_module(&module, filename, cm).ok()
+}
+
+fn module_item_is_export(item: &ModuleItem) -> bool {
+    matches!(
+        item,
+        ModuleItem::ModuleDecl(
+            ModuleDecl::ExportDecl(_)
+                | ModuleDecl::ExportNamed(_)
+                | ModuleDecl::ExportDefaultDecl(_)
+                | ModuleDecl::ExportDefaultExpr(_)
+                | ModuleDecl::ExportAll(_)
+        )
+    )
+}
+
+fn original_register_code(register: &SystemRegister, cm: &SourceMap) -> Option<String> {
+    let (start, end) = span_byte_range(cm, register.span)?;
+    let file = cm.lookup_byte_offset(register.span.lo).sf;
+    file.src
+        .get(start as usize..end as usize)
+        .map(str::to_string)
 }
 
 struct RegisterDescriptor {
@@ -647,9 +692,9 @@ struct ExportNameUse {
 
 struct ExportNameUsageSummary {
     mutable: Vec<Atom>,
-    /// Every single-exported name in first-seen order. Each of these may
-    /// become a direct ESM binding, so each is a candidate for the free-name
-    /// analysis.
+    /// Every exported name in first-seen order (two-arg and object keys).
+    /// Each of these may become a direct ESM binding, so each is a candidate
+    /// for the free-name analysis.
     seen: Vec<Atom>,
 }
 
@@ -696,21 +741,32 @@ struct ExportNameUseCollector<'a> {
     order: Vec<Atom>,
 }
 
+impl ExportNameUseCollector<'_> {
+    fn record(&mut self, exported: Atom, local: Option<Atom>) {
+        let usage = self.uses.entry(exported.clone()).or_default();
+        if usage.count == 0 {
+            self.order.push(exported);
+            usage.needs_mutable_binding = local.is_none();
+            usage.shared_local = local;
+        } else if usage.shared_local.as_ref() != local.as_ref() {
+            usage.needs_mutable_binding = true;
+        }
+        usage.count += 1;
+    }
+}
+
 impl Visit for ExportNameUseCollector<'_> {
     fn visit_call_expr(&mut self, call: &CallExpr) {
-        if let Some(ExportCall::Single { exported, value }) =
-            parse_export_call(call, self.export_sym)
-        {
-            let local = exported_value_local(value.as_ref());
-            let usage = self.uses.entry(exported.clone()).or_default();
-            if usage.count == 0 {
-                self.order.push(exported);
-                usage.needs_mutable_binding = local.is_none();
-                usage.shared_local = local;
-            } else if usage.shared_local.as_ref() != local.as_ref() {
-                usage.needs_mutable_binding = true;
+        match parse_export_call(call, self.export_sym) {
+            Some(ExportCall::Single { exported, value }) => {
+                self.record(exported, exported_value_local(value.as_ref()));
             }
-            usage.count += 1;
+            Some(ExportCall::Bulk(exports)) => {
+                for (exported, value) in exports {
+                    self.record(exported, exported_value_local(value.as_ref()));
+                }
+            }
+            None => {}
         }
         call.visit_children_with(self);
     }
@@ -1291,6 +1347,14 @@ struct SystemExecuteTransformer {
     mutable_export_bindings: HashMap<Atom, Atom>,
     /// Side-effect-free live-binding declarations needed by expression-position exports.
     pending_expr_export_decls: Vec<ModuleItem>,
+    /// Top-level `_export({...})` that `export_call_items` could not lower.
+    unlowerable_export: bool,
+    /// Expression-position object `_export` left in place; the module must
+    /// stay fail-closed so the free call is not emitted as ESM.
+    leftover_export_call: bool,
+    /// Nested functions that bind the declare `_export` ident. Inner
+    /// `e({` recursive calls must not look like leftover exports (#209).
+    export_shadow_depth: usize,
 }
 
 impl SystemExecuteTransformer {
@@ -1313,6 +1377,9 @@ impl SystemExecuteTransformer {
             has_direct_eval,
             mutable_export_bindings: HashMap::new(),
             pending_expr_export_decls: Vec::new(),
+            unlowerable_export: false,
+            leftover_export_call: false,
+            export_shadow_depth: 0,
         }
     }
 
@@ -1435,15 +1502,56 @@ impl SystemExecuteTransformer {
         ))]
     }
 
+    fn is_export_callee(&self, call: &CallExpr) -> bool {
+        if self.export_shadow_depth > 0 {
+            return false;
+        }
+        let Some(export_sym) = self.export_sym.as_ref() else {
+            return false;
+        };
+        matches!(
+            &call.callee,
+            Callee::Expr(callee) if matches!(callee.as_ref(), Expr::Ident(id) if id.sym == *export_sym)
+        )
+    }
+
+    /// Lower a top-level `_export(...)`. An unlowerable Bulk / unreadable
+    /// object is dropped (not left as a free call). `_export(n)` and other
+    /// unparsed execute shapes are left in place (`for-in` / `export *`
+    /// stay out of scope). A Single that `export_call_items` cannot take
+    /// is left for `visit_mut_expr`.
+    fn take_parsed_export_call(&mut self, call: &CallExpr) -> Option<Vec<ModuleItem>> {
+        if !self.is_export_callee(call) {
+            return None;
+        }
+        match parse_optional_export_call(call, self.export_sym.as_ref()) {
+            Some(ExportCall::Bulk(exports)) => {
+                match self.export_call_items(ExportCall::Bulk(exports)) {
+                    Some(items) => Some(items),
+                    None => {
+                        self.unlowerable_export = true;
+                        Some(Vec::new())
+                    }
+                }
+            }
+            Some(single) => self.export_call_items(single),
+            None => {
+                if export_call_object_arg(call) {
+                    self.unlowerable_export = true;
+                    Some(Vec::new())
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
     fn take_export_stmt(&mut self, stmt: &Stmt) -> Option<Vec<ModuleItem>> {
         let Stmt::Expr(expr_stmt) = stmt else {
             return None;
         };
-        match expr_stmt.expr.as_ref() {
-            Expr::Call(call) => {
-                let export_call = parse_optional_export_call(call, self.export_sym.as_ref())?;
-                self.export_call_items(export_call)
-            }
+        match strip_paren_expr(expr_stmt.expr.as_ref()) {
+            Expr::Call(call) => self.take_parsed_export_call(call),
             Expr::Assign(assign) => self
                 .export_member_assignment_items(assign)
                 .or_else(|| self.take_ident_assign_export(assign)),
@@ -1451,11 +1559,8 @@ impl SystemExecuteTransformer {
                 let mut items = Vec::new();
                 let mut saw_export = false;
                 for expr in &seq.exprs {
-                    let export_items = match expr.as_ref() {
-                        Expr::Call(call) => {
-                            parse_optional_export_call(call, self.export_sym.as_ref())
-                                .and_then(|export_call| self.export_call_items(export_call))
-                        }
+                    let export_items = match strip_paren_expr(expr) {
+                        Expr::Call(call) => self.take_parsed_export_call(call),
                         Expr::Assign(assign) => self
                             .export_member_assignment_items(assign)
                             .or_else(|| self.take_ident_assign_export(assign)),
@@ -1706,18 +1811,36 @@ impl SystemExecuteTransformer {
                 ])
             }
             ExportCall::Bulk(exports) => {
-                let mut assignment_items = Vec::new();
+                // Empty `_export({})` is not a proven execute shape.
+                // Check every pair before committing: a later void 0 must
+                // not leave earlier `add_export` / `export const` in place.
+                if exports.is_empty()
+                    || !exports
+                        .iter()
+                        .all(|(exported, value)| self.bulk_value_is_restorable(exported, value))
+                {
+                    self.unlowerable_export = true;
+                    return None;
+                }
+                let export_len = self.exports.len();
+                let declared_exports = self.declared_exports.clone();
+                let used_names = self.used_names.clone();
+                let module_bound_names = self.module_bound_names.clone();
+                let mut items = Vec::new();
                 for (exported, value) in exports {
-                    let local = exported_value_local(value.as_ref())?;
-                    self.add_export(local, exported);
-                    if exported_value_is_assignment(value.as_ref()) {
-                        assignment_items.push(ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                            span: DUMMY_SP,
-                            expr: value,
-                        })));
+                    match self.lower_bulk_export_value(exported, value) {
+                        Some(part) => items.extend(part),
+                        None => {
+                            self.exports.truncate(export_len);
+                            self.declared_exports = declared_exports;
+                            self.used_names = used_names;
+                            self.module_bound_names = module_bound_names;
+                            self.unlowerable_export = true;
+                            return None;
+                        }
                     }
                 }
-                Some(assignment_items)
+                Some(items)
             }
         }
     }
@@ -1790,7 +1913,13 @@ impl SystemExecuteTransformer {
             single @ ExportCall::Single { .. } => self
                 .export_call_result_items(single)
                 .map(|(items, _)| items),
-            bulk @ ExportCall::Bulk(_) => self.export_call_items(bulk),
+            bulk @ ExportCall::Bulk(_) => match self.export_call_items(bulk) {
+                Some(items) => Some(items),
+                None => {
+                    self.unlowerable_export = true;
+                    Some(Vec::new())
+                }
+            },
         }
     }
 
@@ -1998,9 +2127,105 @@ impl SystemExecuteTransformer {
         }
         self.exports.push(ExportBinding { local, exported });
     }
+
+    /// Ident values must already be module locals. Pretty-printed `undefined`
+    /// and free globals (`window`) are not restorable — that would invent
+    /// `export { undefined as Name }`. Assignments still name the target.
+    fn restorable_bulk_local(&self, value: &Expr) -> Option<Atom> {
+        let local = exported_value_local(value)?;
+        if exported_value_is_assignment(value) || self.module_bound_names.contains(&local) {
+            Some(local)
+        } else {
+            None
+        }
+    }
+
+    fn bulk_value_is_restorable(&self, exported: &Atom, value: &Expr) -> bool {
+        if self.mutable_export_bindings.contains_key(exported) {
+            return true;
+        }
+        if self.restorable_bulk_local(value).is_some() {
+            return true;
+        }
+        is_function_or_class_expr(value) && exported.as_ref() != "default"
+    }
+
+    /// Lower one `_export({ Name: value })` pair. Ident / assign reuse
+    /// `add_export`; anonymous functions reuse `export_const_item`. A name
+    /// already prepared as a live binding becomes an assignment.
+    fn lower_bulk_export_value(
+        &mut self,
+        exported: Atom,
+        mut value: Box<Expr>,
+    ) -> Option<Vec<ModuleItem>> {
+        value.visit_mut_with(self);
+        if let Some(local) = self.mutable_export_bindings.get(&exported).cloned() {
+            return Some(vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                span: DUMMY_SP,
+                expr: Box::new(assign_local_expr(local, value)),
+            }))]);
+        }
+        if let Some(local) = self.restorable_bulk_local(value.as_ref()) {
+            self.add_export(local, exported);
+            if exported_value_is_assignment(value.as_ref()) {
+                return Some(vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                    span: DUMMY_SP,
+                    expr: value,
+                }))]);
+            }
+            return Some(Vec::new());
+        }
+        // Same values Single already binds with `export const`. Keep the
+        // inner function/class ident on the expression (#209), do not hoist it.
+        if !is_function_or_class_expr(value.as_ref()) {
+            return None;
+        }
+        if exported.as_ref() == "default" {
+            return None;
+        }
+        if is_valid_ident_name(exported.as_ref()) && self.can_bind_export_name(&exported) {
+            return Some(vec![self.export_const_item(exported, value)]);
+        }
+        let local = self.fresh_export_name();
+        self.declared_exports
+            .insert((local.clone(), exported.clone()));
+        Some(vec![
+            self.binding_item(local.clone(), value),
+            named_export_item(local, exported),
+        ])
+    }
 }
 
 impl VisitMut for SystemExecuteTransformer {
+    fn visit_mut_fn_expr(&mut self, node: &mut FnExpr) {
+        let shadows = node
+            .ident
+            .as_ref()
+            .is_some_and(|id| self.is_export_sym(&id.sym));
+        self.with_export_shadow(shadows, |this| node.visit_mut_children_with(this));
+    }
+
+    fn visit_mut_function(&mut self, node: &mut Function) {
+        let shadows = node
+            .params
+            .iter()
+            .any(|param| self.pat_binds_export(&param.pat));
+        self.with_export_shadow(shadows, |this| node.visit_mut_children_with(this));
+    }
+
+    fn visit_mut_arrow_expr(&mut self, node: &mut ArrowExpr) {
+        let shadows = node.params.iter().any(|pat| self.pat_binds_export(pat));
+        self.with_export_shadow(shadows, |this| node.visit_mut_children_with(this));
+    }
+
+    fn visit_mut_class_expr(&mut self, node: &mut ClassExpr) {
+        let shadows = node
+            .ident
+            .as_ref()
+            .is_some_and(|id| self.is_export_sym(&id.sym));
+        self.with_export_shadow(shadows, |this| node.visit_mut_children_with(this));
+    }
+
     fn visit_mut_call_expr(&mut self, call: &mut CallExpr) {
         if self.is_context_import(call) {
             call.callee = Callee::Import(swc_core::ecma::ast::Import {
@@ -2023,28 +2248,35 @@ impl VisitMut for SystemExecuteTransformer {
         }
 
         if let Expr::Call(call) = expr {
-            if let Some(ExportCall::Single { exported, value }) =
-                parse_optional_export_call(call, self.export_sym.as_ref())
-            {
-                let mut value = value;
-                value.visit_mut_with(self);
-                if let Some(local) = exported_value_local(value.as_ref()) {
-                    self.add_export(local, exported);
-                    *expr = export_replacement_expr(value);
+            if self.is_export_callee(call) {
+                if let Some(ExportCall::Single { exported, value }) =
+                    parse_optional_export_call(call, self.export_sym.as_ref())
+                {
+                    let mut value = value;
+                    value.visit_mut_with(self);
+                    if let Some(local) = exported_value_local(value.as_ref()) {
+                        self.add_export(local, exported);
+                        *expr = export_replacement_expr(value);
+                        return;
+                    }
+
+                    // Lifting an initialized declaration would evaluate `value`
+                    // before its containing condition, call arguments, or other
+                    // siblings. Lift only a side-effect-free declaration and keep
+                    // the assignment exactly where `_export` appeared.
+                    let (local, declarations) = self.ensure_mutable_export_binding(exported);
+                    self.pending_expr_export_decls.extend(declarations);
+                    *expr = Expr::Paren(ParenExpr {
+                        span: DUMMY_SP,
+                        expr: Box::new(assign_local_expr(local, value)),
+                    });
                     return;
                 }
-
-                // Lifting an initialized declaration would evaluate `value`
-                // before its containing condition, call arguments, or other
-                // siblings. Lift only a side-effect-free declaration and keep
-                // the assignment exactly where `_export` appeared.
-                let (local, declarations) = self.ensure_mutable_export_binding(exported);
-                self.pending_expr_export_decls.extend(declarations);
-                *expr = Expr::Paren(ParenExpr {
-                    span: DUMMY_SP,
-                    expr: Box::new(assign_local_expr(local, value)),
-                });
-                return;
+                // Object `_export` in `&&` / call args / assignment RHS is not a
+                // top-level drop. Mark leftover so emit stays fail-closed.
+                if self.is_expression_unlowerable_export(call) {
+                    self.leftover_export_call = true;
+                }
             }
         }
 
@@ -2053,6 +2285,38 @@ impl VisitMut for SystemExecuteTransformer {
 }
 
 impl SystemExecuteTransformer {
+    fn is_export_sym(&self, sym: &Atom) -> bool {
+        self.export_sym.as_ref().is_some_and(|export| export == sym)
+    }
+
+    fn pat_binds_export(&self, pat: &Pat) -> bool {
+        let Some(export_sym) = self.export_sym.as_ref() else {
+            return false;
+        };
+        pat_binds_ident(pat, export_sym)
+    }
+
+    fn with_export_shadow(&mut self, shadows: bool, f: impl FnOnce(&mut Self)) {
+        if shadows {
+            self.export_shadow_depth += 1;
+        }
+        f(self);
+        if shadows {
+            self.export_shadow_depth -= 1;
+        }
+    }
+
+    fn is_expression_unlowerable_export(&self, call: &CallExpr) -> bool {
+        if !self.is_export_callee(call) {
+            return false;
+        }
+        match parse_optional_export_call(call, self.export_sym.as_ref()) {
+            Some(ExportCall::Bulk(_)) => true,
+            None => export_call_object_arg(call),
+            Some(ExportCall::Single { .. }) => false,
+        }
+    }
+
     fn is_context_import(&self, call: &CallExpr) -> bool {
         let Some(context_sym) = &self.context_sym else {
             return false;
@@ -2183,6 +2447,15 @@ fn parse_optional_export_call(call: &CallExpr, export_sym: Option<&Atom>) -> Opt
     parse_export_call(call, export_sym?)
 }
 
+fn export_call_object_arg(call: &CallExpr) -> bool {
+    call.args.len() == 1
+        && call.args[0].spread.is_none()
+        && matches!(
+            strip_paren_expr(call.args[0].expr.as_ref()),
+            Expr::Object(_)
+        )
+}
+
 fn parse_export_call(call: &CallExpr, export_sym: &Atom) -> Option<ExportCall> {
     let Callee::Expr(callee) = &call.callee else {
         return None;
@@ -2216,6 +2489,14 @@ fn object_export_pairs(object: &ObjectLit) -> Option<Vec<(Atom, Box<Expr>)>> {
         match prop.as_ref() {
             Prop::Shorthand(id) => pairs.push((id.sym.clone(), Box::new(Expr::Ident(id.clone())))),
             Prop::KeyValue(kv) => pairs.push((prop_name(&kv.key)?.into(), kv.value.clone())),
+            // Pretty-printers rewrite `assert: function () {}` as a method.
+            Prop::Method(method) => pairs.push((
+                prop_name(&method.key)?.into(),
+                Box::new(Expr::Fn(FnExpr {
+                    ident: None,
+                    function: method.function.clone(),
+                })),
+            )),
             _ => return None,
         }
     }
@@ -2228,6 +2509,13 @@ fn exported_value_local(expr: &Expr) -> Option<Atom> {
         Expr::Assign(assign) => assign.left.as_simple()?.as_ident().map(|id| id.sym.clone()),
         _ => None,
     }
+}
+
+fn is_function_or_class_expr(expr: &Expr) -> bool {
+    matches!(
+        strip_paren_expr(expr),
+        Expr::Fn(_) | Expr::Arrow(_) | Expr::Class(_)
+    )
 }
 
 fn emit_exported_value(value: Box<Expr>) -> Box<Expr> {
@@ -2357,6 +2645,14 @@ fn var_declarator_item(var: &VarDecl, decl: VarDeclarator) -> ModuleItem {
         declare: var.declare,
         decls: vec![decl],
     }))))
+}
+
+fn pat_binds_ident(pat: &Pat, sym: &Atom) -> bool {
+    match pat {
+        Pat::Ident(binding) => binding.id.sym == *sym,
+        Pat::Assign(assign) => pat_binds_ident(&assign.left, sym),
+        _ => false,
+    }
 }
 
 fn strip_paren_expr(expr: &Expr) -> &Expr {

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -3434,6 +3434,101 @@ System.register("property", [], function (e) {
 }
 
 #[test]
+fn named_function_expression_recursive_calls_do_not_invent_bulk_exports() {
+    // Rollup + Terser can reuse the declare callback's short name for a named
+    // function expression. Its recursive object arguments are ordinary calls,
+    // not SystemJS bulk exports.
+    let source = r#"
+System.register("recurse", [], function (t) {
+  return {
+    execute: function () {
+      t("recurse", function t(e) {
+        if (e.left) return 1 + t({ step: e.step + 1, left: false });
+        if (e.right) return 2 + t({ step: e.step + 2, right: false });
+        return e.step;
+      });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "recurse.js");
+    assert_no_system_register(entry, "named recursive calls with object arguments");
+    assert!(
+        entry.contains("export const recurse ="),
+        "the real two-arg export must reconstruct:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export let step") && !entry.contains("export const step"),
+        "recursive calls must not invent an export named `step`:\n{entry}"
+    );
+    assert!(
+        entry.matches("t({").count() == 2,
+        "both recursive calls must remain calls to the named function:\n{entry}"
+    );
+}
+
+#[test]
+fn mutable_export_rewrite_ignores_named_function_recursive_calls() {
+    // The two real `value` exports prepare a mutable ESM binding. A nested
+    // function reusing the callback's short name must still recurse normally;
+    // the mutable-export pass must not turn its call into `value = 3`.
+    let source = r#"
+System.register("recurse", [], function (t) {
+  return {
+    execute: function () {
+      t("value", 1);
+      t("value", 2);
+      t("recurse", function t(name, value) {
+        if (name === "value") return value;
+        return t("value", 3);
+      });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "recurse.js");
+    assert_no_system_register(entry, "mutable export beside named recursion");
+    assert!(
+        entry.contains("export let value"),
+        "the repeated real export must use one mutable binding:\n{entry}"
+    );
+    assert!(
+        entry.contains("return t(\"value\", 3)") && !entry.contains("return value = 3"),
+        "the shadowed recursive call must not become an export assignment:\n{entry}"
+    );
+}
+
+#[test]
+fn execute_local_function_shadow_is_not_export_callback() {
+    // The execute function is nested under the declare callback. A local with
+    // the same short name shadows that callback even for top-level initializers
+    // that specialized export paths inspect before the general AST visitor.
+    let source = r#"
+System.register("local", [], function (t) {
+  return {
+    execute: function () {
+      function t(name, value) {
+        return value;
+      }
+      var result = t("value", 1);
+      use(result);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "local.js");
+    assert_no_system_register(entry, "execute-local callback shadow");
+    assert_no_invented_export(entry, "execute-local callback shadow");
+    assert!(
+        entry.contains("result = t(\"value\", 1)"),
+        "the call to the local function must remain intact:\n{entry}"
+    );
+}
+
+#[test]
 fn execute_object_export_method_shorthand_is_the_same_shape() {
     // Pretty-printers turn `assert: function () {}` into a method.
     let source = r#"
@@ -3629,6 +3724,10 @@ System.register("odd", [], function (_export) {
         !entry.contains("export {") || entry.contains("\"foo-bar\"") || entry.contains("'foo-bar'"),
         "the public name must stay quoted (#211):\n{entry}"
     );
+    assert!(
+        entry.contains("[\"foo-bar\"]: function") && entry.contains("}[\"foo-bar\"]"),
+        "the alias initializer must preserve the anonymous function's inferred name:\n{entry}"
+    );
 }
 
 #[test]
@@ -3656,6 +3755,10 @@ System.register("odd", [], function (_export) {
     assert!(
         entry.contains("class"),
         "the public name must still be exported:\n{entry}"
+    );
+    assert!(
+        entry.contains("[\"class\"]: function") && entry.contains("}[\"class\"]"),
+        "the alias initializer must preserve the anonymous function's inferred name:\n{entry}"
     );
 }
 
@@ -3972,9 +4075,9 @@ System.register("field", [], function (_export) {
 }
 
 #[test]
-fn execute_object_export_void0_with_imports_keeps_esm() {
-    // descriptor_pb.js: `_export({ Edition: void 0 })` plus setter imports and
-    // later `_export("Name", local)`. Blanket fail-closed would regress esm.
+fn execute_object_export_void0_with_unrelated_export_preserves_whole_register() {
+    // Babel emits dummy bulk exports beside unrelated two-arg exports. Dropping
+    // only the dummy would silently remove a public namespace key.
     let source = r#"
 System.register("desc", ["./message.js"], function (_export) {
   var Message;
@@ -3991,16 +4094,26 @@ System.register("desc", ["./message.js"], function (_export) {
   };
 });
 "#;
-    let raw = unpack_source_raw(source);
-    let entry = module_code(&raw, "desc.js");
-    assert_no_system_register(entry, "void0 bulk beside setter imports");
-    assert_no_leftover_export_call(entry, "void0 bulk beside setter imports");
-    assert!(
-        entry.contains("import") && entry.contains("FileDescriptorProto"),
-        "imports and the reconstructable export must survive:\n{entry}"
-    );
-    assert!(
-        !entry.contains("export let Edition") && !entry.contains("export const Edition"),
-        "the dummy must not be lifted to an export (#206):\n{entry}"
-    );
+    assert_preserves_whole_register(source, "void0 bulk beside unrelated export");
+}
+
+#[test]
+fn execute_object_export_default_bulk_with_later_single_preserves_whole_register() {
+    // Rollup + Terser can group default/named functions into a bulk call and
+    // emit a later primitive as a two-arg export. The unsupported default pair
+    // must not disappear merely because the later export is reconstructable.
+    let source = r#"
+System.register("entry", [], function (t) {
+  return {
+    execute: function () {
+      t({
+        default: function () { return 1; },
+        other: function () { return 2; }
+      });
+      t("value", 3);
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "default bulk beside unrelated export");
 }

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -2992,6 +2992,15 @@ fn assert_no_invented_export(code: &str, label: &str) {
     );
 }
 
+fn assert_no_leftover_export_call(code: &str, label: &str) {
+    // Only the unminified declare name. Scanning `e({` / `t({` false-positives
+    // named function expressions that recurse (#209).
+    assert!(
+        !code.contains("_export(") && !code.contains("_export({"),
+        "{label} must not leave a free `_export` call:\n{code}"
+    );
+}
+
 #[test]
 fn no_export_param_empty_execute_unwraps_without_export() {
     let source = r#"
@@ -3289,4 +3298,709 @@ System.register("odd", ["./dep.js"], function (_export) {
 });
 "#;
     assert_preserves_whole_register(source, "expression-body arrow setter");
+}
+
+#[test]
+fn execute_object_export_of_functions_becomes_named_exports() {
+    // protobuf-ts / engine chunks emit `_export({ assert: function () {} })`.
+    // That is the same contract as `_export("assert", function () {})`.
+    let source = r#"
+System.register("assert", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        assert: function (e, t) {
+          if (!e) throw new Error(t);
+        },
+        assertInt32: function (t) {
+          if (typeof t !== "number") throw new Error("invalid int 32");
+        }
+      });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "assert.js");
+    assert_no_system_register(entry, "execute object export of functions");
+    assert!(
+        entry.contains("export const assert =") && entry.contains("export const assertInt32 ="),
+        "function values must become export const:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export function assert") && !entry.contains("export function assertInt32"),
+        "must not emit export function (Function.name, #204):\n{entry}"
+    );
+    assert_no_leftover_export_call(entry, "execute object export of functions");
+}
+
+#[test]
+fn execute_object_export_mixes_function_and_ident() {
+    // varint.js: `_export({ int64FromString: function () {}, uInt64ToString: n })`.
+    let source = r#"
+System.register("varint", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        foo: function () {
+          return n();
+        },
+        bar: n
+      });
+      function n() {
+        return 1;
+      }
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "varint.js");
+    assert_no_system_register(entry, "execute object export mix");
+    assert!(
+        entry.contains("export const foo ="),
+        "function value must become export const:\n{entry}"
+    );
+    assert!(
+        entry.contains("export { n as bar }")
+            || entry.contains("export {n as bar}")
+            || entry.contains("export {n as bar};"),
+        "ident value must become a named re-export:\n{entry}"
+    );
+}
+
+#[test]
+fn execute_object_export_named_function_value_is_the_same_shape() {
+    // number.js: `_export({ num_to_s: function e(t) { ... } })`.
+    let source = r#"
+System.register("number", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        num_to_s: function e(t) {
+          if (t < 0) return "-" + e(-t);
+          return String(t);
+        },
+        int_to_s: m
+      });
+      function m(t) {
+        return String(t);
+      }
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "number.js");
+    assert_no_system_register(entry, "execute object export named function");
+    assert!(
+        entry.contains("export const num_to_s ="),
+        "named function value must become export const:\n{entry}"
+    );
+    assert!(
+        entry.contains("function e") && entry.contains("e(-t)"),
+        "the inner function ident must stay in expression scope (#209):\n{entry}"
+    );
+    assert!(
+        entry.contains("export { m as int_to_s }")
+            || entry.contains("export {m as int_to_s}")
+            || entry.contains("export {m as int_to_s};"),
+        "ident sibling must still become a named re-export:\n{entry}"
+    );
+}
+
+#[test]
+fn named_function_expression_recursive_call_is_not_leftover_export() {
+    // property.js: `_export("property", function e(t) { return e({ type: void 0 }); })`.
+    let source = r#"
+System.register("property", [], function (e) {
+  return {
+    execute: function () {
+      e("property", function e(t) {
+        if (t == null) return e({ type: void 0 });
+        return t;
+      });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "property.js");
+    assert_no_system_register(entry, "named function recursive call");
+    assert!(
+        entry.contains("export const property ="),
+        "two-arg named function export must reconstruct:\n{entry}"
+    );
+}
+
+#[test]
+fn execute_object_export_method_shorthand_is_the_same_shape() {
+    // Pretty-printers turn `assert: function () {}` into a method.
+    let source = r#"
+System.register("assert", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        assert(e, t) {
+          if (!e) throw new Error(t);
+        }
+      });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "assert.js");
+    assert_no_system_register(entry, "execute object export method shorthand");
+    assert!(
+        entry.contains("export const assert ="),
+        "method shorthand must become export const:\n{entry}"
+    );
+}
+
+#[test]
+fn execute_object_export_sibling_two_arg_still_reconstructs() {
+    let source = r#"
+System.register("plain", [], function (_export) {
+  return {
+    execute: function () {
+      _export("X", 1);
+    }
+  };
+});
+System.register("fns", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        assert: function (e, t) {
+          if (!e) throw new Error(t);
+        }
+      });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let plain = module_code(&raw, "plain.js");
+    let fns = module_code(&raw, "fns.js");
+    assert_no_system_register(plain, "sibling two-arg export");
+    assert_no_system_register(fns, "sibling object export of functions");
+    assert!(
+        plain.contains("export const X = 1"),
+        "two-arg `_export` must still reconstruct:\n{plain}"
+    );
+    assert!(
+        fns.contains("export const assert ="),
+        "object function export must reconstruct next to a two-arg sibling:\n{fns}"
+    );
+}
+
+#[test]
+fn execute_object_export_void0_dummy_only_preserves_whole_register() {
+    // A lone dummy object export is not a proven live binding (#206).
+    let source = r#"
+System.register("field", [], function (_export) {
+  return {
+    execute: function () {
+      _export({ ScalarType: void 0 });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "void 0 dummy only");
+}
+
+#[test]
+fn execute_object_export_undefined_predeclare_preserves_whole_register() {
+    // Pretty-printers rewrite `void 0` to `undefined`. That ident is not a
+    // local and must not become `export { undefined as ScalarType }`.
+    let source = r#"
+System.register("field", [], function (_export) {
+  return {
+    execute: function () {
+      _export({ LongType: undefined, ScalarType: undefined });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "undefined dummy predeclare");
+}
+
+#[test]
+fn execute_object_export_unbound_ident_preserves_whole_register() {
+    // `window` is not a module local. Do not invent `export { window as bar }`.
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({ bar: window });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "unbound ident object export");
+}
+
+#[test]
+fn execute_object_export_void0_dummy_drops_and_keeps_later_singles() {
+    // field.js: drop the dummy object, reconstruct later `_export("Name", {})`.
+    // Do not leave a free `_export({...})` and do not lift the dummy itself.
+    let source = r#"
+System.register("field", [], function (_export) {
+  return {
+    execute: function () {
+      var t, n;
+      _export({ LongType: void 0, ScalarType: void 0 });
+      (function (e) {
+        e[e.DOUBLE = 1] = "DOUBLE";
+      })(t || (t = _export("ScalarType", {})));
+      (function (e) {
+        e[e.BIGINT = 0] = "BIGINT";
+      })(n || (n = _export("LongType", {})));
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "field.js");
+    assert_no_system_register(entry, "void0 dummy plus later singles");
+    assert_no_leftover_export_call(entry, "void0 dummy plus later singles");
+    assert!(
+        entry.contains("ScalarType") && entry.contains("LongType"),
+        "later two-arg fills must reconstruct:\n{entry}"
+    );
+}
+
+#[test]
+fn execute_object_export_computed_key_preserves_whole_register() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({ [key]: function () {} });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "computed key object export");
+}
+
+#[test]
+fn execute_object_export_getter_preserves_whole_register() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        get foo() {
+          return 1;
+        }
+      });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "getter object export");
+}
+
+#[test]
+fn execute_object_export_quoted_name_uses_string_alias() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        "foo-bar": function () {
+          return 1;
+        }
+      });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "odd.js");
+    assert_no_system_register(entry, "quoted object export name");
+    assert!(
+        entry.contains("foo-bar") && (entry.contains("export {") || entry.contains("export{")),
+        "illegal ident must use a string alias:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export {") || entry.contains("\"foo-bar\"") || entry.contains("'foo-bar'"),
+        "the public name must stay quoted (#211):\n{entry}"
+    );
+}
+
+#[test]
+fn execute_object_export_reserved_name_uses_alias() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        class: function () {
+          return 1;
+        }
+      });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "odd.js");
+    assert_no_system_register(entry, "reserved object export name");
+    assert!(
+        !entry.contains("export const class"),
+        "must not bind a reserved word:\n{entry}"
+    );
+    assert!(
+        entry.contains("class"),
+        "the public name must still be exported:\n{entry}"
+    );
+}
+
+#[test]
+fn execute_object_export_mixed_fn_and_void0_preserves_whole_register() {
+    // One unlowerable pair fails the whole object. Do not emit half an export
+    // list plus leftover `_export({ bad: void 0 })`.
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        ok: function () {
+          return 1;
+        },
+        bad: void 0
+      });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "mixed restorable and void 0");
+}
+
+#[test]
+fn execute_object_export_mixed_ident_and_void0_preserves_whole_register() {
+    // Ident pairs call `add_export` before a later void 0 fails. The whole
+    // object must roll back; do not emit `export { n as bar }` alone.
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        bar: n,
+        bad: void 0
+      });
+      function n() {
+        return 1;
+      }
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "mixed ident and void 0");
+}
+
+#[test]
+fn execute_object_export_mixed_assign_and_void0_preserves_whole_register() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      var n;
+      _export({
+        bar: (n = 1),
+        bad: void 0
+      });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "mixed assign and void 0");
+}
+
+#[test]
+fn execute_object_export_same_name_bulk_then_single_uses_live_binding() {
+    // Handbook §3: one public name, one live binding. A Bulk function then
+    // `_export("foo", 2)` must not emit `export const` plus a second export.
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        foo: function () {
+          return 1;
+        }
+      });
+      _export("foo", 2);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert_no_system_register(entry, "bulk then single same name");
+    assert_no_leftover_export_call(entry, "bulk then single same name");
+    assert!(
+        entry.contains("export let foo"),
+        "repeated public name must share one live binding:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export const foo"),
+        "must not emit a second const export for the same name:\n{entry}"
+    );
+    assert_eq!(
+        validate_output_modules(&raw),
+        vec![],
+        "same-name bulk then single must stay legal ESM:\n{entry}"
+    );
+}
+
+#[test]
+fn execute_object_export_in_and_expr_preserves_whole_register() {
+    // Expression-position Bulk is not a top-level drop. Leaving `_export({`
+    // would be illegal ESM; fail-closed instead.
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      cond && _export({
+        foo: function () {
+          return 1;
+        }
+      });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "expression-position object export");
+}
+
+#[test]
+fn execute_object_export_assign_rhs_preserves_whole_register() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      var x;
+      x = _export({
+        foo: function () {
+          return 1;
+        }
+      });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "assignment-rhs object export");
+}
+
+#[test]
+fn execute_object_export_void0_with_import_only_preserves_whole_register() {
+    // Import is not an export surface. Dropping the dummy must not unwrap
+    // a module that never reconstructed a public name (#206 dual).
+    let source = r#"
+System.register("desc", ["./message.js"], function (_export) {
+  var Message;
+  return {
+    setters: [
+      function (m) {
+        Message = m.Message;
+      }
+    ],
+    execute: function () {
+      _export({ Edition: void 0 });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "void0 dummy with import only");
+}
+
+#[test]
+fn execute_object_export_arrow_is_the_same_shape() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        foo: () => 1
+      });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "odd.js");
+    assert_no_system_register(entry, "execute object export of arrow");
+    assert!(
+        entry.contains("export const foo ="),
+        "arrow value must become export const:\n{entry}"
+    );
+    assert_no_leftover_export_call(entry, "execute object export of arrow");
+}
+
+#[test]
+fn execute_object_export_class_is_the_same_shape() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        Foo: class {
+          m() {
+            return 1;
+          }
+        }
+      });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "odd.js");
+    assert_no_system_register(entry, "execute object export of class");
+    assert!(
+        entry.contains("export const Foo ="),
+        "class value must become export const:\n{entry}"
+    );
+    assert!(
+        entry.contains("function m") || entry.contains("m()"),
+        "the class method must stay on the expression:\n{entry}"
+    );
+    assert_no_leftover_export_call(entry, "execute object export of class");
+}
+
+#[test]
+fn execute_object_export_number_literal_preserves_whole_register() {
+    // `_export("foo", 1)` reconstructs; `{ foo: 1 }` is not that proven shape.
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({ foo: 1 });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "object number literal");
+}
+
+#[test]
+fn execute_object_export_default_key_preserves_whole_register() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        default: function () {
+          return 1;
+        }
+      });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "object default key");
+}
+
+#[test]
+fn execute_object_export_empty_preserves_whole_register() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({});
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "empty execute object export");
+}
+
+#[test]
+fn execute_object_export_spread_preserves_whole_register() {
+    let source = r#"
+System.register("odd", [], function (_export) {
+  return {
+    execute: function () {
+      _export({
+        foo: function () {},
+        ...other
+      });
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "spread execute object export");
+}
+
+#[test]
+fn execute_object_export_void0_does_not_fail_sibling_registers() {
+    // Engine bundles mix many registers. One unlowerable `_export({ Name: void 0 })`
+    // must not fail-closed the siblings (leftover-scan used to do that).
+    let source = r#"
+System.register("plain", [], function (_export) {
+  return {
+    execute: function () {
+      _export("X", 1);
+    }
+  };
+});
+System.register("field", [], function (_export) {
+  return {
+    execute: function () {
+      _export({ ScalarType: void 0 });
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let plain = module_code(&raw, "plain.js");
+    let field = module_code(&raw, "field.js");
+    assert_no_system_register(plain, "sibling of unlowerable object export");
+    assert_no_leftover_export_call(plain, "sibling of unlowerable object export");
+    assert!(
+        plain.contains("export const X = 1"),
+        "the reconstructable sibling must stay ESM:\n{plain}"
+    );
+    assert!(
+        field.contains("System.register") && field.contains("void 0"),
+        "the dummy sibling must keep its own register, not leftover ESM:\n{field}"
+    );
+}
+
+#[test]
+fn execute_object_export_void0_with_imports_keeps_esm() {
+    // descriptor_pb.js: `_export({ Edition: void 0 })` plus setter imports and
+    // later `_export("Name", local)`. Blanket fail-closed would regress esm.
+    let source = r#"
+System.register("desc", ["./message.js"], function (_export) {
+  var Message;
+  return {
+    setters: [
+      function (m) {
+        Message = m.Message;
+      }
+    ],
+    execute: function () {
+      _export({ Edition: void 0 });
+      _export("FileDescriptorProto", Message);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "desc.js");
+    assert_no_system_register(entry, "void0 bulk beside setter imports");
+    assert_no_leftover_export_call(entry, "void0 bulk beside setter imports");
+    assert!(
+        entry.contains("import") && entry.contains("FileDescriptorProto"),
+        "imports and the reconstructable export must survive:\n{entry}"
+    );
+    assert!(
+        !entry.contains("export let Edition") && !entry.contains("export const Edition"),
+        "the dummy must not be lifted to an export (#206):\n{entry}"
+    );
 }


### PR DESCRIPTION
## Summary
- `export_call_items`'s `Bulk` arm only accepted idents / assignments. `_export({ Name: function () {} })` (and the pretty-printed method shorthand) aborted the whole call; `push_stmt` still lifted execute, so unpack left a free `_export(` / `e({` with no ESM export.
- That object form is the [SystemJS execute bulk export](https://github.com/systemjs/systemjs/blob/main/docs/system-register.md) — the same contract as two-arg `_export("Name", value)`. Restorable static keys become named ESM (`export const` / `add_export`). Unreadable object `_export` is dropped, not left as a free call. The whole object is checked before commit; one unrestorable pair rolls back (no half `export { n as bar }`). Same-name Bulk then Single reuses the existing live binding (`export let`). Object `_export` in `&&` / assignment RHS fail-closes the module.
- Do not invent exports. Do not promote `void 0` dummies to `export let` (#206). Do not emit `export function` (#204 `Function.name`). Nested functions that shadow the declare `_export` ident are not leftovers (#209). `_export(n)` / non-object arity stay untouched. If dropping the call leaves no export surface (imports do not count): single register → `None`; multi-register → that register's original source.

Related: leftover from #214 (execute side, not setter native). Independent of unused setter member reads. Does not recover `for-in` / `export *` or `_export({ Name: void 0 })` dummy live bindings.

Please feel free to take it from here if that is easier.
Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
System.register("assert", [], function (_export) {
  return {
    execute: function () {
      _export({
        assert: function (e, t) {
          if (!e) throw new Error(t);
        }
      });
    }
  };
});
```

`wakaru --unpack` left an unbound `_export({ assert: function … })` (or pretty-printed `t({ assert() {} })`) with no `export`. After this change: `export const assert = function (e, t) { … }` and no `System.register`.

Dummy-only `_export({ ScalarType: void 0 })` with no later two-arg export stays `System.register`. A dummy followed by `_export("ScalarType", {})` drops the dummy and reconstructs the two-arg call.

Seen from `@protobuf-ts/runtime` and Cocos / SystemJS producers.

Covered by `execute_object_export_of_functions_becomes_named_exports`, `execute_object_export_void0_dummy_only_preserves_whole_register`, `execute_object_export_undefined_predeclare_preserves_whole_register`, `execute_object_export_same_name_bulk_then_single_uses_live_binding`, `execute_object_export_in_and_expr_preserves_whole_register`, and existing `setter_bulk_export_preserves_whole_register`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack`
