### PR TITLE
fix(rules): ignore Cocos cc._RF.push(module) when proving collapsed enum exports

### DIFF
--- a/crates/core/src/rules/un_enum.rs
+++ b/crates/core/src/rules/un_enum.rs
@@ -118,6 +118,12 @@ fn process_module_items_for_enum(items: &mut Vec<ModuleItem>, unresolved_mark: O
                                     items.iter().chain(remaining.iter().skip(1)),
                                     public_name,
                                     unresolved_mark.expect("exported enum parsing requires a mark"),
+                                    enclosing_cc_rf_push_span(
+                                        items.iter(),
+                                        remaining.iter().skip(1),
+                                        unresolved_mark
+                                            .expect("exported enum parsing requires a mark"),
+                                    ),
                                 )
                             })
                         {
@@ -179,6 +185,11 @@ fn process_module_items_for_enum(items: &mut Vec<ModuleItem>, unresolved_mark: O
                                 items.iter().chain(remaining.iter()),
                                 public_name,
                                 unresolved_mark.expect("exported enum parsing requires a mark"),
+                                enclosing_cc_rf_push_span(
+                                    items.iter(),
+                                    remaining.iter(),
+                                    unresolved_mark.expect("exported enum parsing requires a mark"),
+                                ),
                             )
                         })
                 {
@@ -217,15 +228,122 @@ fn process_module_items_for_enum(items: &mut Vec<ModuleItem>, unresolved_mark: O
     }
 }
 
+enum CcRfMarker {
+    Push { skippable_span: Option<Span> },
+    Pop,
+}
+
+/// Return the direct top-level `cc._RF.push` whose matching `pop` encloses
+/// the current enum. A push elsewhere in the AST is not evidence that its
+/// bare `module` argument is the Cocos registration marker for this enum.
+fn enclosing_cc_rf_push_span<'a>(
+    before: impl DoubleEndedIterator<Item = &'a ModuleItem>,
+    after: impl Iterator<Item = &'a ModuleItem>,
+    unresolved_mark: Mark,
+) -> Option<Span> {
+    let mut closed_frames = 0usize;
+    let mut enclosing_push_span = None;
+
+    for item in before.rev() {
+        match direct_cc_rf_marker(item, unresolved_mark) {
+            Some(CcRfMarker::Pop) => closed_frames += 1,
+            Some(CcRfMarker::Push { .. }) if closed_frames > 0 => closed_frames -= 1,
+            Some(CcRfMarker::Push { skippable_span }) => {
+                enclosing_push_span = skippable_span;
+                break;
+            }
+            None => {}
+        }
+    }
+
+    let enclosing_push_span = enclosing_push_span?;
+    let mut opened_frames = 0usize;
+    for item in after {
+        match direct_cc_rf_marker(item, unresolved_mark) {
+            Some(CcRfMarker::Push { .. }) => opened_frames += 1,
+            Some(CcRfMarker::Pop) if opened_frames == 0 => {
+                return Some(enclosing_push_span);
+            }
+            Some(CcRfMarker::Pop) => opened_frames -= 1,
+            None => {}
+        }
+    }
+
+    None
+}
+
+fn direct_cc_rf_marker(item: &ModuleItem, unresolved_mark: Mark) -> Option<CcRfMarker> {
+    let ModuleItem::Stmt(Stmt::Expr(expr_stmt)) = item else {
+        return None;
+    };
+    let Expr::Call(call) = strip_parens(&expr_stmt.expr) else {
+        return None;
+    };
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+
+    if is_cc_rf_method_callee(callee, "push", unresolved_mark) {
+        return Some(CcRfMarker::Push {
+            skippable_span: first_arg_is_unresolved_module(call, unresolved_mark)
+                .then_some(call.span),
+        });
+    }
+    if is_cc_rf_method_callee(callee, "pop", unresolved_mark) {
+        return Some(CcRfMarker::Pop);
+    }
+    None
+}
+
+fn is_cc_rf_method_callee(callee: &Expr, method: &str, unresolved_mark: Mark) -> bool {
+    let Expr::Member(method_member) = strip_parens(callee) else {
+        return false;
+    };
+    let MemberProp::Ident(method_name) = &method_member.prop else {
+        return false;
+    };
+    if method_name.sym != *method {
+        return false;
+    }
+    let Expr::Member(rf) = strip_parens(&method_member.obj) else {
+        return false;
+    };
+    let MemberProp::Ident(rf_name) = &rf.prop else {
+        return false;
+    };
+    if rf_name.sym != "_RF" {
+        return false;
+    }
+    let Expr::Ident(cc) = strip_parens(&rf.obj) else {
+        return false;
+    };
+    is_unresolved_named(cc, "cc", unresolved_mark)
+}
+
+fn first_arg_is_unresolved_module(call: &CallExpr, unresolved_mark: Mark) -> bool {
+    let Some(first) = call.args.first() else {
+        return false;
+    };
+    if first.spread.is_some() {
+        return false;
+    }
+    matches!(
+        strip_parens(&first.expr),
+        Expr::Ident(ident) if is_unresolved_named(ident, "module", unresolved_mark)
+    )
+}
+
 fn module_items_reference_public_export<'a>(
     items: impl IntoIterator<Item = &'a ModuleItem>,
     public_name: &Atom,
     unresolved_mark: Mark,
