### PR TITLE
fix(systemjs): parenthesize enum IIFE after object live-binding

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -5,10 +5,10 @@ use swc_core::common::{
     sync::Lrc, Globals, Mark, SourceMap, Span, SyntaxContext, DUMMY_SP, GLOBALS,
 };
 use swc_core::ecma::ast::{
-    ArrayLit, ArrowFunctionBody, AssignExpr, AssignOp, AssignTarget, BindingIdent, CallExpr,
-    Callee, ComputedPropName, Decl, EsVersion, ExportDecl, ExportDefaultExpr, ExportNamedSpecifier,
-    ExportSpecifier, Expr, ExprOrSpread, ExprStmt, FnExpr, Function, FunctionBody, Ident,
-    ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier,
+    ArrayLit, ArrowFunctionBody, AssignExpr, AssignOp, AssignTarget, AssignTargetPat, BindingIdent,
+    CallExpr, Callee, ComputedPropName, Decl, EsVersion, ExportDecl, ExportDefaultExpr,
+    ExportNamedSpecifier, ExportSpecifier, Expr, ExprOrSpread, ExprStmt, FnExpr, Function,
+    FunctionBody, Ident, ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier,
     ImportStarAsSpecifier, KeyValueProp, Lit, MemberExpr, MemberProp, MetaPropExpr, MetaPropKind,
     Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport, ObjectLit, OptChainBase,
     ParenExpr, Pat, Prop, PropName, PropOrSpread, ReturnStmt, SimpleAssignTarget, Stmt, Str,
@@ -2740,15 +2740,14 @@ fn exported_value_is_assignment(expr: &Expr) -> bool {
     matches!(strip_paren_expr(expr), Expr::Assign(_))
 }
 
-// Comma-sequence leftovers become statements. A function-callee IIFE is
-// legal in expression position and a SyntaxError as `function () {}()`.
+// A comma-sequence operand is already in expression context. Once lifted to a
+// statement, a function/class/object-headed expression can be reinterpreted as
+// a declaration or block, and a leading string can become a directive.
 fn parenthesize_lifted_stmt_expr(stmt: &mut Stmt) {
     let Stmt::Expr(expr_stmt) = stmt else {
         return;
     };
-    if !is_function_callee_iife(expr_stmt.expr.as_ref())
-        && !starts_with_function_or_class(expr_stmt.expr.as_ref())
-    {
+    if !lifted_stmt_expr_needs_parens(expr_stmt.expr.as_ref()) {
         return;
     }
     let inner = expr_stmt.expr.clone();
@@ -2756,6 +2755,95 @@ fn parenthesize_lifted_stmt_expr(stmt: &mut Stmt) {
         span: DUMMY_SP,
         expr: inner,
     });
+}
+
+fn lifted_stmt_expr_needs_parens(expr: &Expr) -> bool {
+    let mut unwrapped = expr;
+    while let Expr::Paren(paren) = unwrapped {
+        unwrapped = paren.expr.as_ref();
+    }
+    matches!(unwrapped, Expr::Lit(Lit::Str(_))) || starts_with_forbidden_stmt_head(expr)
+}
+
+fn starts_with_forbidden_stmt_head(expr: &Expr) -> bool {
+    match expr {
+        Expr::Fn(_) | Expr::Class(_) | Expr::Object(_) => true,
+        Expr::Bin(binary) => starts_with_forbidden_stmt_head(binary.left.as_ref()),
+        Expr::Call(call) => matches!(
+            &call.callee,
+            Callee::Expr(callee) if starts_with_forbidden_stmt_head(callee.as_ref())
+        ),
+        Expr::Member(member) => starts_with_forbidden_stmt_head(member.obj.as_ref()),
+        Expr::Cond(condition) => starts_with_forbidden_stmt_head(condition.test.as_ref()),
+        Expr::Seq(sequence) => sequence
+            .exprs
+            .first()
+            .is_some_and(|first| starts_with_forbidden_stmt_head(first.as_ref())),
+        Expr::TaggedTpl(tagged) => starts_with_forbidden_stmt_head(tagged.tag.as_ref()),
+        Expr::Assign(assign) => assign_target_starts_with_forbidden_stmt_head(&assign.left),
+        Expr::OptChain(chain) => match chain.base.as_ref() {
+            OptChainBase::Member(member) => starts_with_forbidden_stmt_head(member.obj.as_ref()),
+            OptChainBase::Call(call) => starts_with_forbidden_stmt_head(call.callee.as_ref()),
+        },
+        Expr::Update(update) if !update.prefix => {
+            starts_with_forbidden_stmt_head(update.arg.as_ref())
+        }
+        // Add one defensive layer even when the source supplied parentheses:
+        // the later SWC fixer may remove the original layer as redundant.
+        Expr::Paren(paren) => starts_with_forbidden_stmt_head(paren.expr.as_ref()),
+        Expr::TsAs(as_expr) => starts_with_forbidden_stmt_head(as_expr.expr.as_ref()),
+        Expr::TsConstAssertion(assertion) => {
+            starts_with_forbidden_stmt_head(assertion.expr.as_ref())
+        }
+        Expr::TsTypeAssertion(assertion) => {
+            starts_with_forbidden_stmt_head(assertion.expr.as_ref())
+        }
+        Expr::TsNonNull(non_null) => starts_with_forbidden_stmt_head(non_null.expr.as_ref()),
+        Expr::TsInstantiation(instantiation) => {
+            starts_with_forbidden_stmt_head(instantiation.expr.as_ref())
+        }
+        Expr::TsSatisfies(satisfies) => starts_with_forbidden_stmt_head(satisfies.expr.as_ref()),
+        _ => false,
+    }
+}
+
+fn assign_target_starts_with_forbidden_stmt_head(target: &AssignTarget) -> bool {
+    match target {
+        AssignTarget::Pat(AssignTargetPat::Object(_)) => true,
+        AssignTarget::Pat(_) => false,
+        AssignTarget::Simple(target) => match target {
+            SimpleAssignTarget::Member(member) => {
+                starts_with_forbidden_stmt_head(member.obj.as_ref())
+            }
+            SimpleAssignTarget::OptChain(chain) => match chain.base.as_ref() {
+                OptChainBase::Member(member) => {
+                    starts_with_forbidden_stmt_head(member.obj.as_ref())
+                }
+                OptChainBase::Call(call) => starts_with_forbidden_stmt_head(call.callee.as_ref()),
+            },
+            SimpleAssignTarget::Paren(paren) => {
+                starts_with_forbidden_stmt_head(paren.expr.as_ref())
+            }
+            SimpleAssignTarget::TsAs(as_expr) => {
+                starts_with_forbidden_stmt_head(as_expr.expr.as_ref())
+            }
+            SimpleAssignTarget::TsSatisfies(satisfies) => {
+                starts_with_forbidden_stmt_head(satisfies.expr.as_ref())
+            }
+            SimpleAssignTarget::TsNonNull(non_null) => {
+                starts_with_forbidden_stmt_head(non_null.expr.as_ref())
+            }
+            SimpleAssignTarget::TsTypeAssertion(assertion) => {
+                starts_with_forbidden_stmt_head(assertion.expr.as_ref())
+            }
+            SimpleAssignTarget::TsInstantiation(instantiation) => {
+                starts_with_forbidden_stmt_head(instantiation.expr.as_ref())
+            }
+            SimpleAssignTarget::Ident(_)
+            | SimpleAssignTarget::SuperProp(_)
+            | SimpleAssignTarget::Invalid(_) => false,
+        },
+    }
 }
 
 fn export_replacement_expr(value: Box<Expr>) -> Expr {

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -1764,6 +1764,7 @@ impl SystemExecuteTransformer {
                             expr: expr.clone(),
                         });
                         stmt.visit_mut_with(self);
+                        parenthesize_lifted_stmt_expr(&mut stmt);
                         items.extend(self.take_pending_expr_export_decls());
                         items.push(ModuleItem::Stmt(stmt));
                     }
