### PR TITLE
fix(systemjs): bind default IIFE member-assign to the returned ident

### DIFF
--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -382,6 +382,7 @@ fn emit_system_module(
     lifted_stmts.extend(register.prelude.iter().cloned());
     lifted_stmts.extend(hoisted.iter().cloned());
     lifted_stmts.extend(execute_body.stmts.iter().cloned());
+    let transformed_stmts = &lifted_stmts[register.prelude.len()..];
 
     let mut module_bound_names = assigned_import_locals;
     collect_lifted_decl_names(&lifted_stmts, &mut module_bound_names);
@@ -419,9 +420,11 @@ fn emit_system_module(
     }));
     direct_binding_candidates.extend(inferred_import_locals.iter().cloned());
     let default_iife_return_idents = match export_sym.as_ref() {
-        Some(export_sym) => {
-            collect_default_iife_member_return_idents(&lifted_stmts, export_sym, &export_call_spans)
-        }
+        Some(export_sym) => collect_default_iife_member_return_idents(
+            transformed_stmts,
+            export_sym,
+            &export_call_spans,
+        ),
         None => HashSet::new(),
     };
     let needs_unresolved_analysis = (!direct_binding_candidates.is_empty()
@@ -438,8 +441,13 @@ fn emit_system_module(
     let (temp_local_unresolved, temp_local_proof_ready) = if default_iife_return_idents.is_empty() {
         (HashSet::new(), false)
     } else {
+        let parsed_export_call_spans = collect_parsed_export_call_spans(
+            transformed_stmts,
+            export_sym.as_ref()?,
+            &export_call_spans,
+        );
         (
-            analyze_unresolved_names(&lifted_stmts, &export_call_spans).names,
+            analyze_unresolved_names(&lifted_stmts, &parsed_export_call_spans).names,
             true,
         )
     };
@@ -952,6 +960,42 @@ fn collect_default_iife_member_return_idents(
         stmt.visit_with(&mut collector);
     }
     collector.names
+}
+
+/// Parsed calls in statements handled by `SystemExecuteTransformer` are
+/// either lowered or make the module fall back as a whole. Unparsed callback
+/// calls survive, so their callee must remain visible to the free-name proof.
+fn collect_parsed_export_call_spans(
+    stmts: &[Stmt],
+    export_sym: &Atom,
+    export_call_spans: &HashSet<Span>,
+) -> HashSet<Span> {
+    let mut collector = ParsedExportCallSpanCollector {
+        export_sym,
+        export_call_spans,
+        parsed: HashSet::new(),
+    };
+    for stmt in stmts {
+        stmt.visit_with(&mut collector);
+    }
+    collector.parsed
+}
+
+struct ParsedExportCallSpanCollector<'a> {
+    export_sym: &'a Atom,
+    export_call_spans: &'a HashSet<Span>,
+    parsed: HashSet<Span>,
+}
+
+impl Visit for ParsedExportCallSpanCollector<'_> {
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if self.export_call_spans.contains(&call.span)
+            && parse_export_call(call, self.export_sym).is_some()
+        {
+            self.parsed.insert(call.span);
+        }
+        call.visit_children_with(self);
+    }
 }
 
 struct DefaultIifeMemberReturnCollector<'a> {
@@ -2973,17 +3017,12 @@ fn is_function_callee_iife(expr: &Expr) -> bool {
     )
 }
 
-/// Unique `return Ident` from the outermost function-callee IIFE. Nested
-/// functions are skipped. A comma sequence is inferred only when its
-/// completion value is an Ident.
+/// Unique `return Ident` from the outermost synchronous, non-generator IIFE.
+/// Nested functions are skipped. A comma sequence is inferred only when its
+/// completion value is an Ident. Async and generator calls produce a Promise
+/// or iterator rather than the returned binding itself.
 fn inferred_iife_returned_ident(expr: &Expr) -> Option<Atom> {
     let expr = strip_paren_expr(expr);
-    if !is_function_callee_iife(expr) {
-        return None;
-    }
-    if let Some(body) = iife_body(expr) {
-        return unique_block_returned_ident(body);
-    }
     let Expr::Call(call) = expr else {
         return None;
     };
@@ -2991,12 +3030,15 @@ fn inferred_iife_returned_ident(expr: &Expr) -> Option<Atom> {
         return None;
     };
     match strip_paren_expr(callee.as_ref()) {
-        Expr::Arrow(arrow) => match arrow.body.as_ref() {
+        Expr::Fn(function) if !function.function.is_async && !function.function.is_generator => {
+            unique_block_returned_ident(function.function.body.as_ref()?)
+        }
+        Expr::Arrow(arrow) if !arrow.is_async && !arrow.is_generator => match arrow.body.as_ref() {
+            ArrowFunctionBody::FunctionBody(body) => unique_block_returned_ident(body),
             ArrowFunctionBody::Expr(value) => match strip_paren_expr(value.as_ref()) {
                 Expr::Ident(id) => Some(id.sym.clone()),
                 _ => None,
             },
-            _ => None,
         },
         _ => None,
     }

--- a/crates/core/src/unpacker/systemjs.rs
+++ b/crates/core/src/unpacker/systemjs.rs
@@ -418,15 +418,30 @@ fn emit_system_module(
             && !is_reserved_binding_name(name.as_ref())
     }));
     direct_binding_candidates.extend(inferred_import_locals.iter().cloned());
