### PR TITLE
test(systemjs): keep shadowed execute callback calls off the export path

### DIFF
--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -3529,6 +3529,87 @@ System.register("local", [], function (t) {
 }
 
 #[test]
+fn nested_fn_expr_param_is_not_string_export() {
+    // A nested callback parameter can reuse the factory `_export` short name.
+    // That inner call is an ordinary argument, not an export. A same-named
+    // execute local must not be rewritten to the imported binding.
+    let source = r#"
+System.register("widget", ["./helpers.js"], function (e) {
+  var n, t;
+  return {
+    setters: [function (mod) {
+      n = mod.helper;
+    }],
+    execute: function () {
+      e("Widget", function () {});
+      t = {};
+      t.update = function () {
+        var n = "01:00";
+        this.label.setByFunc(function (e) {
+          return t.prefix + "\n\n" + e("MESSAGE_KEY", n);
+        });
+      };
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "widget.js");
+    assert_no_system_register(entry, "nested fn-expr param shadow");
+    assert!(
+        entry.contains("export") && (entry.contains("Widget") || entry.contains("widget")),
+        "the real two-arg export must reconstruct:\n{entry}"
+    );
+    assert!(
+        !entry.contains("as MESSAGE_KEY") && !entry.contains("export const MESSAGE_KEY"),
+        "the shadowed callback call must not become an export:\n{entry}"
+    );
+    assert!(
+        entry.contains("e(\"MESSAGE_KEY\", n)") || entry.contains("e('MESSAGE_KEY', n)"),
+        "the inner call must remain a call:\n{entry}"
+    );
+}
+
+#[test]
+fn nested_arrow_param_is_not_string_export() {
+    // Same contract as a function-expression parameter: an arrow parameter that
+    // reuses the factory short name is not the export callback.
+    let source = r#"
+System.register("widget", ["./helpers.js"], function (e) {
+  var n, t;
+  return {
+    setters: [function (mod) {
+      n = mod.helper;
+    }],
+    execute: function () {
+      e("Widget", function () {});
+      t = {};
+      t.update = function () {
+        var n = "01:00";
+        this.label.setByFunc((e) => t.prefix + "\n\n" + e("MESSAGE_KEY", n));
+      };
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "widget.js");
+    assert_no_system_register(entry, "nested arrow param shadow");
+    assert!(
+        entry.contains("export") && (entry.contains("Widget") || entry.contains("widget")),
+        "the real two-arg export must reconstruct:\n{entry}"
+    );
+    assert!(
+        !entry.contains("as MESSAGE_KEY") && !entry.contains("export const MESSAGE_KEY"),
+        "the shadowed callback call must not become an export:\n{entry}"
+    );
+    assert!(
+        entry.contains("e(\"MESSAGE_KEY\", n)") || entry.contains("e('MESSAGE_KEY', n)"),
+        "the inner call must remain a call:\n{entry}"
+    );
+}
+
+#[test]
 fn execute_object_export_method_shorthand_is_the_same_shape() {
     // Pretty-printers turn `assert: function () {}` into a method.
     let source = r#"


### PR DESCRIPTION
## Summary

- In v1.10.0, execute lowering treats a two-arg call as `_export` when the callee spelling matches the factory parameter (`id.sym == export_sym`). After minification that name is usually `e`. A nested callback can reuse the same short name as its own parameter. That inner `e("KEY", value)` is an ordinary call, not the SystemJS export API. v1.10.0 still rewrites it, then binds the value ident to a module-top local of the same spelling (often an import). The observable damage is an invented named export and a stripped call site.
- `badefc29` (the #215 follow-up) already closed this class of hole: before lifting execute, it clones the declare function, runs SWC `resolver`, records call spans whose callee has the factory parameter `SyntaxContext`, and `is_export_callee` requires that span **and** the short name. A nested `function (e)` / arrow parameter is a different binding, so those calls stay calls.
- Existing tests lock function-declaration shadowing (`execute_local_function_shadow_is_not_export_callback`) and named recursion / object bulk. They do not lock an anonymous function-expression or arrow parameter plus a two-arg string call plus an import local that collides with the value ident. This PR adds those two cases only.
- No change to `systemjs.rs`. The new tests fail on v1.10.0 (`export { n as MESSAGE_KEY }`, call rewritten to a bare `n`) and pass on current `main` without touching export matching. This is a leftover regression lock from #215, not a second rewrite.
- Does not invent export. Does not change setter / Bulk / `export *` / `for-in`. Unrecognized shapes stay fail-closed.

Related: leftover from #215 follow-up. Independent of #216. Does not recover unused setter member reads.

Please feel free to take it from here if that is easier.
Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Why v1.10.0 mis-fires

SystemJS contract: the factory first parameter is `_export`; calls to that binding in `execute` are exports. After minify everyone is `e`. Matching by spelling alone cannot tell:

1. factory `_export` (`e`)
2. a nested callback parameter also named `e`
3. an execute-local `n` vs a setter import also named `n`

Setter already fail-closes when `module_sym == export_sym` (a namespace call, not a re-export). Execute had no equivalent for an extra nested `function (e)`. Once the inner call is taken as `_export("MESSAGE_KEY", n)`, the value ident is resolved against lifted module scope and becomes the import.

This is not binding analysis failing so two `e`s look like one. The AST already has two Idents. The old path never asked the resolver / `SyntaxContext`; same spelling meant same callee.

The #215 follow-up already fixed the matching rule. What was still missing is a lock for the anonymous callback + string-key + import-collision shape. A function **declaration** shadow is already tested; an anonymous `function (e)` / `(e) =>` parameter is the leftover.

## Reproduce

```javascript
System.register("widget", ["./helpers.js"], function (e) {
  var n, t;
  return {
    setters: [function (mod) {
      n = mod.helper;
    }],
    execute: function () {
      e("Widget", function () {});
      t = {};
      t.update = function () {
        var n = "01:00";
        this.label.setByFunc(function (e) {
          return t.prefix + "\n\n" + e("MESSAGE_KEY", n);
        });
      };
    }
  };
});
```

`wakaru --unpack` on v1.10.0:

```javascript
export const Widget = function () {};
this.label.setByFunc((e) => t.prefix + "\n\n" + n);
export { n as MESSAGE_KEY };
```

After `badefc29` / this branch:

- `Widget` is still a real export (the factory `e` call).
- `e("MESSAGE_KEY", n)` remains a call on the callback parameter.
- There is no `MESSAGE_KEY` export.
- The inner `n` is the execute-local countdown, not the imported `helper`.

Same contract with an arrow parameter: `(e) => e("MESSAGE_KEY", n)`.

Covered by `nested_fn_expr_param_is_not_string_export`, `nested_arrow_param_is_not_string_export`, and existing `execute_local_function_shadow_is_not_export_callback` / `setter_param_shadowing_export_preserves_whole_register`.

## What this PR changes

Tests only, in `crates/core/tests/systemjs_unpack.rs`:

1. Anonymous function-expression parameter shadows factory `e`, two-arg string call, setter import also named `n`.
2. The same shape with an arrow parameter.

Both assert: real two-arg export still lowers; the shadowed call is not rewritten; no invented `export { n as MESSAGE_KEY }`.

## What this does not change

- `systemjs.rs` export matching (already `resolver` + call-span on `main`).
- Setter `module_sym == export_sym` fail-closed (already tested).
- Object / bulk `_export` (already #215).
- Unused setter member reads (#216).
- `for-in` / `_export(n)` / `export *`.
- CHANGELOG (left for the next release).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace` (4010 passed, 2 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack` (143; the two new tests fail on v1.10.0 and pass on current main)