@@ -2090,6 +2091,7 @@ impl SystemExecuteTransformer {
                 expr: part.clone(),
             });
             stmt.visit_mut_with(self);
+            parenthesize_lifted_stmt_expr(&mut stmt);
             items.push(ModuleItem::Stmt(stmt));
         }
         None
@@ -2272,6 +2274,7 @@ impl SystemExecuteTransformer {
                 expr: part.clone(),
             });
             stmt.visit_mut_with(self);
+            parenthesize_lifted_stmt_expr(&mut stmt);
             items.push(ModuleItem::Stmt(stmt));
         }
         None
@@ -2735,6 +2738,24 @@ fn starts_with_function_or_class(expr: &Expr) -> bool {
 
 fn exported_value_is_assignment(expr: &Expr) -> bool {
     matches!(strip_paren_expr(expr), Expr::Assign(_))
+}
+
+// Comma-sequence leftovers become statements. A function-callee IIFE is
+// legal in expression position and a SyntaxError as `function () {}()`.
+fn parenthesize_lifted_stmt_expr(stmt: &mut Stmt) {
+    let Stmt::Expr(expr_stmt) = stmt else {
+        return;
+    };
+    if !is_function_callee_iife(expr_stmt.expr.as_ref())
+        && !starts_with_function_or_class(expr_stmt.expr.as_ref())
+    {
+        return;
+    }
+    let inner = expr_stmt.expr.clone();
+    *expr_stmt.expr = Expr::Paren(ParenExpr {
+        span: DUMMY_SP,
+        expr: inner,
+    });
 }
 
 fn export_replacement_expr(value: Box<Expr>) -> Expr {

--- a/crates/core/tests/bundles/systemjs-gen/dist/rollup-terser/entry.js
+++ b/crates/core/tests/bundles/systemjs-gen/dist/rollup-terser/entry.js
@@ -1,0 +1,1 @@
+System.register([],(function(e){"use strict";return{execute:function(){e("Before",0),{[key()]:handler}[lookup()](),e("After",1)}}}));

--- a/crates/core/tests/bundles/systemjs-gen/generate.mjs
+++ b/crates/core/tests/bundles/systemjs-gen/generate.mjs
@@ -17,6 +17,7 @@ const versions = {
   babelSystemjs: "7.25.9",
   swcCli: "0.7.9",
   swcCore: "1.15.3",
+  terser: "5.31.6",
   typescript: "5.9.3",
   webpack: "5.103.0",
   webpackCli: "5.1.4",
@@ -58,6 +59,31 @@ run("npx", [
   "--dir",
   "dist/preserve",
 ]);
+
+console.log("");
+console.log(`=== Rollup ${versions.rollup} + Terser ${versions.terser} ===`);
+console.log("  rollup-terser: compressed System.register sequence output");
+mkdirSync(`${cwd}/dist/rollup-terser`, { recursive: true });
+run("npx", [
+  "--yes",
+  `rollup@${versions.rollup}`,
+  "src-rollup-terser/entry.js",
+  "--format",
+  "system",
+  "--file",
+  "dist/.rollup-terser.js",
+]);
+run("npx", [
+  "--yes",
+  `terser@${versions.terser}`,
+  "dist/.rollup-terser.js",
+  "--compress",
+  "sequences=1000,passes=3",
+  "--mangle",
+  "--output",
+  "dist/rollup-terser/entry.js",
+]);
+rmSync(`${cwd}/dist/.rollup-terser.js`, { force: true });
 
 console.log("");
 console.log(`=== Babel ${versions.babelCore} ===`);

--- a/crates/core/tests/bundles/systemjs-gen/src-rollup-terser/entry.js
+++ b/crates/core/tests/bundles/systemjs-gen/src-rollup-terser/entry.js
@@ -1,0 +1,5 @@
+export const Before = 0;
+
+({ [key()]: handler })[lookup()]();
+
+export const After = 1;

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -3748,6 +3748,56 @@ System.register("field", [], function (_export) {
 }
 
 #[test]
+fn execute_object_export_comma_enum_iife_is_parenthesized() {
+    // protobuf-es v1 ScalarType/LongType: dummy object + comma-operator enum
+    // IIFE. The IIFE is legal in expression position; after live-binding
+    // splits the sequence it must stay parenthesized as a statement.
+    let source = r#"
+System.register("field", [], function (_export) {
+  return {
+    execute: function () {
+      var t, n;
+      _export({ LongType: void 0, ScalarType: void 0 }),
+      function (e) {
+        e[e.DOUBLE = 1] = "DOUBLE";
+      }(t || (t = _export("ScalarType", {}))),
+      function (e) {
+        e[e.BIGINT = 0] = "BIGINT";
+      }(n || (n = _export("LongType", {})));
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "field.js");
+    assert_no_system_register(entry, "comma enum IIFE");
+    assert_no_leftover_export_call(entry, "comma enum IIFE");
+    assert!(
+        entry.contains("ScalarType") && entry.contains("LongType"),
+        "live bindings must reconstruct:\n{entry}"
+    );
+    assert!(
+        entry.contains("DOUBLE = 1") && entry.contains("BIGINT = 0"),
+        "enum values must survive:\n{entry}"
+    );
+    assert!(
+        entry.contains("(function"),
+        "lifted enum IIFE must stay parenthesized:\n{entry}"
+    );
+    assert!(
+        !has_bare_function_stmt(entry),
+        "must not emit a statement-level `function (`:\n{entry}"
+    );
+}
+
+fn has_bare_function_stmt(code: &str) -> bool {
+    code.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("function(") || trimmed.starts_with("function (")
+    })
+}
+
+#[test]
 fn execute_object_export_computed_key_preserves_whole_register() {
     let source = r#"
 System.register("odd", [], function (_export) {

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -3788,6 +3788,10 @@ System.register("field", [], function (_export) {
         !has_bare_function_stmt(entry),
         "must not emit a statement-level `function (`:\n{entry}"
     );
+    assert_valid_unpacked_esm(&raw, "comma enum IIFE raw");
+
+    let decompiled = unpack_source(source);
+    assert_valid_unpacked_esm(&decompiled, "comma enum IIFE decompiled");
 }
 
 fn has_bare_function_stmt(code: &str) -> bool {
@@ -3795,6 +3799,135 @@ fn has_bare_function_stmt(code: &str) -> bool {
         let trimmed = line.trim_start();
         trimmed.starts_with("function(") || trimmed.starts_with("function (")
     })
+}
+
+#[test]
+fn lifted_object_and_assignment_heads_keep_expression_context() {
+    let cases = [
+        (
+            "object-headed call",
+            r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("Before", 0),
+      { [key()]: handler }[lookup()](),
+      _export("After", 1);
+    }
+  };
+});
+"#,
+        ),
+        (
+            "function-headed assignment",
+            r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("Before", 0),
+      function () { return {}; }().value = side(),
+      _export("After", 1);
+    }
+  };
+});
+"#,
+        ),
+        (
+            "source-parenthesized object-headed call",
+            r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("Before", 0),
+      ({ [key()]: handler }[lookup()]()),
+      _export("After", 1);
+    }
+  };
+});
+"#,
+        ),
+    ];
+
+    for (label, source) in cases {
+        for (stage, modules) in [
+            ("raw", unpack_source_raw(source)),
+            ("decompiled", unpack_source(source)),
+        ] {
+            let entry = module_code(&modules, "entry.js");
+            assert_no_system_register(entry, label);
+            assert_no_leftover_export_call(entry, label);
+            assert!(
+                entry.contains("Before") && entry.contains("After"),
+                "{label}/{stage} must retain both exports:\n{entry}"
+            );
+            assert_valid_unpacked_esm(&modules, &format!("{label}/{stage}"));
+        }
+    }
+}
+
+#[test]
+fn lifted_string_operand_does_not_become_a_directive() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      "use client", _export("Value", 1);
+    }
+  };
+});
+"#;
+    let raw = unpack_source_raw(source);
+    let entry = module_code(&raw, "entry.js");
+    assert!(
+        entry.contains("(\"use client\");") || entry.contains("('use client');"),
+        "a comma operand must not become a directive after lifting:\n{entry}"
+    );
+    assert_valid_unpacked_esm(&raw, "lifted string operand");
+}
+
+#[test]
+fn lifted_iife_prefix_is_parenthesized_in_assignment_and_initializer_sequences() {
+    let cases = [
+        (
+            "assignment sequence",
+            r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      var result;
+      result = (function (value) { value.hit = 1; }({}), _export("After", 1));
+    }
+  };
+});
+"#,
+        ),
+        (
+            "initializer sequence",
+            r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      var result = (function (value) { value.hit = 1; }({}), _export("After", 1));
+    }
+  };
+});
+"#,
+        ),
+    ];
+
+    for (label, source) in cases {
+        for (stage, modules) in [
+            ("raw", unpack_source_raw(source)),
+            ("decompiled", unpack_source(source)),
+        ] {
+            let entry = module_code(&modules, "entry.js");
+            assert!(
+                entry.contains("hit = 1") && entry.contains("After"),
+                "{label}/{stage} must retain the IIFE and export:\n{entry}"
+            );
+            assert_valid_unpacked_esm(&modules, &format!("{label}/{stage}"));
+        }
+    }
 }
 
 #[test]

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -89,6 +89,29 @@ fn rollup_preserve_module_entry_raw_reconstructs_esm() {
 }
 
 #[test]