+    allowed_cc_rf_push_span: Option<Span>,
 ) -> bool {
     items.into_iter().any(|item| {
         let mut finder = PublicExportUseFinder {
             public_name,
             unresolved_mark,
+            allowed_cc_rf_push_span,
             found: false,
         };
         item.visit_with(&mut finder);
@@ -241,6 +359,7 @@ fn module_items_reference_public_export<'a>(
 struct PublicExportUseFinder<'a> {
     public_name: &'a Atom,
     unresolved_mark: Mark,
+    allowed_cc_rf_push_span: Option<Span>,
     found: bool,
 }
 
@@ -304,8 +423,9 @@ impl PublicExportUseFinder<'_> {
 
     /// Cocos 2.x `cc._RF.push(module, uuid, script)` stores the CJS module
     /// handle for uuid / script-name registration. That bare `module` ident
-    /// is not a read of `exports.<public_name>`. Only unresolved `cc` plus
-    /// ident members `_RF.push` match; `cclegacy` and computed keys do not.
+    /// is not a read of `exports.<public_name>`. Only the direct top-level
+    /// push proven to frame this enum is allowed; nested or out-of-range
+    /// lookalikes remain observable CommonJS escapes.
     ///
     /// `pop()` later iterates `module.exports` keys and may assign
     /// `module.exports = frame.cls` if that object is empty. Folding the
@@ -313,51 +433,17 @@ impl PublicExportUseFinder<'_> {
     /// key set. UnEsm already emits `export class` beside the same marker,
     /// which is the same mixed CJS/ESM contract; this skip matches that
     /// recovered shape rather than re-running Cocos's loader.
-    fn is_cc_rf_push_callee(&self, callee: &Expr) -> bool {
-        let Expr::Member(push) = strip_parens(callee) else {
-            return false;
-        };
-        let MemberProp::Ident(push_name) = &push.prop else {
-            return false;
-        };
-        if push_name.sym != "push" {
-            return false;
-        }
-        let Expr::Member(rf) = strip_parens(&push.obj) else {
-            return false;
-        };
-        let MemberProp::Ident(rf_name) = &rf.prop else {
-            return false;
-        };
-        if rf_name.sym != "_RF" {
-            return false;
-        }
-        let Expr::Ident(cc) = strip_parens(&rf.obj) else {
-            return false;
-        };
-        is_unresolved_named(cc, "cc", self.unresolved_mark)
-    }
-
-    fn first_arg_is_unresolved_module(&self, call: &CallExpr) -> bool {
-        let Some(first) = call.args.first() else {
-            return false;
-        };
-        if first.spread.is_some() {
-            return false;
-        }
-        matches!(
-            strip_parens(&first.expr),
-            Expr::Ident(ident) if is_unresolved_named(ident, "module", self.unresolved_mark)
-        )
-    }
-
     /// Skip visiting the first `module` ident of `cc._RF.push(module, …)`.
     /// Remaining args and the callee are still walked.
     fn should_skip_cc_rf_push_module_arg(&self, call: &CallExpr) -> bool {
+        if self.allowed_cc_rf_push_span != Some(call.span) {
+            return false;
+        }
         let Callee::Expr(callee) = &call.callee else {
             return false;
         };
-        self.is_cc_rf_push_callee(callee) && self.first_arg_is_unresolved_module(call)
+        is_cc_rf_method_callee(callee, "push", self.unresolved_mark)
+            && first_arg_is_unresolved_module(call, self.unresolved_mark)
     }
 
     /// Direct eval resolves `exports`/`module` from the calling scope, so it

--- a/crates/core/src/rules/un_enum.rs
+++ b/crates/core/src/rules/un_enum.rs
@@ -302,6 +302,64 @@ impl PublicExportUseFinder<'_> {
         matches!(obj, Expr::Ident(ident) if is_unresolved_named(ident, "module", self.unresolved_mark))
     }
 
+    /// Cocos 2.x `cc._RF.push(module, uuid, script)` stores the CJS module
+    /// handle for uuid / script-name registration. That bare `module` ident
+    /// is not a read of `exports.<public_name>`. Only unresolved `cc` plus
+    /// ident members `_RF.push` match; `cclegacy` and computed keys do not.
+    ///
+    /// `pop()` later iterates `module.exports` keys and may assign
+    /// `module.exports = frame.cls` if that object is empty. Folding the
+    /// enum removes a CJS write, so a real `module` could see a different
+    /// key set. UnEsm already emits `export class` beside the same marker,
+    /// which is the same mixed CJS/ESM contract; this skip matches that
+    /// recovered shape rather than re-running Cocos's loader.
+    fn is_cc_rf_push_callee(&self, callee: &Expr) -> bool {
+        let Expr::Member(push) = strip_parens(callee) else {
+            return false;
+        };
+        let MemberProp::Ident(push_name) = &push.prop else {
+            return false;
+        };
+        if push_name.sym != "push" {
+            return false;
+        }
+        let Expr::Member(rf) = strip_parens(&push.obj) else {
+            return false;
+        };
+        let MemberProp::Ident(rf_name) = &rf.prop else {
+            return false;
+        };
+        if rf_name.sym != "_RF" {
+            return false;
+        }
+        let Expr::Ident(cc) = strip_parens(&rf.obj) else {
+            return false;
+        };
+        is_unresolved_named(cc, "cc", self.unresolved_mark)
+    }
+
+    fn first_arg_is_unresolved_module(&self, call: &CallExpr) -> bool {
+        let Some(first) = call.args.first() else {
+            return false;
+        };
+        if first.spread.is_some() {
+            return false;
+        }
+        matches!(
+            strip_parens(&first.expr),
+            Expr::Ident(ident) if is_unresolved_named(ident, "module", self.unresolved_mark)
+        )
+    }
+
+    /// Skip visiting the first `module` ident of `cc._RF.push(module, …)`.
+    /// Remaining args and the callee are still walked.
+    fn should_skip_cc_rf_push_module_arg(&self, call: &CallExpr) -> bool {
+        let Callee::Expr(callee) = &call.callee else {
+            return false;
+        };
+        self.is_cc_rf_push_callee(callee) && self.first_arg_is_unresolved_module(call)
+    }
+
     /// Direct eval resolves `exports`/`module` from the calling scope, so it
     /// can read the surface invisibly to the AST scan. Returns true when the
     /// call was a direct eval (handled here, hazardous or not).
@@ -369,9 +427,20 @@ impl Visit for PublicExportUseFinder<'_> {
                 }
             }
         }