-    let unresolved_analysis = if !direct_binding_candidates.is_empty()
+    let default_iife_return_idents = match export_sym.as_ref() {
+        Some(export_sym) => {
+            collect_default_iife_member_return_idents(&lifted_stmts, export_sym, &export_call_spans)
+        }
+        None => HashSet::new(),
+    };
+    let needs_unresolved_analysis = (!direct_binding_candidates.is_empty()
         && (direct_binding_candidates
             .iter()
             .any(|name| used_names.names.contains(name))
-            || used_names.names.iter().any(|name| name.as_ref() == "eval"))
-    {
-        analyze_unresolved_names(&lifted_stmts)
+            || used_names.names.iter().any(|name| name.as_ref() == "eval")))
+        || !default_iife_return_idents.is_empty();
+    let unresolved_analysis = if needs_unresolved_analysis {
+        analyze_unresolved_names(&lifted_stmts, &HashSet::new())
     } else {
         UnresolvedNameAnalysis::default()
+    };
+    let (temp_local_unresolved, temp_local_proof_ready) = if default_iife_return_idents.is_empty() {
+        (HashSet::new(), false)
+    } else {
+        (
+            analyze_unresolved_names(&lifted_stmts, &export_call_spans).names,
+            true,
+        )
     };
     if inferred_import_locals
         .iter()
@@ -450,6 +465,8 @@ fn emit_system_module(
         unresolved_analysis.has_direct_eval,
         export_call_spans,
     );
+    transformer.temp_local_unresolved = temp_local_unresolved;
+    transformer.temp_local_proof_ready = temp_local_proof_ready;
     items.extend(transformer.prepare_mutable_exports(mutable_export_names));
     for stmt in hoisted {
         transformer.push_stmt(stmt, &mut items);
@@ -616,7 +633,10 @@ impl Visit for LiftedDeclNameCollector<'_> {
 /// Resolve a clone of the statements in the scope they will occupy after
 /// lifting. Any identifier still carrying `unresolved_mark` is a free/global
 /// read that a newly introduced module binding would capture.
-fn analyze_unresolved_names(stmts: &[Stmt]) -> UnresolvedNameAnalysis {
+fn analyze_unresolved_names(
+    stmts: &[Stmt],
+    skip_export_call_spans: &HashSet<Span>,
+) -> UnresolvedNameAnalysis {
     let globals = Globals::new();
     GLOBALS.set(&globals, || {
         let unresolved_mark = Mark::new();
@@ -653,6 +673,7 @@ fn analyze_unresolved_names(stmts: &[Stmt]) -> UnresolvedNameAnalysis {
             unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
             names: HashSet::new(),
             has_direct_eval: false,
+            skip_export_call_spans: skip_export_call_spans.clone(),
         };
         probe.visit_with(&mut collector);
         UnresolvedNameAnalysis {
@@ -672,6 +693,7 @@ struct UnresolvedNameCollector {
     unresolved_ctxt: SyntaxContext,
     names: HashSet<Atom>,
     has_direct_eval: bool,
+    skip_export_call_spans: HashSet<Span>,
 }
 
 impl Visit for UnresolvedNameCollector {
@@ -694,6 +716,12 @@ impl Visit for UnresolvedNameCollector {
                 )
         ) {
             self.has_direct_eval = true;
+        }
+        if self.skip_export_call_spans.contains(&call.span) {
+            for arg in &call.args {
+                arg.visit_with(self);
+            }
+            return;
         }
         call.visit_children_with(self);
     }
@@ -907,6 +935,45 @@ impl Visit for MemberExportBindingNameCollector<'_> {
             self.names.insert(exported);
         }
         assign.visit_children_with(self);
+    }
+}
+
+fn collect_default_iife_member_return_idents(
+    stmts: &[Stmt],
+    export_sym: &Atom,
+    export_call_spans: &HashSet<Span>,
+) -> HashSet<Atom> {
+    let mut collector = DefaultIifeMemberReturnCollector {
+        export_sym,
+        export_call_spans,
+        names: HashSet::new(),
+    };
+    for stmt in stmts {
+        stmt.visit_with(&mut collector);
+    }
+    collector.names
+}
+
+struct DefaultIifeMemberReturnCollector<'a> {
+    export_sym: &'a Atom,
+    export_call_spans: &'a HashSet<Span>,
+    names: HashSet<Atom>,
+}
+
+impl Visit for DefaultIifeMemberReturnCollector<'_> {
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if self.export_call_spans.contains(&call.span) {
+            if let Some(ExportCall::Single { exported, value }) =
+                parse_export_call(call, self.export_sym)
+            {
+                if exported.as_ref() == "default" {
+                    if let Some(returned) = inferred_iife_returned_ident(value.as_ref()) {
+                        self.names.insert(returned);
+                    }
+                }
+            }
+        }
+        call.visit_children_with(self);
     }
 }
 
