### PR TITLE
fix(systemjs): treat unused setter member reads as named imports

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -18,7 +18,7 @@ use swc_core::ecma::codegen::{text_writer::JsWriter, Config, Emitter};
 use swc_core::ecma::transforms::base::resolver;
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
-use crate::js_names::is_reserved_binding_name;
+use crate::js_names::{is_reserved_binding_name, is_valid_identifier_name};
 use crate::unpacker::{span_byte_range, BundleFormat, UnpackResult, UnpackedModule};
 
 pub(super) fn detect_from_module(module: &Module, cm: Lrc<SourceMap>) -> Option<UnpackResult> {
@@ -896,6 +896,8 @@ struct ImportParts {
     default: Option<Atom>,
     namespace: Option<Atom>,
     named: Vec<(Atom, Atom)>,
+    /// Leftover `module.Name` gets. Not the same as `Name = module.Name`.
+    leftover_named: Vec<Atom>,
     /// Live `export { local as Name }` from a setter assignment + `_export`.
     reexports: Vec<(Atom, Atom)>,
     /// `export { imported as Name } from "dep"` — no synthesized local.
@@ -908,11 +910,15 @@ impl ImportParts {
         names.extend(self.default.clone());
         names.extend(self.namespace.clone());
         names.extend(self.named.iter().map(|(_, local)| local.clone()));
+        names.extend(self.leftover_named.iter().cloned());
         names
     }
 
     fn has_import_bindings(&self) -> bool {
-        self.default.is_some() || self.namespace.is_some() || !self.named.is_empty()
+        self.default.is_some()
+            || self.namespace.is_some()
+            || !self.named.is_empty()
+            || !self.leftover_named.is_empty()
     }
 
     fn to_module_items(&self) -> Vec<ModuleItem> {
@@ -969,6 +975,17 @@ impl ImportParts {
                 }),
                 is_type_only: false,
             })