-        if !self.found {
-            call.visit_children_with(self);
+        if self.found {
+            return;
         }
+        if self.should_skip_cc_rf_push_module_arg(call) {
+            call.callee.visit_with(self);
+            for arg in call.args.iter().skip(1) {
+                if self.found {
+                    return;
+                }
+                arg.visit_with(self);
+            }
+            return;
+        }
+        call.visit_children_with(self);
     }
 
     fn visit_opt_call(&mut self, call: &OptCall) {

--- a/crates/core/tests/un_enum_rule.rs
+++ b/crates/core/tests/un_enum_rule.rs
@@ -128,6 +128,381 @@ export var Mode = {
     assert_eq_normalized(&apply_resolved(input), expected);
 }
 
+const CC_RF_PUSH: &str = r#"cc._RF.push(module, "uuid", "ScriptName");"#;
+const CC_RF_POP: &str = r#"cc._RF.pop();"#;
+
+fn collapsed_numeric_mode_iife() -> &'static str {
+    r#"(function (e) {
+  e[e.None = 0] = "None";
+})(exports.Mode || (exports.Mode = {}));"#
+}
+
+fn wrap_cc_rf(body: &str) -> String {
+    format!("{CC_RF_PUSH}\n{body}\n{CC_RF_POP}\n")
+}
+
+#[test]
+fn recovers_collapsed_enum_beside_cc_rf_push_module() {
+    let input = wrap_cc_rf(collapsed_numeric_mode_iife());
+    let expected = wrap_cc_rf(
+        r#"export var Mode = {
+  None: 0,
+  0: "None"
+};"#,
+    );
+    assert_eq_normalized(&apply_resolved(&input), &expected);
+}
+
+#[test]
+fn recovers_collapsed_arrow_enum_beside_cc_rf_push_module() {
+    let input = wrap_cc_rf(
+        r#"((t) => {
+  t[t.None = 0] = "None";
+})(exports.Mode || (exports.Mode = {}));"#,
+    );
+    let expected = wrap_cc_rf(
+        r#"export var Mode = {
+  None: 0,
+  0: "None"
+};"#,
+    );
+    assert_eq_normalized(&apply_resolved(&input), &expected);
+}
+
+#[test]
+fn collapsed_enum_rejects_cclegacy_rf_push_module() {
+    let input = r#"
+cclegacy._RF.push(module, "uuid", "ScriptName");
+(function (e) {
+  e[e.None = 0] = "None";
+})(exports.Mode || (exports.Mode = {}));
+cclegacy._RF.pop();
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_enum_rejects_cc_rf_push_module_exports() {
+    let input = format!(
+        "cc._RF.push(module.exports, \"uuid\", \"ScriptName\");\n{}\n{CC_RF_POP}\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_rejects_cc_rf_push_exports() {
+    let input = format!(
+        "cc._RF.push(exports, \"uuid\", \"ScriptName\");\n{}\n{CC_RF_POP}\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_rejects_cc_rf_push_extra_exports_mode_arg() {
+    let input = format!(
+        "cc._RF.push(module, exports.Mode);\n{}\n{CC_RF_POP}\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_rejects_local_cc_rf_push_module() {
+    let input = format!(
+        "const cc = fake;\ncc._RF.push(module, \"uuid\", \"ScriptName\");\n{}\ncc._RF.pop();\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_rejects_other_rf_push_module() {
+    let input = format!(
+        "other._RF.push(module, \"uuid\", \"ScriptName\");\n{}\n{CC_RF_POP}\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_rejects_cc_rf_unshift_module() {
+    let input = format!(
+        "cc._RF.unshift(module, \"uuid\", \"ScriptName\");\n{}\n{CC_RF_POP}\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_rejects_comma_called_cc_rf_push_module() {
+    let input = format!(
+        "(0, cc._RF.push)(module, \"uuid\", \"ScriptName\");\n{}\n{CC_RF_POP}\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_rejects_computed_cc_rf_push_keys() {
+    let input = r#"
+cc["_RF"]["push"](module, "uuid", "ScriptName");
+(function (e) {
+  e[e.None = 0] = "None";
+})(exports.Mode || (exports.Mode = {}));
+cc["_RF"].pop();
+"#;
+    assert_eq_normalized(&apply_resolved(input), input);
+}
+
+#[test]
+fn collapsed_enum_rejects_cc_rf_push_spread_module() {
+    let input = format!(
+        "cc._RF.push(...module, \"uuid\", \"ScriptName\");\n{}\n{CC_RF_POP}\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_rejects_cc_rf_push_second_module_arg() {
+    let input = format!(
+        "cc._RF.push(module, module);\n{}\n{CC_RF_POP}\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn pipeline_unbrackets_computed_cc_rf_push_then_recovers_enum() {
+    let input = r#"
+cc["_RF"]["push"](module, "uuid", "ScriptName");
+(function (e) {
+  e[e.None = 0] = "None";
+})(exports.Mode || (exports.Mode = {}));
+cc["_RF"].pop();
+"#;
+    let expected = r#"
+cc._RF.push(module, "uuid", "ScriptName");
+export const Mode = {
+  None: 0,
+  0: "None"
+};
+cc._RF.pop();
+"#;
+    assert_eq_normalized(&render_pipeline(input), expected);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_later_public_export_read() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nobserve(exports.Mode);",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_exports_escape() {
+    let input = wrap_cc_rf(&format!(
+        "const publicApi = exports;\n{}\nobserve(publicApi.Mode);",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_module_exports_read() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nobserve(module.exports.Mode);",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_other_bare_module() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nconst api = module;",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_surface_method_call() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nobserve(exports.hasOwnProperty(\"Mode\"));",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_module_identity_call() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nobserve(module.valueOf().exports.Mode);",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_direct_eval_reading_exports() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nobserve(eval(\"exports.Mode\"));",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_direct_eval_mentioning_name() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nobserve(eval(\"Mode\"));",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_unknown_direct_eval() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nobserve(eval(source));",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_existing_local_name() {
+    let input = wrap_cc_rf(&format!("var Mode = 1;\n{}", collapsed_numeric_mode_iife()));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_import_collision() {
+    let input = format!(
+        "import {{ Mode }} from \"./dep.js\";\n{CC_RF_PUSH}\n{}\n{CC_RF_POP}\nuse(Mode);\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_reserved_name() {
+    let input = wrap_cc_rf(
+        r#"(function (e) {
+  e["Dev"] = "dev";
+})(exports.class || (exports.class = {}));"#,
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_invalid_identifier_name() {
+    let input = wrap_cc_rf(
+        "(function (e) {\n  e[\"Dev\"] = \"dev\";\n})(exports[\"a\u{B2}\"] || (exports[\"a\u{B2}\"] = {}));",
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_duplicate_exported_class_name() {
+    let input = wrap_cc_rf(&format!(
+        "export class Mode {{}}\n{}",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_duplicate_esm_export() {
+    let input = wrap_cc_rf(&format!(
+        "var Existing;\nexport {{ Existing as Mode }};\n{}",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_delete_exports_mode() {
+    let input = wrap_cc_rf(&format!(
+        "{}\ndelete exports.Mode;",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_inner_class_despite_sibling_export() {
+    let input = wrap_cc_rf(
+        r#"export class Config {}
+(function (e) {
+  class Inner {}
+  e[e.Dev = 0] = "Dev";
+})(exports.Mode || (exports.Mode = {}));"#,
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_effectful_values() {
+    let input = wrap_cc_rf(
+        r#"(function (e) {
+  e[e.Dev = observe()] = "Dev";
+})(exports.Mode || (exports.Mode = {}));"#,
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_for_in_exports() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nfor (const k in exports) {{\n  observe(k);\n}}",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_for_in_module_exports() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nfor (const k in module.exports) {{\n  observe(k);\n}}",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_spread_exports() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nobserve({{ ...exports }});",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_destructured_exports() {
+    let input = wrap_cc_rf(&format!(
+        "{}\nconst {{ Mode }} = exports;",
+        collapsed_numeric_mode_iife()
+    ));
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_with_cc_rf_push_rejects_rest_param_iife() {
+    let input = wrap_cc_rf(
+        r#"(function (t, ...rest) {
+  t[t.Dev = 0] = "Dev";
+})(exports.Mode || (exports.Mode = {}));"#,
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
 #[test]
 fn collapsed_exported_enum_rejects_later_public_export_read() {
     let input = r#"

--- a/crates/core/tests/un_enum_rule.rs
+++ b/crates/core/tests/un_enum_rule.rs
@@ -170,6 +170,33 @@ fn recovers_collapsed_arrow_enum_beside_cc_rf_push_module() {
 }
 
 #[test]
+fn collapsed_enum_rejects_nested_cc_rf_marker_pair() {
+    let input = format!(
+        "function registerLater() {{\n  {CC_RF_PUSH}\n  {CC_RF_POP}\n}}\n{}\nregisterLater();\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_rejects_cc_rf_marker_pair_after_enum() {
+    let input = format!(
+        "{}\n{CC_RF_PUSH}\n{CC_RF_POP}\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
+fn collapsed_enum_rejects_closed_cc_rf_marker_pair_before_enum() {
+    let input = format!(
+        "{CC_RF_PUSH}\n{CC_RF_POP}\n{}\n",
+        collapsed_numeric_mode_iife()
+    );
+    assert_eq_normalized(&apply_resolved(&input), &input);
+}
+
+#[test]
 fn collapsed_enum_rejects_cclegacy_rf_push_module() {
     let input = r#"
 cclegacy._RF.push(module, "uuid", "ScriptName");


### PR DESCRIPTION
## Summary
- `PublicExportUseFinder::visit_ident` treats any unresolved bare `module` as an export-surface escape. Cocos 2.x `cc._RF.push(module, uuid, script)` therefore fail-closes collapsed numeric enum IIFEs that #206 already knows how to parse.
- This PR ignores only that first-argument unresolved `module` ident when the callee is unresolved `cc._RF.push` (ident members). Remaining arguments are still visited. `cclegacy._RF.push` is out of scope. UnEnum itself does not match computed keys; the full pipeline may unbracket `cc["_RF"]["push"]` first.
- No invented import / local. Dummy `exports.x = void 0` promotion and `require(base).Name` stay out of scope. Unrecognized shapes stay fail-closed.

`push` stores `{ uuid, script, module, exports: module.exports }` for `ccclass` registration ([requiring-frame.js](https://github.com/cocos-creator/engine/blob/2.4.13/cocos2d/core/platform/requiring-frame.js)). `pop()` iterates `module.exports` keys and may assign `module.exports = frame.cls` if that object is empty. Folding the enum removes a CJS write, so a real `module` object could observe a different key set at `pop`. That is the same mixed CJS/ESM contract UnEsm already uses when it emits `export class` beside preserved `_RF` markers. This change does not remove the marker calls or treat recovered files as re-runnable Cocos CJS.

Related: leftover from #206. Independent of SystemJS PRs. Does not recover dummy→`export let` or `require(base).Name`.

Please feel free to take it from here if that is easier.
Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
cc._RF.push(module, "uuid", "ScriptName");
(function (t) {
  t[t.None = 0] = "None";
})(exports.Mode || (exports.Mode = {}));
cc._RF.pop();
```

`wakaru --unpack` today leaves the IIFE. After this change: `export var Mode = { None: 0, 0: "None" }` with the `_RF` markers unchanged.

Covered by `recovers_collapsed_enum_beside_cc_rf_push_module`, matcher fail-closed tests (`cclegacy`, `module.exports` / `exports` as the first arg, extra `exports.Mode` / second `module` arg, spread `...module`, computed keys under UnEnum-only, local `cc`, comma-called `push`), `pipeline_unbrackets_computed_cc_rf_push_then_recovers_enum`, same-file surface / name-proof / `for-in` / spread / rest negatives, and existing `collapsed_exported_enum_rejects_*`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test un_enum_rule`