@@ -1527,6 +1594,10 @@ struct SystemExecuteTransformer {
     /// Calls proven by resolver to target the declare callback, rather than a
     /// nested binding that happens to have the same minified name.
     export_call_spans: HashSet<Span>,
+    /// Unresolved names after ignoring proven export-call callees. Used only
+    /// for inferred default IIFE locals; `unresolved_names` stays complete.
+    temp_local_unresolved: HashSet<Atom>,
+    temp_local_proof_ready: bool,
     mutable_export_bindings: HashMap<Atom, Atom>,
     /// Side-effect-free live-binding declarations needed by expression-position exports.
     pending_expr_export_decls: Vec<ModuleItem>,
@@ -1557,6 +1628,8 @@ impl SystemExecuteTransformer {
             unresolved_names,
             has_direct_eval,
             export_call_spans,
+            temp_local_unresolved: HashSet::new(),
+            temp_local_proof_ready: false,
             mutable_export_bindings: HashMap::new(),
             pending_expr_export_decls: Vec::new(),
             unlowerable_export: false,
@@ -1794,9 +1867,9 @@ impl SystemExecuteTransformer {
         let mut value = value;
         value.visit_mut_with(self);
         let exported_local = exported_value_local(value.as_ref());
-        let local = exported_local
-            .clone()
-            .unwrap_or_else(|| self.bind_member_export_local(&exported, is_default));
+        let local = exported_local.clone().unwrap_or_else(|| {
+            self.bind_member_export_local(&exported, is_default, value.as_ref())
+        });
 
         let mut assignment = assign.clone();
         let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &mut assignment.left else {
@@ -1847,14 +1920,42 @@ impl SystemExecuteTransformer {
 
     /// Bind a free, legal Identifier to the export name. Reserved words and
     /// module-scope collisions keep the `__systemjs_export` alias path.
-    fn bind_member_export_local(&mut self, exported: &Atom, is_default: bool) -> Atom {
-        if !is_default && self.can_bind_export_name(exported) {
+    /// Default member-assign IIFEs prefer the unique returned ident when the
+    /// binding-identity freedom proof allows it.
+    fn bind_member_export_local(
+        &mut self,
+        exported: &Atom,
+        is_default: bool,
+        value: &Expr,
+    ) -> Atom {
+        if is_default {
+            if let Some(inferred) = inferred_iife_returned_ident(value) {
+                if self.can_bind_temp_local(&inferred) {
+                    self.module_bound_names.insert(inferred.clone());
+                    self.used_names.insert(inferred.clone());
+                    return inferred;
+                }
+            }
+            return self.fresh_export_name();
+        }
+        if self.can_bind_export_name(exported) {
             self.module_bound_names.insert(exported.clone());
             self.used_names.insert(exported.clone());
             exported.clone()
         } else {
             self.fresh_export_name()
         }
+    }
+
+    fn can_bind_temp_local(&self, name: &Atom) -> bool {
+        self.temp_local_proof_ready
+            && Ident::verify_symbol(name.as_ref()).is_ok()
+            && !is_reserved_binding_name(name.as_ref())
+            && !self.module_bound_names.contains(name)
+            && !self.temp_local_unresolved.contains(name)
+            && !self.has_direct_eval
+            && !self.exports.iter().any(|binding| binding.local == *name)
+            && !self.declared_exports.iter().any(|(local, _)| local == name)
     }
 
     fn can_bind_export_name(&self, exported: &Atom) -> bool {
@@ -2145,7 +2246,11 @@ impl SystemExecuteTransformer {
             return Some((vec![self.export_const_item(exported, value)], result));
         }
 
-        let local = self.fresh_export_name();
+        let local = if is_default {
+            self.bind_member_export_local(&exported, true, value.as_ref())
+        } else {
+            self.fresh_export_name()
+        };
         let mut items = vec![self.binding_item(local.clone(), value)];
         if is_default {
             items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
@@ -2866,6 +2971,96 @@ fn is_function_callee_iife(expr: &Expr) -> bool {
         Callee::Expr(callee)
             if matches!(callee.as_ref(), Expr::Fn(_) | Expr::Arrow(_))
     )
+}
+
+/// Unique `return Ident` from the outermost function-callee IIFE. Nested
+/// functions are skipped. A comma sequence is inferred only when its
+/// completion value is an Ident.
+fn inferred_iife_returned_ident(expr: &Expr) -> Option<Atom> {
+    let expr = strip_paren_expr(expr);
+    if !is_function_callee_iife(expr) {
+        return None;
+    }
+    if let Some(body) = iife_body(expr) {
+        return unique_block_returned_ident(body);
+    }
+    let Expr::Call(call) = expr else {
+        return None;
+    };
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    match strip_paren_expr(callee.as_ref()) {
+        Expr::Arrow(arrow) => match arrow.body.as_ref() {
+            ArrowFunctionBody::Expr(value) => match strip_paren_expr(value.as_ref()) {
+                Expr::Ident(id) => Some(id.sym.clone()),
+                _ => None,
+            },
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn unique_block_returned_ident(body: &FunctionBody) -> Option<Atom> {
+    let mut collector = OwnFunctionReturnIdentCollector::default();
+    for stmt in &body.stmts {
+        stmt.visit_with(&mut collector);
+    }
+    if collector.conflict {
+        None
+    } else {
+        collector.found
+    }
+}
+
+/// Collect `return` completion values in this function only. Nested
+/// functions / arrows / classes are skipped so their returns cannot
+/// satisfy or poison the outer IIFE.
+#[derive(Default)]
+struct OwnFunctionReturnIdentCollector {
+    found: Option<Atom>,
+    conflict: bool,
+}
+
+impl Visit for OwnFunctionReturnIdentCollector {
+    fn visit_function(&mut self, _function: &Function) {}
+
+    fn visit_arrow_expr(&mut self, _arrow: &swc_core::ecma::ast::ArrowExpr) {}
+
+    fn visit_class(&mut self, _class: &swc_core::ecma::ast::Class) {}
+
+    fn visit_return_stmt(&mut self, ret: &ReturnStmt) {
+        if self.conflict {
+            return;
+        }
+        let Some(name) = ret
+            .arg
+            .as_ref()
+            .and_then(|arg| returned_value_ident(arg.as_ref()))
+        else {
+            self.conflict = true;
+            return;
+        };
+        match &self.found {
+            None => self.found = Some(name),
+            Some(prev) if *prev == name => {}
+            Some(_) => self.conflict = true,
+        }
+    }
+}
+
+/// Bare `return ident`, or a comma sequence whose completion value is `ident`
+/// (`return proto.m = fn, ident`).
+fn returned_value_ident(expr: &Expr) -> Option<Atom> {
+    match strip_paren_expr(expr) {
+        Expr::Ident(id) => Some(id.sym.clone()),
+        Expr::Seq(seq) => match strip_paren_expr(seq.exprs.last()?.as_ref()) {
+            Expr::Ident(id) => Some(id.sym.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 #[derive(Default)]

--- a/crates/core/tests/bundles/systemjs-gen/dist/rollup-terser/async-default.js
+++ b/crates/core/tests/bundles/systemjs-gen/dist/rollup-terser/async-default.js
@@ -1,0 +1,1 @@
+System.register([],(function(e){"use strict";return{execute:function(){e("default",async function(){function e(){}return e.self=e,e}()).marker=!0}}}));

--- a/crates/core/tests/bundles/systemjs-gen/generate.mjs
+++ b/crates/core/tests/bundles/systemjs-gen/generate.mjs
@@ -62,28 +62,31 @@ run("npx", [
 
 console.log("");
 console.log(`=== Rollup ${versions.rollup} + Terser ${versions.terser} ===`);
-console.log("  rollup-terser: compressed System.register sequence output");
+console.log("  rollup-terser: compressed System.register expression outputs");
 mkdirSync(`${cwd}/dist/rollup-terser`, { recursive: true });
-run("npx", [
-  "--yes",
-  `rollup@${versions.rollup}`,
-  "src-rollup-terser/entry.js",
-  "--format",
-  "system",
-  "--file",
-  "dist/.rollup-terser.js",
-]);
-run("npx", [
-  "--yes",
-  `terser@${versions.terser}`,
-  "dist/.rollup-terser.js",
-  "--compress",
-  "sequences=1000,passes=3",
-  "--mangle",
-  "--output",
-  "dist/rollup-terser/entry.js",
-]);
-rmSync(`${cwd}/dist/.rollup-terser.js`, { force: true });
+for (const name of ["entry", "async-default"]) {
+  const intermediate = `dist/.rollup-terser-${name}.js`;
+  run("npx", [
+    "--yes",
+    `rollup@${versions.rollup}`,
+    `src-rollup-terser/${name}.js`,
+    "--format",
+    "system",
+    "--file",
+    intermediate,
+  ]);
+  run("npx", [
+    "--yes",
+    `terser@${versions.terser}`,
+    intermediate,
+    "--compress",
+    "sequences=1000,passes=3",
+    "--mangle",
+    "--output",
+    `dist/rollup-terser/${name}.js`,
+  ]);
+  rmSync(`${cwd}/${intermediate}`, { force: true });
+}
 
 console.log("");
 console.log(`=== Babel ${versions.babelCore} ===`);

--- a/crates/core/tests/bundles/systemjs-gen/src-rollup-terser/async-default.js
+++ b/crates/core/tests/bundles/systemjs-gen/src-rollup-terser/async-default.js
@@ -1,0 +1,8 @@
+const promise = (async function () {
+  function DefaultValue() {}
+  DefaultValue.self = DefaultValue;
+  return DefaultValue;
+})();
+
+export default promise;
+promise.marker = true;

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -140,6 +140,28 @@ fn swc_systemjs_raw_reconstructs_context_and_assignment_exports() {
 }
 
 #[test]
+fn rollup_terser_async_default_keeps_generated_result_local() {
+    let source = fixture("rollup-terser/async-default.js");
+
+    for (stage, modules) in [
+        ("raw", unpack_source_raw(&source)),
+        ("decompiled", unpack_source(&source)),
+    ] {
+        assert_eq!(modules.len(), 1, "unexpected {stage} modules: {modules:?}");
+        let entry = &modules[0].1;
+        assert_no_system_register(entry, stage);
+        assert!(
+            entry.contains("__systemjs_export")
+                && entry.contains("export default __systemjs_export;")
+                && entry.contains("__systemjs_export.marker")
+                && !entry.contains("const e ="),
+            "{stage} output must not claim the async return ident as the Promise binding:\n{entry}"
+        );
+        assert_valid_unpacked_esm(&modules, &format!("Rollup + Terser async {stage}"));
+    }
+}
+
+#[test]
 fn babel_systemjs_raw_reconstructs_outer_exports() {
     let raw = unpack_fixture_raw("babel/entry.js");
     assert_eq!(raw.len(), 1);
@@ -896,6 +918,55 @@ System.register("entry", [], function (_export) {
 }
 
 #[test]
+fn async_and_generator_iife_results_do_not_claim_returned_binding_identity() {
+    let cases = [
+        (
+            "async function",
+            r#"async function () {
+        function DefaultValue() {}
+        return DefaultValue;
+      }()"#,
+        ),
+        (
+            "async arrow",
+            r#"(async () => {
+        function DefaultValue() {}
+        return DefaultValue;
+      })()"#,
+        ),
+        (
+            "generator function",
+            r#"function* () {
+        function DefaultValue() {}
+        return DefaultValue;
+      }()"#,
+        ),
+    ];
+
+    for (label, value) in cases {
+        let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("default", $VALUE$).marker = true;
+    }
+  };
+});
+"#
+        .replace("$VALUE$", value);
+        let modules = unpack_source_raw(&source);
+        let entry = module_code(&modules, "entry.js");
+        assert!(
+            entry.contains("const __systemjs_export =")
+                && entry.contains("export default __systemjs_export;")
+                && entry.contains("__systemjs_export.marker = true;")
+                && !entry.contains("const DefaultValue ="),
+            "{label} call result must keep a generated local instead of claiming the returned binding identity:\n{entry}"
+        );
+    }
+}
+
+#[test]
 fn default_iife_member_minified_return_ident_is_bound() {
     let source = r#"
 System.register("entry", [], function (_export) {
@@ -949,6 +1020,34 @@ System.register("entry", [], function (e) {
             && entry.contains("e.marker = true;")
             && !entry.contains("__systemjs_export"),
         "matching callback name must still bind the returned ident:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_surviving_callback_call_falls_back() {
+    let source = r#"
+System.register("entry", [], function (e) {
+  return {
+    execute: function () {
+      e("default", function () {
+        function e() {}
+        return e;
+      }()).marker = true;
+      e(dynamicName, dynamicValue);
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const __systemjs_export =")
+            && entry.contains("export default __systemjs_export;")
+            && entry.contains("__systemjs_export.marker = true;")
+            && (entry.contains("e(dynamicName, dynamicValue)")
+                || entry.contains("e(dynamicName,dynamicValue)"))
+            && !entry.contains("const e ="),
+        "a callback call that survives lowering must block reuse of its name:\n{entry}"
     );
 }
 

--- a/crates/core/tests/systemjs_unpack.rs
+++ b/crates/core/tests/systemjs_unpack.rs
@@ -796,18 +796,22 @@ System.register("entry", [], function (_export) {
     let modules = unpack_source(source);
     let entry = module_code(&modules, "entry.js");
     let binding = entry
-        .find("const __systemjs_export_2 =")
-        .unwrap_or_else(|| panic!("default export should use a collision-free binding:\n{entry}"));
+        .find("const DefaultValue =")
+        .unwrap_or_else(|| panic!("default export should reuse the IIFE return ident:\n{entry}"));
     let member_assignment = entry
-        .find("__systemjs_export_2.marker = \"default\";")
+        .find("DefaultValue.marker = \"default\";")
         .unwrap_or_else(|| panic!("member assignment should use the binding:\n{entry}"));
     let default_export = entry
-        .find("export default __systemjs_export_2;")
+        .find("export default DefaultValue;")
         .unwrap_or_else(|| panic!("default export should use the binding:\n{entry}"));
 
     assert!(
         binding < default_export && default_export < member_assignment,
         "binding, default export, and member assignment should preserve order:\n{entry}"
+    );
+    assert!(
+        !entry.contains("__systemjs_export"),
+        "prelude `__systemjs_export` must not become the default local:\n{entry}"
     );
     assert_eq!(
         entry.matches("function DefaultValue()").count(),
@@ -846,9 +850,454 @@ fn default_iife_member_export_avoids_module_prelude_names() {
     let entry = module_code(&modules, "entry.js");
 
     assert!(
-        entry.contains("const __systemjs_export_2 =")
-            && entry.contains("export default __systemjs_export_2;"),
-        "default export binding should avoid names in the module prelude:\n{entry}"
+        entry.contains("const DefaultValue =")
+            && entry.contains("export default DefaultValue;")
+            && entry.contains("DefaultValue.ready = true;"),
+        "default export should reuse the IIFE return ident instead of the prelude name:\n{entry}"
+    );
+    assert!(
+        !entry.contains("const __systemjs_export") && !entry.contains("const __systemjs_export_2"),
+        "prelude `__systemjs_export` must not be reused as the default local:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_returned_ident_is_bound() {
+    // Reconstruction contract is `--raw`. Decompile may later fold a
+    // parameter-less IIFE into `class`, which is a different rule.
+    // Member-assigned `_export("default", IIFE).prop =` should reuse the
+    // unique returned Identifier when that name is free at module scope.
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("default", function (Base) {
+        function DefaultValue() {}
+        return DefaultValue;
+      }(Base)).marker = "default";
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const DefaultValue =")
+            && entry.contains("export default DefaultValue;")
+            && entry.contains("DefaultValue.marker = \"default\";"),
+        "returned ident must back the default binding:\n{entry}"
+    );
+    assert!(
+        !entry.contains("__systemjs_export")
+            && !entry.contains("export default function")
+            && !entry.contains("export default ("),
+        "must not fall through to the synthetic alias or a default IIFE:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_minified_return_ident_is_bound() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("Named", 1);
+      _export("default", function () {
+        function e() {}
+        return e;
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const e =")
+            && entry.contains("export default e;")
+            && entry.contains("e.marker = true;"),
+        "minified return ident must back the default binding:\n{entry}"
+    );
+    assert!(
+        entry.contains("export const Named =") && !entry.contains("__systemjs_export"),
+        "sibling named exports must stay and no synthetic alias should appear:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_callback_name_match_is_binding_safe() {
+    // The declare callback and the returned ident may share a minified name.
+    // Only proven export-call callees are ignored; the inner function still
+    // owns that name, so the module binding is safe.
+    let source = r#"
+System.register("entry", [], function (e) {
+  return {
+    execute: function () {
+      e("default", function () {
+        function e() {}
+        return e;
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const e =")
+            && entry.contains("export default e;")
+            && entry.contains("e.marker = true;")
+            && !entry.contains("__systemjs_export"),
+        "matching callback name must still bind the returned ident:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_module_collision_falls_back() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      const DefaultValue = 1;
+      _export("default", function () {
+        function DefaultValue() {}
+        return DefaultValue;
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const __systemjs_export")
+            && entry.contains("export default __systemjs_export;")
+            && !entry.contains("const DefaultValue = function"),
+        "an existing module local must force the synthetic alias:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_import_collision_falls_back() {
+    // Returned ident `n` is already the setter local for an import.
+    let source = r#"
+System.register("entry", ["./dep.js"], function (_export) {
+  var n;
+  return {
+    setters: [function (mod) {
+      n = mod.legacy;
+    }],
+    execute: function () {
+      _export("default", function () {
+        var e, n;
+        return (e = (n = function () {}).prototype).init = function () {}, n;
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("import { legacy as n }")
+            && entry.contains("const __systemjs_export")
+            && entry.contains("export default __systemjs_export;")
+            && !entry.contains("const n = function"),
+        "an imported local must force the synthetic alias:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_typeof_free_name_falls_back() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      observe(typeof e);
+      _export("default", function () {
+        function e() {}
+        return e;
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const __systemjs_export")
+            && entry.contains("export default __systemjs_export;")
+            && !entry.contains("const e ="),
+        "a free/typeof name must not be captured by the inferred local:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_direct_eval_falls_back() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      eval("observe()");
+      _export("default", function () {
+        function DefaultValue() {}
+        return DefaultValue;
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const __systemjs_export")
+            && entry.contains("export default __systemjs_export;")
+            && !entry.contains("const DefaultValue ="),
+        "direct eval must keep the synthetic alias:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_free_arrow_return_falls_back() {
+    // `() => { return e }` reads a free `e`. Inventing `const e` would make
+    // that return self-referential.
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("default", (() => {
+        return e;
+      })()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const __systemjs_export")
+            && entry.contains("export default __systemjs_export;")
+            && !entry.contains("const e ="),
+        "a free arrow return must not become `const e`:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_surviving_callback_use_falls_back() {
+    let source = r#"
+System.register("entry", [], function (e) {
+  return {
+    execute: function () {
+      observe(e);
+      e("default", function () {
+        function e() {}
+        return e;
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const __systemjs_export")
+            && entry.contains("export default __systemjs_export;")
+            && !entry.contains("const e ="),
+        "a surviving callback reference must keep the name unresolved:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_repeated_default_stays_mutable() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("default", function () {
+        function First() {}
+        return First;
+      }()).a = 1;
+      _export("default", function () {
+        function Second() {}
+        return Second;
+      }()).b = 2;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("let __systemjs_export;")
+            && entry.contains("export { __systemjs_export as default };")
+            && entry.matches(" as default").count() == 1
+            && !entry.contains("const First =")
+            && !entry.contains("const Second =")
+            && !entry.contains("export default"),
+        "repeated default member exports must keep one live binding:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_seq_tail_ident_is_bound() {
+    // Class IIFEs assign prototype methods in the return sequence, then
+    // complete with the constructor ident.
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("default", function () {
+        function e() {}
+        var n = e.prototype;
+        return n.method = function () {}, e;
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const e =")
+            && entry.contains("export default e;")
+            && entry.contains("e.marker = true;")
+            && !entry.contains("__systemjs_export"),
+        "a sequence whose completion value is the ctor ident must bind that ident:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_comma_return_does_not_infer() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("default", function () {
+        function e() {}
+        return e, make();
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const __systemjs_export")
+            && entry.contains("export default __systemjs_export;")
+            && !entry.contains("const e ="),
+        "a comma return whose completion value is not an Ident must not infer:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_nested_return_does_not_infer() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("default", function () {
+        function inner() {
+          function Nested() {}
+          return Nested;
+        }
+        return inner();
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const __systemjs_export")
+            && entry.contains("export default __systemjs_export;")
+            && !entry.contains("const Nested =")
+            && !entry.contains("const inner ="),
+        "a nested function return must not be treated as the outer return:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_branch_return_does_not_infer() {
+    // Returns in the same function, including `if` branches, must all
+    // complete with the same Ident. A second Ident fails closed.
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("default", function () {
+        function DefaultValue() {}
+        if (cond) return Other;
+        return DefaultValue;
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const __systemjs_export")
+            && entry.contains("export default __systemjs_export;")
+            && !entry.contains("const DefaultValue =")
+            && !entry.contains("const Other ="),
+        "divergent branch returns must not infer a writable binding:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_member_branch_same_ident_is_bound() {
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      _export("default", function () {
+        function DefaultValue() {}
+        if (cond) return DefaultValue;
+        return DefaultValue;
+      }()).marker = true;
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const DefaultValue =")
+            && entry.contains("export default DefaultValue;")
+            && entry.contains("DefaultValue.marker = true;")
+            && !entry.contains("__systemjs_export"),
+        "the same Ident in every own-function return must still bind:\n{entry}"
+    );
+}
+
+#[test]
+fn default_iife_result_returned_ident_is_bound() {
+    // Ident-assign of `_export("default", IIFE())` goes through
+    // `export_call_result_items`. Proof must not depend on a sibling
+    // member-assign. Nested `use(_export(...))` stays on the existing
+    // mutable live-binding path.
+    let source = r#"
+System.register("entry", [], function (_export) {
+  return {
+    execute: function () {
+      result = _export("default", function () {
+        function DefaultValue() {}
+        return DefaultValue;
+      }());
+    }
+  };
+});
+"#;
+    let modules = unpack_source_raw(source);
+    let entry = module_code(&modules, "entry.js");
+    assert!(
+        entry.contains("const DefaultValue =")
+            && entry.contains("export default DefaultValue;")
+            && entry.contains("result = DefaultValue")
+            && !entry.contains("__systemjs_export"),
+        "an export-call result IIFE must bind the returned ident:\n{entry}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Member-assigned `_export("default", IIFE()).prop =` currently always binds `const __systemjs_export`. When the IIFE is a function-callee with a unique `return Ident` (or a comma sequence that completes with that ident) and a binding-identity freedom proof says the name is free, reuse it as the writable local.
- Do not invent a source class name. Do not lift `function Named` / `class Named` expressions (#209). Do not extend bulk object-property NamedEvaluation to the two-arg path.
- Collision, free/`typeof` names, direct eval, nested returns, and `return e, make()` stay on `__systemjs_export_*`. Repeated default member assigns still share one live binding.

Related: leftover from #209 member-assign default alias. Independent of #215 bulk NamedEvaluation and #218.

Please feel free to take it from here if that is easier.
Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
System.register("entry", [], function (_export) {
  return {
    execute: function () {
      _export("default", function (Base) {
        function DefaultValue() {}
        return DefaultValue;
      }(Base)).marker = "default";
    }
  };
});
```

`wakaru --unpack` today: `const __systemjs_export = …; export default __systemjs_export`. After this change: `const DefaultValue = …; export default DefaultValue; DefaultValue.marker = "default"`.

Covered by `default_iife_member_returned_ident_is_bound`, `default_iife_member_minified_return_ident_is_bound`, `default_iife_member_seq_tail_ident_is_bound`, `default_iife_result_returned_ident_is_bound`, `default_iife_member_branch_return_does_not_infer`, `default_iife_member_import_collision_falls_back`, `default_iife_member_free_arrow_return_falls_back`, and existing `named_default_*_stays_local` / `repeated_default_member_exports_share_one_live_binding`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test systemjs_unpack`