+fn rollup_terser_lifted_object_expression_stays_valid() {
+    let source = fixture("rollup-terser/entry.js");
+
+    for (stage, modules) in [
+        ("raw", unpack_source_raw(&source)),
+        ("decompiled", unpack_source(&source)),
+    ] {
+        assert_eq!(modules.len(), 1, "unexpected {stage} modules: {modules:?}");
+        let entry = &modules[0].1;
+        assert_no_system_register(entry, stage);
+        assert_no_leftover_export_call(entry, stage);
+        assert!(
+            entry.contains("Before")
+                && entry.contains("After")
+                && entry.contains("key()")
+                && entry.contains("lookup()"),
+            "{stage} output must retain the exports and object-headed call:\n{entry}"
+        );
+        assert_valid_unpacked_esm(&modules, &format!("Rollup + Terser {stage}"));
+    }
+}
+
+#[test]
 fn swc_systemjs_raw_reconstructs_context_and_assignment_exports() {
     let raw = unpack_fixture_raw("swc/src/entry.js");
     assert_eq!(raw.len(), 1);


### PR DESCRIPTION
## Summary

`_export({ ScalarType: void 0, LongType: void 0 }), function (e) { … }(t || (t = _export("ScalarType", {})))` is legal as a comma expression: the IIFE is a function *expression* there. After [#215](https://github.com/pionxzh/wakaru/pull/215) reconstructs the dummy object keys plus the two-argument seed as a live binding (`export let ScalarType` / `export let LongType`), `take_export_stmt` (and the two sibling comma-lift helpers) turn the leftover IIFE into a *statement*. SWC then prints a bare top-level `function (e) { … }(…)`, which is a SyntaxError (`ExpectedIdent`).

This is the same codegen class as [#209](https://github.com/pionxzh/wakaru/pull/209) (`export default function () {}()`), but #209 only wraps `export_replacement_expr` / `emit_exported_value`. Those paths never see a leftover comma operand that has already been lifted to `Stmt::Expr`.

This PR only parenthesizes the lifted leftover:

- After `visit_mut` on the leftover expression (so `_export("Name", {})` inside the seed is already rewritten to `(Name = {})`), wrap it in `ParenExpr` when `is_function_callee_iife` or `starts_with_function_or_class`.
- The helper is `parenthesize_lifted_stmt_expr`. It is used at the three comma→statement lift sites: `take_export_stmt` (Seq arm), `take_ident_assign_export_seq`, and `take_bound_export_seq`.
- No new export is invented. Dummy-only object `_export` still fail-closes the whole file (existing #215 follow-up). Bulk reconstruction, setter paths, `emit_exported_value` default IIFE wrapping, and UnEsm are unchanged.

Related: leftover from #215. Same class as #209. Independent of UnEsm. Does not recover `export enum`, and does not promote dummy-only `void 0` to `export let` (#206).

Please feel free to take it from here if that is easier.
Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Why the leftover is illegal

In expression position, `function (e) { … }(args)` is an IIFE. As a statement, the same tokens parse as a function *declaration* followed by a call of that declaration. A declaration cannot be immediately invoked, so the printed ESM is invalid.

The protobuf-es v1 Shape (tsc numeric enum IIFE + Rollup/SystemJS object dummy + two-arg seed) hits this only after #215 succeeds: the dummy keys are recovered, the comma IIFE is no longer inside a sequence, and SWC emits it without parens. Inputs that already wrap the IIFE (`((e) => { … })(…)` or `(function (e) { … })(…)`) stay valid; this PR covers the unwrapped comma form.

## Reproduce

Producer: [@bufbuild/protobuf v1 `ScalarType` / `LongType`](https://github.com/bufbuild/protobuf-es/blob/v1.10.0/packages/protobuf/src/scalar.ts) (tsc numeric enum IIFE; protobuf-es v2 dropped `LongType`). Rollup/SystemJS emits the dummy object plus two-arg seed:

```js
System.register("field", [], function (_export) {
  return {
    execute: function () {
      var t, n;
      _export({ LongType: void 0, ScalarType: void 0 }),
      function (e) {
        e[e.DOUBLE = 1] = "DOUBLE";
      }(t || (t = _export("ScalarType", {}))),
      function (e) {
        e[e.BIGINT = 0] = "BIGINT";
      }(n || (n = _export("LongType", {})));
    }
  };
});
```

`wakaru --unpack` today: `export let ScalarType` / `export let LongType` plus a top-level `function (e) { … }(t || (t = (ScalarType = {})))` — illegal ESM.

After this change: the same live bindings, with the leftover IIFEs printed as `(function (e) { … })(…)`.

Covered by `execute_object_export_comma_enum_iife_is_parenthesized`. Existing `execute_object_export_void0_dummy_only_preserves_whole_register` still fail-closes dummy-only object `_export`. Existing `execute_object_export_void0_dummy_drops_and_keeps_later_singles` still reconstructs dummy + later singles. Existing `default_iife_export_is_parenthesized` still covers the #209 `export default` path.

## Out of scope

- Folding the IIFE into `export enum`.
- Promoting dummy-only `_export({ Name: void 0 })` to `export let` (#206).
- UnEsm, setter reconstruction, or `export default` emit (already parenthesized by #209).
- CHANGELOG (still at v1.10.0; #215–#217 have not shipped a release).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace` (4046 passed / 2 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack execute_object_export_comma_enum_iife_is_parenthesized`