+        }));
+        specifiers.extend(self.leftover_named.iter().filter_map(|imported| {
+            if self.named.iter().any(|(name, _)| name == imported) {
+                return None;
+            }
+            Some(ImportSpecifier::Named(ImportNamedSpecifier {
+                span: DUMMY_SP,
+                local: ident(imported.clone()),
+                imported: None,
+                is_type_only: false,
+            }))
         }));
 
         if !specifiers.is_empty() {
@@ -1031,7 +1048,45 @@ fn collect_imports(
             match part {
                 SetterPart::Import(local, kind) => match kind {
                     SetterImportKind::Default => parts.default = Some(local),
-                    SetterImportKind::Named(imported) => parts.named.push((imported, local)),
+                    SetterImportKind::Named(imported) => {
+                        // An assigned leftover of the same specifier is the
+                        // DCE twin of this write. Drop the leftover get only.
+                        if let Some(idx) = parts
+                            .leftover_named
+                            .iter()
+                            .position(|name| name == &imported)
+                        {
+                            parts.leftover_named.remove(idx);
+                        }
+                        if let Some((_, existing)) =
+                            parts.named.iter().find(|(name, _)| *name == imported)
+                        {
+                            if *existing == local {
+                                // same assigned binding twice
+                            } else if parts.local_names().iter().any(|name| name == &local) {
+                                return None;
+                            } else {
+                                parts.named.push((imported, local));
+                            }
+                        } else if parts.local_names().iter().any(|name| name == &local) {
+                            return None;
+                        } else {
+                            parts.named.push((imported, local));
+                        }
+                    }
+                    SetterImportKind::UnusedNamed(imported) => {
+                        let already = parts.named.iter().any(|(name, _)| name == &imported)
+                            || parts.leftover_named.iter().any(|name| name == &imported);
+                        if already {
+                            // leftover get of an already-imported name
+                        } else if parts.local_names().iter().any(|name| name == &imported) {
+                            // Invented leftover local collides (`module.n`
+                            // beside `n = module.cclegacy`).
+                            return None;
+                        } else {
+                            parts.leftover_named.push(imported);
+                        }
+                    }
                     SetterImportKind::Namespace => parts.namespace = Some(local),
                 },
                 SetterPart::Reexport { exported, value } => {
@@ -1050,6 +1105,8 @@ fn collect_imports(
 enum SetterImportKind {
     Default,
     Named(Atom),
+    /// Terser leftover `module.Name` with no assigned local.
+    UnusedNamed(Atom),
     Namespace,
 }
 
@@ -1305,6 +1362,11 @@ fn setter_expr_part(
     if let Some((local, kind)) = setter_assignment_expr(expr, module_sym) {
         return Some(SetterPart::Import(local, kind));
     }
+    // Terser drops `a = module.Name` but keeps the getter. Recognize that
+    // before requiring `_export`, including factories with no export param.
+    if let Some((local, kind)) = unused_setter_member_import(expr, module_sym) {
+        return Some(SetterPart::Import(local, kind));
+    }
     let export_sym = export_sym?;
     // A setter parameter that shadows `_export` makes `e(...)` a call on the
     // module namespace, not a re-export. Keep the whole module fail-closed.
@@ -1350,6 +1412,25 @@ fn apply_setter_reexport(
         }
         _ => None,
     }
+}
+
+fn unused_setter_member_import(expr: &Expr, module_sym: &Atom) -> Option<(Atom, SetterImportKind)> {
+    let Expr::Member(member) = strip_paren_expr(expr) else {
+        return None;
+    };
+    if !member_obj_ident(member, module_sym) {
+        return None;
+    }
+    let imported = member_prop_name(&member.prop)?;
+    // Unused `module.default` is a default import, not this named shape.
+    // Illegal / reserved keys would print as Ident and emit invalid ESM.
+    if imported.as_ref() == "default"
+        || !is_valid_identifier_name(imported.as_ref())
+        || is_reserved_binding_name(imported.as_ref())
+    {
+        return None;
+    }
+    Some((imported.clone(), SetterImportKind::UnusedNamed(imported)))
 }
 
 fn setter_assignment_expr(expr: &Expr, module_sym: &Atom) -> Option<(Atom, SetterImportKind)> {

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -359,31 +359,37 @@ fn emit_system_module(
         .unwrap_or_default();
 
     let imports = collect_imports(&register.deps, &descriptor.setters, export_sym.as_ref())?;
-    let imported_locals = imports
+    let assigned_import_locals = imports
         .iter()
-        .flat_map(|import| import.local_names())
+        .flat_map(|import| import.assigned_local_names())
         .collect::<HashSet<_>>();
-
-    let mut items = Vec::new();
-    for import in &imports {
-        items.extend(import.to_module_items());
-    }
-    items.extend(register.prelude.iter().cloned().map(ModuleItem::Stmt));
+    let inferred_import_locals = imports
+        .iter()
+        .flat_map(|import| import.leftover_named.iter().cloned())
+        .collect::<Vec<_>>();
 
     let mut used_names = UsedIdentCollector::default();
     register.declare.visit_with(&mut used_names);
     for stmt in &register.prelude {
         stmt.visit_with(&mut used_names);
     }
-    let hoisted = outer_hoisted_stmts(body, &imported_locals);
+    // A leftover member read has lost its original local alias. Do not let
+    // that guessed local hide a real outer declaration before collision
+    // checks have seen it.
+    let hoisted = outer_hoisted_stmts(body, &assigned_import_locals);
     let mut lifted_stmts =
         Vec::with_capacity(register.prelude.len() + hoisted.len() + execute_body.stmts.len());
     lifted_stmts.extend(register.prelude.iter().cloned());
     lifted_stmts.extend(hoisted.iter().cloned());
     lifted_stmts.extend(execute_body.stmts.iter().cloned());
 
-    let mut module_bound_names = imported_locals.clone();
+    let mut module_bound_names = assigned_import_locals;
     collect_lifted_decl_names(&lifted_stmts, &mut module_bound_names);
+    for inferred in &inferred_import_locals {
+        if !module_bound_names.insert(inferred.clone()) {
+            return None;
+        }
+    }
     let export_name_usage = match export_sym.as_ref() {
         Some(export_sym) => collect_export_name_usage(
             &lifted_stmts,
@@ -411,6 +417,7 @@ fn emit_system_module(
             && Ident::verify_symbol(name.as_ref()).is_ok()
             && !is_reserved_binding_name(name.as_ref())
     }));
+    direct_binding_candidates.extend(inferred_import_locals.iter().cloned());
     let unresolved_analysis = if !direct_binding_candidates.is_empty()
         && (direct_binding_candidates
             .iter()
@@ -421,6 +428,19 @@ fn emit_system_module(
     } else {
         UnresolvedNameAnalysis::default()
     };
+    if inferred_import_locals
+        .iter()
+        .any(|name| unresolved_analysis.names.contains(name))
+    {
+        return None;
+    }
+
+    let mut items = Vec::new();
+    for import in &imports {
+        items.extend(import.to_module_items());
+    }
+    items.extend(register.prelude.iter().cloned().map(ModuleItem::Stmt));
+
     let mut transformer = SystemExecuteTransformer::new(
         export_sym,
         context_sym,
@@ -905,11 +925,16 @@ struct ImportParts {
 }
 
 impl ImportParts {
-    fn local_names(&self) -> Vec<Atom> {
+    fn assigned_local_names(&self) -> Vec<Atom> {
         let mut names = Vec::new();
         names.extend(self.default.clone());
         names.extend(self.namespace.clone());
         names.extend(self.named.iter().map(|(_, local)| local.clone()));
+        names
+    }
+
+    fn local_names(&self) -> Vec<Atom> {
+        let mut names = self.assigned_local_names();
         names.extend(self.leftover_named.iter().cloned());
         names
     }

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -4551,3 +4551,77 @@ System.register("odd", ["cc"], function (_export) {
 "#;
     assert_preserves_whole_register(source, "unused setter colliding invented local");
 }
+
+#[test]
+fn unused_setter_member_cross_dependency_collision_preserves_whole_register() {
+    // Babel SystemJS + Terser `pure_getters: false` produces this from:
+    //   import { foo as kept } from "./a.js";
+    //   import { kept as unused } from "./b.js";
+    //   export const result = kept;
+    // The second import has lost its local alias, so `kept` is not free.
+    let source = r#"
+System.register("entry", ["./a.js", "./b.js"], function (_export, _context) {
+  "use strict";
+  var kept;
+  return {
+    setters: [
+      function (_aJs) {
+        kept = _aJs.foo;
+      },
+      function (_bJs) {
+        _bJs.kept;
+      }
+    ],
+    execute: function () {
+      _export("result", kept);
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "cross-dependency inferred import collision");
+}
+
+#[test]
+fn unused_setter_member_lifted_local_collision_preserves_whole_register() {
+    // Babel SystemJS + Terser `pure_getters: false` produces this from:
+    //   import { foo as unused } from "./dep.js";
+    //   let foo = 0;
+    //   globalThis.inc = () => ++foo;
+    // Treating the getter as `import { foo }` would turn `foo = 0` into an
+    // assignment to a read-only import binding.
+    let source = r#"
+System.register("entry", ["./dep.js"], function (_export, _context) {
+  "use strict";
+  var foo;
+  return {
+    setters: [function (_depJs) {
+      _depJs.foo;
+    }],
+    execute: function () {
+      foo = 0, globalThis.inc = () => ++foo;
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "lifted-local inferred import collision");
+}
+
+#[test]
+fn unused_setter_member_free_name_capture_preserves_whole_register() {
+    // The erased local alias is unknowable. Introducing `import { foo }`
+    // must not capture an execute-body reference that was still global.
+    let source = r#"
+System.register("entry", ["./dep.js"], function (_export, _context) {
+  "use strict";
+  return {
+    setters: [function (_depJs) {
+      _depJs.foo;
+    }],
+    execute: function () {
+      globalThis.result = foo;
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "free-name inferred import capture");
+}

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -4117,3 +4117,437 @@ System.register("entry", [], function (t) {
 "#;
     assert_preserves_whole_register(source, "default bulk beside unrelated export");
 }
+
+fn assert_named_import_from(code: &str, spec: &str, source: &str, label: &str) {
+    let spaced = format!(r#"import {{ {spec} }} from "{source}""#);
+    let compact = format!(r#"import {{{spec}}} from "{source}""#);
+    assert!(
+        code.contains(&spaced) || code.contains(&compact),
+        "{label} must reconstruct `{spaced}`:\n{code}"
+    );
+}
+
+fn assert_valid_unpacked_esm(modules: &[(String, String)], label: &str) {
+    assert_eq!(
+        validate_output_modules(modules),
+        vec![],
+        "{label} output must remain valid ESM:\n{}",
+        modules
+            .iter()
+            .map(|(name, code)| format!("// {name}\n{code}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+#[test]
+fn unused_setter_member_read_becomes_named_import() {
+    // Terser drops an unused `a = module.native` left-hand side but keeps the
+    // getter (`pure_getters: false`). That is still `import { native }`.
+    let source = r#"
+System.register("herobdc", ["cc"], function (_export) {
+  var n;
+  return {
+    setters: [function (module) {
+      n = module.cclegacy, module.native;
+    }],
+    execute: function () {
+      n._RF.push({}, "id", "herobdc", undefined);
+      _export("HeroBDC", {});
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "herobdc.js");
+    assert_no_system_register(entry, "unused setter member + assigned sibling");
+    assert_named_import_from(
+        entry,
+        "cclegacy as n, native",
+        "cc",
+        "unused setter member + assigned sibling",
+    );
+    assert!(
+        entry.contains("export const HeroBDC") || entry.contains("as HeroBDC"),
+        "the two-arg execute export must still reconstruct:\n{entry}"
+    );
+    assert_valid_unpacked_esm(&raw, "unused setter member + assigned sibling");
+}
+
+#[test]
+fn unused_setter_member_read_alone_becomes_named_import() {
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      module.foo;
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert_no_system_register(entry, "standalone unused setter member");
+    assert_named_import_from(entry, "foo", "dep", "standalone unused setter member");
+    assert_valid_unpacked_esm(&raw, "standalone unused setter member");
+}
+
+#[test]
+fn unused_setter_member_quoted_key_is_the_same_shape() {
+    let source = r#"
+System.register("entry", ["cc"], function (_export) {
+  var n;
+  return {
+    setters: [function (module) {
+      n = module.cclegacy;
+      module["native"];
+    }],
+    execute: function () {
+      n._RF.push();
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert_no_system_register(entry, "quoted unused setter member");
+    assert_named_import_from(
+        entry,
+        "cclegacy as n, native",
+        "cc",
+        "quoted unused setter member",
+    );
+    assert_valid_unpacked_esm(&raw, "quoted unused setter member");
+}
+
+#[test]
+fn unused_setter_member_after_same_name_assignment_keeps_assigned_local() {
+    // The unused get is the DCE leftover of `a = module.native`. Keep `a`.
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  var a;
+  return {
+    setters: [function (module) {
+      a = module.native, module.native;
+    }],
+    execute: function () {
+      use(a);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert_no_system_register(entry, "assigned then unused same name");
+    assert_named_import_from(
+        entry,
+        "native as a",
+        "dep",
+        "assigned then unused same name",
+    );
+    assert!(
+        !entry.contains("native as a, native") && !entry.contains("native, native"),
+        "must not emit a second specifier for the unused get:\n{entry}"
+    );
+    assert!(
+        entry.contains("use(a)"),
+        "execute must keep the assigned local:\n{entry}"
+    );
+    assert_valid_unpacked_esm(&raw, "assigned then unused same name");
+}
+
+#[test]
+fn unused_setter_member_without_export_param_still_imports() {
+    let source = r#"
+System.register("entry", ["cc"], function () {
+  var n;
+  return {
+    setters: [function (module) {
+      n = module.cclegacy, module.native;
+    }],
+    execute: function () {
+      n._RF.push();
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert_no_system_register(entry, "unused member without export param");
+    assert_named_import_from(
+        entry,
+        "cclegacy as n, native",
+        "cc",
+        "unused member without export param",
+    );
+    assert_no_invented_export(entry, "unused member without export param");
+    assert_valid_unpacked_esm(&raw, "unused member without export param");
+}
+
+#[test]
+fn unused_setter_member_call_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      module.foo();
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "unused setter member call");
+}
+
+#[test]
+fn unused_setter_member_computed_key_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      module[k];
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "unused setter computed member");
+}
+
+#[test]
+fn unused_setter_member_optional_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      module?.foo;
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "unused setter optional member");
+}
+
+#[test]
+fn unused_setter_member_default_preserves_whole_register() {
+    // Unused `module.default` would be a default import, not this named shape.
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      module.default;
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "unused setter default member");
+}
+
+#[test]
+fn unused_setter_member_before_same_name_assignment_keeps_assigned_local() {
+    // Same leftover as assigned-then-unused, opposite comma order.
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  var a;
+  return {
+    setters: [function (module) {
+      module.native, a = module.native;
+    }],
+    execute: function () {
+      use(a);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert_no_system_register(entry, "unused then assigned same name");
+    assert_named_import_from(
+        entry,
+        "native as a",
+        "dep",
+        "unused then assigned same name",
+    );
+    assert!(
+        !entry.contains("native as a, native") && !entry.contains("{ native, native as a }"),
+        "must not emit a second specifier for the unused get:\n{entry}"
+    );
+    assert_valid_unpacked_esm(&raw, "unused then assigned same name");
+}
+
+#[test]
+fn unused_setter_member_eval_still_imports_the_source_local() {
+    // Source was `import { native }`. Restoring that local is the contract,
+    // unlike `export { X } from` which never had a local (#211).
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      module.native;
+    }],
+    execute: function () {
+      eval("native");
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert_no_system_register(entry, "unused member visible to eval");
+    assert_named_import_from(entry, "native", "dep", "unused member visible to eval");
+    assert!(
+        entry.contains("eval("),
+        "direct eval in execute must remain:\n{entry}"
+    );
+    assert_valid_unpacked_esm(&raw, "unused member visible to eval");
+}
+
+#[test]
+fn two_assigned_locals_for_same_imported_both_stay() {
+    // Dedup is only for the unused leftover get, not a second assigned alias.
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  var a, b;
+  return {
+    setters: [function (module) {
+      a = module.native, b = module.native;
+    }],
+    execute: function () {
+      use(a, b);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert_no_system_register(entry, "two assigned locals same imported");
+    assert_named_import_from(
+        entry,
+        "native as a, native as b",
+        "dep",
+        "two assigned locals same imported",
+    );
+    assert!(
+        entry.contains("use(a, b)") || entry.contains("use(a,b)"),
+        "both assigned locals must remain in execute:\n{entry}"
+    );
+    assert_valid_unpacked_esm(&raw, "two assigned locals same imported");
+}
+
+#[test]
+fn assigned_identity_alias_beside_renamed_alias_both_stay() {
+    // `native = module.native` is an assigned import, not a leftover get.
+    // Dedup must not treat `local == imported` as unused.
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  var a, native;
+  return {
+    setters: [function (module) {
+      a = module.native, native = module.native;
+    }],
+    execute: function () {
+      use(a, native);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert_no_system_register(entry, "identity assign after renamed alias");
+    assert_named_import_from(
+        entry,
+        "native as a, native",
+        "dep",
+        "identity assign after renamed alias",
+    );
+    assert!(
+        entry.contains("use(a, native)") || entry.contains("use(a,native)"),
+        "both assigned locals must remain in execute:\n{entry}"
+    );
+    assert_valid_unpacked_esm(&raw, "identity assign after renamed alias");
+}
+
+#[test]
+fn assigned_identity_alias_before_renamed_alias_both_stay() {
+    let source = r#"
+System.register("entry", ["dep"], function (_export) {
+  var a, native;
+  return {
+    setters: [function (module) {
+      native = module.native, a = module.native;
+    }],
+    execute: function () {
+      use(a, native);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = unpacked_named_module(&raw, "entry.js");
+    assert_no_system_register(entry, "identity assign before renamed alias");
+    assert_named_import_from(
+        entry,
+        "native, native as a",
+        "dep",
+        "identity assign before renamed alias",
+    );
+    assert!(
+        entry.contains("use(a, native)") || entry.contains("use(a,native)"),
+        "both assigned locals must remain in execute:\n{entry}"
+    );
+    assert_valid_unpacked_esm(&raw, "identity assign before renamed alias");
+}
+
+#[test]
+fn unused_setter_member_reserved_key_preserves_whole_register() {
+    // Member `class` is an IdentifierName. Binding it as `import { class }`
+    // (or a sanitized local with Ident imported) is illegal ESM.
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      module.class;
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "unused setter reserved member");
+}
+
+#[test]
+fn unused_setter_member_invalid_quoted_key_preserves_whole_register() {
+    let source = r#"
+System.register("odd", ["dep"], function (_export) {
+  return {
+    setters: [function (module) {
+      module["foo-bar"];
+    }],
+    execute: function () {}
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "unused setter invalid quoted member");
+}
+
+#[test]
+fn unused_setter_member_colliding_local_preserves_whole_register() {
+    // Inventing `import { n }` beside `import { cclegacy as n }` is illegal.
+    let source = r#"
+System.register("odd", ["cc"], function (_export) {
+  var n;
+  return {
+    setters: [function (module) {
+      n = module.cclegacy, module.n;
+    }],
+    execute: function () {
+      n._RF.push();
+    }
+  };
+});
+"#;
+    assert_preserves_whole_register(source, "unused setter colliding invented local");
+}


### PR DESCRIPTION
## Summary
- `setter_expr_part` only accepted assignments and two-arg `_export`. A leftover `module.Name` (Terser dropped the unused `a = module.Name` left-hand side; `pure_getters: false` keeps the getter) returned `None`, so `collect_imports` fail-closed the whole register.
- This PR treats a static `module.Name` / `module["Name"]` read as `SetterImportKind::UnusedNamed` and emits the same named import as `local = module.Name`. Assigned aliases stay on `Named`; leftover gets are not inferred from `local == imported`.
- No invented export. Unreadable keys (`default`, reserved, `foo-bar`), calls, optional chaining, computed non-string keys, and leftover locals that collide with an existing import stay fail-closed.

Related: leftover from #214 (unused setter member reads). Independent of #215 (execute object `_export`). Does not recover `for-in` / `export *` or unused `module.default`.

Please feel free to take it from here if that is easier.
Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
System.register("entry", ["cc"], function (_export) {
  var n;
  return {
    setters: [function (module) {
      n = module.cclegacy, module.native;
    }],
    execute: function () {
      _export("Widget", {});
    }
  };
});
```

`wakaru --unpack` keeps the whole `System.register`. After this change: `import { cclegacy as n, native } from "cc"` plus the two-arg execute export, no register.

A standalone `module.foo` becomes `import { foo } from "dep"`. `a = module.native, module.native` keeps `import { native as a }`. `a = module.native, native = module.native` keeps both assigned locals.

Covered by `unused_setter_member_read_becomes_named_import`, `unused_setter_member_reserved_key_preserves_whole_register`, `assigned_identity_alias_beside_renamed_alias_both_stay`, and existing `setter_bulk_export_preserves_whole_register`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack`
