### PR TITLE
fix(rules): recover proven top-level require(mod).Name as named import

### DIFF
--- a/crates/core/src/rules/un_esm.rs
+++ b/crates/core/src/rules/un_esm.rs
@@ -25,7 +25,9 @@ use crate::utils::paren::strip_parens;
 use crate::utils::prototype_members::is_prototype_mutating_member_name;
 
 use super::decl_utils::{collect_decl_names, collect_pat_names, same_ident};
-use super::eval_utils::{direct_eval_call_source, js_source_mentions_binding, EvalCallSource};
+use super::eval_utils::{
+    direct_eval_call_source, js_source_mentions_binding, DirectEvalAnalyzer, EvalCallSource,
+};
 use super::helper_matcher::count_binding_refs;
 use super::rename_utils::{collect_unresolved_reference_names, rename_bindings, BindingRename};
 use super::RewriteLevel;
@@ -3808,9 +3810,9 @@ fn has_hoistable_require(items: &[ModuleItem], unresolved_mark: Mark) -> bool {
         ModuleItem::Stmt(Stmt::Decl(Decl::Var(var_decl))) if var_decl.decls.len() == 1 => {
             var_decl.decls[0].init.as_ref().is_some_and(|init| {
                 try_extract_inline_conditional_interop(init, unresolved_mark).is_some()
-            })
+            }) || item_has_toplevel_require_named_member_arg(item, unresolved_mark)
         }
-        _ => false,
+        _ => item_has_toplevel_require_named_member_arg(item, unresolved_mark),
     })
 }
 
@@ -3933,6 +3935,304 @@ fn hoist_embedded_requires(module: &mut Module, unresolved_mark: Mark) {
         }
     }
 
+    module.body = new_body;
+    hoist_toplevel_require_named_member_args(module, unresolved_mark);
+}
+
+/// Top-level immediately-evaluated Call whose direct argument is
+/// `require("mod").Name` (not `.default`). Hoist to
+/// `const Name = require("mod").Name` immediately before the statement so
+/// the existing NamedProp classifier can emit `import { Name }`.
+///
+/// This pass is all-or-nothing: if any candidate fails the binding proof,
+/// no argument is rewritten. Other UnEsm paths still run.
+fn hoist_toplevel_require_named_member_args(module: &mut Module, unresolved_mark: Mark) {
+    let candidates = collect_toplevel_require_named_member_args(&module.body, unresolved_mark);
+    if candidates.is_empty() {
+        return;
+    }
+    let Some(plan) = prove_toplevel_require_named_member_args(module, unresolved_mark, &candidates)
+    else {
+        return;
+    };
+    apply_toplevel_require_named_member_args(module, plan);
+}
+
+struct ToplevelRequireNamedMemberArg {
+    item_index: usize,
+    arg_index: usize,
+    source: String,
+    name: Atom,
+}
+
+struct ToplevelRequireNamedMemberInsert {
+    local: Ident,
+    init: Box<Expr>,
+}
+
+struct ToplevelRequireNamedMemberPlan {
+    replacements: HashMap<usize, Vec<(usize, Ident)>>,
+    inserts: HashMap<usize, Vec<ToplevelRequireNamedMemberInsert>>,
+}
+
+fn item_has_toplevel_require_named_member_arg(item: &ModuleItem, unresolved_mark: Mark) -> bool {
+    let Some(call) = toplevel_item_call_expr(item) else {
+        return false;
+    };
+    call.args.iter().any(|arg| {
+        arg.spread.is_none()
+            && match_require_named_member_expr(&arg.expr, unresolved_mark).is_some()
+    })
+}
+
+fn collect_toplevel_require_named_member_args(
+    items: &[ModuleItem],
+    unresolved_mark: Mark,
+) -> Vec<ToplevelRequireNamedMemberArg> {
+    let mut candidates = Vec::new();
+    for (item_index, item) in items.iter().enumerate() {
+        let Some(call) = toplevel_item_call_expr(item) else {
+            continue;
+        };
+        for (arg_index, arg) in call.args.iter().enumerate() {
+            if arg.spread.is_some() {
+                continue;
+            }
+            let Some((source, name)) = match_require_named_member_expr(&arg.expr, unresolved_mark)
+            else {
+                continue;
+            };
+            candidates.push(ToplevelRequireNamedMemberArg {
+                item_index,
+                arg_index,
+                source,
+                name,
+            });
+        }
+    }
+    candidates
+}
+
+/// Direct argument of a top-level Call: `require("mod").Name` with a static
+/// string specifier and a non-`default` ident (or computed ident string).
+fn match_require_named_member_expr(expr: &Expr, unresolved_mark: Mark) -> Option<(String, Atom)> {
+    let Expr::Member(member) = strip_parens(expr) else {
+        return None;
+    };
+    let Expr::Call(call) = strip_parens(member.obj.as_ref()) else {
+        return None;
+    };
+    let source = is_require_call(call, unresolved_mark)?;
+    let prop = is_ident_prop(&member.prop)?;
+    if prop.as_ref() == "default" {
+        return None;
+    }
+    Some((source, prop))
+}
+
+fn toplevel_item_call_expr(item: &ModuleItem) -> Option<&CallExpr> {
+    let expr = match item {
+        ModuleItem::Stmt(Stmt::Expr(stmt)) => stmt.expr.as_ref(),
+        ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) if var.decls.len() == 1 => {
+            var.decls[0].init.as_deref()?
+        }
+        _ => return None,
+    };
+    match strip_parens(expr) {
+        Expr::Call(call) => Some(call),
+        _ => None,
+    }
+}
+
+fn toplevel_item_call_expr_mut(item: &mut ModuleItem) -> Option<&mut CallExpr> {
+    match item {
+        ModuleItem::Stmt(Stmt::Expr(stmt)) => call_expr_mut(stmt.expr.as_mut()),
+        ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) if var.decls.len() == 1 => {
+            call_expr_mut(var.decls[0].init.as_mut()?.as_mut())
+        }
+        _ => None,
+    }
+}
+
+fn call_expr_mut(expr: &mut Expr) -> Option<&mut CallExpr> {
+    match expr {
+        Expr::Call(call) => Some(call),
+        Expr::Paren(paren) => call_expr_mut(paren.expr.as_mut()),
+        _ => None,
+    }
+}
+
+fn existing_require_named_prop_item(
+    item: &ModuleItem,
+    source: &str,
+    name: &Atom,
+    unresolved_mark: Mark,
+) -> Option<Ident> {
+    let ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) = item else {
+        return None;
+    };
+    if var.decls.len() != 1 {
+        return None;
+    }
+    let decl = &var.decls[0];
+    let Pat::Ident(binding) = &decl.name else {
+        return None;
+    };
+    if binding.id.sym != *name {
+        return None;
+    }
+    let init = decl.init.as_deref()?;
+    match match_require_named_member_expr(init, unresolved_mark) {
+        Some((ref existing_source, ref prop)) if existing_source == source && prop == name => {
+            Some(binding.id.clone())
+        }
+        _ => None,
+    }
+}
+
+/// Reuse a NamedProp local only when it is declared *before* the call, already
+/// initialized, and never written. A later `var Name = require(src).Name` is
+/// not a stable identity for an earlier argument; a mutated local is not the
+/// original member read.
+fn reusable_require_named_prop(
+    items: &[ModuleItem],
+    source: &str,
+    name: &Atom,
+    before_item_index: usize,
+    unresolved_mark: Mark,
+    uses: &BindingUseIndex,
+) -> Option<Ident> {
+    let mut reusable = None;
+    for (index, item) in items.iter().enumerate() {
+        if index >= before_item_index {
+            break;
+        }
+        let Some(ident) = existing_require_named_prop_item(item, source, name, unresolved_mark)
+        else {
+            continue;
+        };
+        if uses.has_direct_write(&binding_id(&ident)) {
+            return None;
+        }
+        reusable = Some(ident);
+    }
+    reusable
+}
+
+fn candidate_named_member_init(
+    items: &[ModuleItem],
+    candidate: &ToplevelRequireNamedMemberArg,
+) -> Option<Box<Expr>> {
+    let call = toplevel_item_call_expr(&items[candidate.item_index])?;
+    let arg = call.args.get(candidate.arg_index)?;
+    Some(Box::new(strip_parens(arg.expr.as_ref()).clone()))
+}
+
+fn prove_toplevel_require_named_member_args(
+    module: &Module,
+    unresolved_mark: Mark,
+    candidates: &[ToplevelRequireNamedMemberArg],
+) -> Option<ToplevelRequireNamedMemberPlan> {
+    let mut eval_analyzer = DirectEvalAnalyzer::default();
+    module.visit_with(&mut eval_analyzer);
+    if eval_analyzer.unknown_direct_eval {
+        return None;
+    }
+
+    let declared_names = collect_all_declared_names(module);
+    let unresolved_reference_names = collect_unresolved_reference_names(module, unresolved_mark);
+    let uses = BindingUseIndex::collect(module);
+    let mut claimed_source_by_local: HashMap<Atom, String> = HashMap::new();
+    let mut claimed_local: HashMap<Atom, Ident> = HashMap::new();
+    let mut plan = ToplevelRequireNamedMemberPlan {
+        replacements: HashMap::new(),
+        inserts: HashMap::new(),
+    };
+
+    for candidate in candidates {
+        let name_str = candidate.name.as_ref();
+        if !is_valid_js_ident(name_str) || is_reserved_binding_name(name_str) {
+            return None;
+        }
+        if eval_analyzer
+            .known_direct_eval_sources
+            .iter()
+            .any(|source| js_source_mentions_binding(source, &candidate.name))
+        {
+            return None;
+        }
+
+        let local = if let Some(claimed_source) = claimed_source_by_local.get(&candidate.name) {
+            if claimed_source != &candidate.source {
+                return None;
+            }
+            claimed_local
+                .get(&candidate.name)
+                .cloned()
+                .expect("claimed source must have a local ident")
+        } else if let Some(existing) = reusable_require_named_prop(
+            &module.body,
+            &candidate.source,
+            &candidate.name,
+            candidate.item_index,
+            unresolved_mark,
+            &uses,
+        ) {
+            claimed_source_by_local.insert(candidate.name.clone(), candidate.source.clone());
+            claimed_local.insert(candidate.name.clone(), existing.clone());
+            existing
+        } else if declared_names.contains(&candidate.name)
+            || unresolved_reference_names.contains(&candidate.name)
+        {
+            return None;
+        } else {
+            let local = make_ident(candidate.name.clone());
+            claimed_source_by_local.insert(candidate.name.clone(), candidate.source.clone());
+            claimed_local.insert(candidate.name.clone(), local.clone());
+            let init = candidate_named_member_init(&module.body, candidate)?;
+            plan.inserts.entry(candidate.item_index).or_default().push(
+                ToplevelRequireNamedMemberInsert {
+                    local: local.clone(),
+                    init,
+                },
+            );
+            local
+        };
+
+        plan.replacements
+            .entry(candidate.item_index)
+            .or_default()
+            .push((candidate.arg_index, local));
+    }
+
+    Some(plan)
+}
+
+fn apply_toplevel_require_named_member_args(
+    module: &mut Module,
+    plan: ToplevelRequireNamedMemberPlan,
+) {
+    let mut new_body = Vec::with_capacity(module.body.len() + plan.inserts.len());
+    for (index, mut item) in std::mem::take(&mut module.body).into_iter().enumerate() {
+        if let Some(inserts) = plan.inserts.get(&index) {
+            for insert in inserts {
+                new_body.push(make_require_var_item(
+                    insert.local.clone(),
+                    insert.init.clone(),
+                ));
+            }
+        }
+        if let Some(replacements) = plan.replacements.get(&index) {
+            if let Some(call) = toplevel_item_call_expr_mut(&mut item) {
+                for (arg_index, ident) in replacements {
+                    if let Some(arg) = call.args.get_mut(*arg_index) {
+                        *arg.expr = Expr::Ident(ident.clone());
+                    }
+                }
+            }
+        }
+        new_body.push(item);
+    }
     module.body = new_body;
 }
 

--- a/crates/core/src/rules/un_esm.rs
+++ b/crates/core/src/rules/un_esm.rs
@@ -18,7 +18,7 @@ use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 use crate::analysis::binding_id;
 use crate::analysis::binding_uses::{BindingId, BindingUseIndex, UseKind};
 use crate::facts::{collect_module_facts, ModuleFactsMap};
-use crate::js_names::is_reserved_binding_name;
+use crate::js_names::{is_reserved_binding_name, is_valid_identifier_name};
 use crate::module_path::resolve_relative_specifier;
 use crate::provider_namespace_repair::run_provider_namespace_repair;
 use crate::utils::paren::strip_parens;
@@ -159,11 +159,21 @@ impl VisitMut for UnEsm {
             return;
         }
         let current_filename = self.current_filename.clone();
-        let original_cjs_module = if contains_local_self_require(
-            module,
-            self.unresolved_mark,
-            current_filename.as_deref(),
-        ) {
+        let has_local_self_require =
+            contains_local_self_require(module, self.unresolved_mark, current_filename.as_deref());
+        // The named-member argument pre-pass cannot prove that a self export
+        // is initialized before the call. Keep the whole CommonJS boundary;
+        // otherwise an early partial-object read becomes an ESM TDZ read.
+        if has_local_self_require
+            && has_toplevel_require_named_member_self_arg(
+                &module.body,
+                self.unresolved_mark,
+                current_filename.as_deref(),
+            )
+        {
+            return;
+        }
+        let original_cjs_module = if has_local_self_require {
             Some(module.clone())
         } else {
             None
@@ -4013,12 +4023,40 @@ fn collect_toplevel_require_named_member_args(
     candidates
 }
 
+fn has_toplevel_require_named_member_self_arg(
+    items: &[ModuleItem],
+    unresolved_mark: Mark,
+    current_filename: Option<&str>,
+) -> bool {
+    let Some(current_filename) = current_filename else {
+        return false;
+    };
+    let Some((normalized_filename, current_key)) = current_module_path_context(current_filename)
+    else {
+        return false;
+    };
+
+    collect_toplevel_require_named_member_args(items, unresolved_mark)
+        .into_iter()
+        .any(|candidate| {
+            resolve_relative_specifier(&normalized_filename, &candidate.source).as_deref()
+                == Some(&current_key)
+        })
+}
+
 /// Direct argument of a top-level Call: `require("mod").Name` with a static
 /// string specifier and a non-`default` ident (or computed ident string).
 fn match_require_named_member_expr(expr: &Expr, unresolved_mark: Mark) -> Option<(String, Atom)> {
     let Expr::Member(member) = strip_parens(expr) else {
         return None;
     };
+    match_require_named_member(member, unresolved_mark)
+}
+
+fn match_require_named_member(
+    member: &MemberExpr,
+    unresolved_mark: Mark,
+) -> Option<(String, Atom)> {
     let Expr::Call(call) = strip_parens(member.obj.as_ref()) else {
         return None;
     };
@@ -4028,6 +4066,77 @@ fn match_require_named_member_expr(expr: &Expr, unresolved_mark: Mark) -> Option
         return None;
     }
     Some((source, prop))
+}
+
+/// Collect direct mutations of `require(source).Name`. Replacing separate
+/// member reads with one recovered import is unsafe when the CommonJS object
+/// can be changed through the same static edge.
+struct RequireNamedMemberMutationCollector {
+    unresolved_mark: Mark,
+    write_target_depth: usize,
+    mutations: HashSet<(String, Atom)>,
+}
+
+impl RequireNamedMemberMutationCollector {
+    fn collect(module: &Module, unresolved_mark: Mark) -> HashSet<(String, Atom)> {
+        let mut collector = Self {
+            unresolved_mark,
+            write_target_depth: 0,
+            mutations: HashSet::new(),
+        };
+        module.visit_with(&mut collector);
+        collector.mutations
+    }
+}
+
+impl Visit for RequireNamedMemberMutationCollector {
+    fn visit_member_expr(&mut self, member: &MemberExpr) {
+        if self.write_target_depth > 0 {
+            if let Some(mutation) = match_require_named_member(member, self.unresolved_mark) {
+                self.mutations.insert(mutation);
+            }
+        }
+        member.visit_children_with(self);
+    }
+
+    fn visit_assign_expr(&mut self, assignment: &AssignExpr) {
+        self.write_target_depth += 1;
+        assignment.left.visit_with(self);
+        self.write_target_depth -= 1;
+        assignment.right.visit_with(self);
+    }
+
+    fn visit_update_expr(&mut self, update: &swc_core::ecma::ast::UpdateExpr) {
+        self.write_target_depth += 1;
+        update.arg.visit_with(self);
+        self.write_target_depth -= 1;
+    }
+
+    fn visit_unary_expr(&mut self, unary: &swc_core::ecma::ast::UnaryExpr) {
+        if unary.op == UnaryOp::Delete {
+            self.write_target_depth += 1;
+            unary.arg.visit_with(self);
+            self.write_target_depth -= 1;
+        } else {
+            unary.visit_children_with(self);
+        }
+    }
+
+    fn visit_for_in_stmt(&mut self, stmt: &ForInStmt) {
+        self.write_target_depth += 1;
+        stmt.left.visit_with(self);
+        self.write_target_depth -= 1;
+        stmt.right.visit_with(self);
+        stmt.body.visit_with(self);
+    }
+
+    fn visit_for_of_stmt(&mut self, stmt: &swc_core::ecma::ast::ForOfStmt) {
+        self.write_target_depth += 1;
+        stmt.left.visit_with(self);
+        self.write_target_depth -= 1;
+        stmt.right.visit_with(self);
+        stmt.body.visit_with(self);
+    }
 }
 
 fn toplevel_item_call_expr(item: &ModuleItem) -> Option<&CallExpr> {
@@ -4142,6 +4251,8 @@ fn prove_toplevel_require_named_member_args(
     let declared_names = collect_all_declared_names(module);
     let unresolved_reference_names = collect_unresolved_reference_names(module, unresolved_mark);
     let uses = BindingUseIndex::collect(module);
+    let provider_member_mutations =
+        RequireNamedMemberMutationCollector::collect(module, unresolved_mark);
     let mut claimed_source_by_local: HashMap<Atom, String> = HashMap::new();
     let mut claimed_local: HashMap<Atom, Ident> = HashMap::new();
     let mut plan = ToplevelRequireNamedMemberPlan {
@@ -4151,7 +4262,10 @@ fn prove_toplevel_require_named_member_args(
 
     for candidate in candidates {
         let name_str = candidate.name.as_ref();
-        if !is_valid_js_ident(name_str) || is_reserved_binding_name(name_str) {
+        if !is_valid_identifier_name(name_str) || is_reserved_binding_name(name_str) {
+            return None;
+        }
+        if provider_member_mutations.contains(&(candidate.source.clone(), candidate.name.clone())) {
             return None;
         }
         if eval_analyzer

--- a/crates/core/tests/un_esm_rule.rs
+++ b/crates/core/tests/un_esm_rule.rs
@@ -2759,3 +2759,520 @@ module.exports.default = module.exports;
         "optional-chained module access must fail the coupling proof:\n{output}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Top-level Call args: require("mod").Name → named import
+//
+// Producer: a CJS compiler emits a static `require(mod).Name` as a direct
+// argument of an immediately-evaluated top-level call (typically an IIFE).
+// UnEsm already converts `var x = require("mod").Name` via NamedProp; this
+// shape never reached that classifier. `.default` args stay out of scope.
+// ---------------------------------------------------------------------------
+
+fn leftover_require_named_member(output: &str) -> bool {
+    output.contains("require(") && output.contains(".UIBase")
+}
+
+fn apply_unesm(input: &str) -> String {
+    render_pipeline_until(input, "UnEsm")
+}
+
+#[test]
+fn toplevel_iife_require_named_member_arg_to_named_import() {
+    let input = r#"
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import { UIBase } from "./UIBase.js";
+(function (base) {
+  use(base);
+})(UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+    assert!(
+        !output.contains("require("),
+        "the hoisted named member must become an import:\n{output}"
+    );
+}
+
+#[test]
+fn toplevel_iife_require_named_member_arg_survives_later_rules() {
+    let input = r#"
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let output = apply(input);
+    assert!(
+        output.contains("import { UIBase } from \"./UIBase.js\"") && !output.contains("require("),
+        "later rules must keep the named import:\n{output}"
+    );
+}
+
+#[test]
+fn toplevel_var_init_iife_require_named_member_arg_to_named_import() {
+    let input = r#"
+var Child = (function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import { UIBase } from "./UIBase.js";
+var Child = function (base) {
+  use(base);
+}(UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_iife_computed_ident_require_named_member_arg_to_named_import() {
+    // UnBracketNotation may already fold this to `.UIBase`; UnEsm must still
+    // accept `is_ident_prop` computed strings if the member survives.
+    let input = r#"
+(function (base) {
+  use(base);
+})(require("./UIBase.js")["UIBase"]);
+"#;
+    let expected = r#"
+import { UIBase } from "./UIBase.js";
+(function (base) {
+  use(base);
+})(UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_arg_reuses_existing_named_prop() {
+    let input = r#"
+var UIBase = require("./UIBase.js").UIBase;
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import { UIBase } from "./UIBase.js";
+(function (base) {
+  use(base);
+})(UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_arg_reuses_existing_named_prop_through_full_pipeline() {
+    // Replacing the argument with make_ident() would drop the resolved ctxt of
+    // `var UIBase`, so DeadImports would treat the named import as unused.
+    let input = r#"
+var UIBase = require("./UIBase.js").UIBase;
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import { UIBase } from "./UIBase.js";
+((base) => {
+  use(base);
+})(UIBase);
+"#;
+    let output = render_pipeline(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_iife_require_named_member_arg_keeps_import_through_full_pipeline() {
+    let input = r#"
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import { UIBase } from "./UIBase.js";
+((base) => {
+  use(base);
+})(UIBase);
+"#;
+    let output = render_pipeline(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_does_not_reuse_later_named_prop() {
+    let input = r#"
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+var UIBase = require("./UIBase.js").UIBase;
+var keep = require("./keep.js");
+"#;
+    let expected = r#"
+import { UIBase } from "./UIBase.js";
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_does_not_reuse_mutated_named_prop() {
+    let input = r#"
+var UIBase = require("./UIBase.js").UIBase;
+UIBase = other;
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+var keep = require("./keep.js");
+"#;
+    let output = apply_unesm(input);
+    assert!(
+        output.contains("require(\"./UIBase.js\").UIBase")
+            && output.contains("import keep from \"./keep.js\""),
+        "a mutated NamedProp local must not be reused as the call argument:\n{output}"
+    );
+}
+
+#[test]
+fn toplevel_require_named_member_default_arg_is_out_of_scope() {
+    let input = r#"
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_ternary_arg_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+f(cond ? require("./UIBase.js").UIBase : other);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+f(cond ? require("./UIBase.js").UIBase : other);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_inside_then_callback_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+then(function () {
+  return require("./UIBase.js").UIBase;
+});
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+then(function () {
+  return require("./UIBase.js").UIBase;
+});
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_inside_function_body_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+function wrap() {
+  (function (base) {
+    use(base);
+  })(require("./UIBase.js").UIBase);
+}
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+function wrap() {
+  (function (base) {
+    use(base);
+  })(require("./UIBase.js").UIBase);
+}
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_dynamic_require_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require(dyn).UIBase);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})(require(dyn).UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_spread_arg_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+f(...require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+f(...require("./UIBase.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_computed_dynamic_key_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js")[key]);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})(require("./UIBase.js")[key]);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_local_require_binding_is_left_alone() {
+    let input = r#"
+function require(x) {
+  return x;
+}
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, input);
+}
+
+#[test]
+fn toplevel_require_named_member_comma_expr_arg_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})((0, require("./UIBase.js").UIBase));
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})((0, require("./UIBase.js").UIBase));
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_existing_import_local() {
+    let input = r#"
+import { UIBase } from "./other.js";
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import { UIBase } from "./other.js";
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_existing_let_binding() {
+    let input = r#"
+let UIBase = 0;
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+let UIBase = 0;
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_unresolved_reference() {
+    let input = r#"
+observe(UIBase);
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+observe(UIBase);
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_two_sources_one_local() {
+    let input = r#"
+var keep = require("./keep.js");
+(function (a) {
+  use(a);
+})(require("./A.js").A);
+(function (b) {
+  use(b);
+})(require("./B.js").A);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+(function (a) {
+  use(a);
+})(require("./A.js").A);
+(function (b) {
+  use(b);
+})(require("./B.js").A);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_eval_of_name() {
+    let input = r#"
+eval("UIBase");
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+eval("UIBase");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_dynamic_eval() {
+    let input = r#"
+eval(source);
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+eval(source);
+(function (base) {
+  use(base);
+})(require("./UIBase.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_reserved_prop() {
+    let input = r#"
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./X.js").class);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})(require("./X.js").class);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_illegal_ident_prop() {
+    let input = r#"
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./X.js")["foo-bar"]);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})(require("./X.js")["foo-bar"]);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_sibling_import_does_not_recover_default_arg() {
+    let input = r#"
+import { keep } from "./keep.js";
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import { keep } from "./keep.js";
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+    assert!(
+        leftover_require_named_member(&output) || output.contains(".default"),
+        "a sibling named import must not recover an out-of-scope .default arg:\n{output}"
+    );
+}

--- a/crates/core/tests/un_esm_rule.rs
+++ b/crates/core/tests/un_esm_rule.rs
@@ -3256,6 +3256,92 @@ import keep from "./keep.js";
 }
 
 #[test]
+fn toplevel_require_named_member_fails_closed_on_invalid_unicode_ident_prop() {
+    let input = r#"
+var keep = require("./keep.js");
+f(require("./X.js")["a²"]);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+f(require("./X.js")["a²"]);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_early_self_read_keeps_commonjs_boundary() {
+    let input = r#"
+consume(require("./module-1.js").value);
+exports.value = 1;
+"#;
+    let output = render_pipeline_until_with_filename(input, "UnEsm", "module-1.js");
+
+    assert_eq_normalized(&output, input);
+    assert!(
+        !output.contains("import ") && !output.contains("export "),
+        "a direct named self-read must not cross only part of its CommonJS boundary:\n{output}"
+    );
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_provider_member_write() {
+    let input = r#"
+consume(require("./dep.js").UIBase);
+require("./dep.js").UIBase = replacement;
+consume(require("./dep.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+
+    assert_eq_normalized(&output, input);
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_other_provider_member_mutations() {
+    let mutations = [
+        r#"require("./dep.js").UIBase += replacement;"#,
+        r#"require("./dep.js").UIBase++;"#,
+        r#"delete require("./dep.js").UIBase;"#,
+        r#"for (require("./dep.js").UIBase in values) {}"#,
+        r#"for (require("./dep.js").UIBase of values) {}"#,
+    ];
+
+    for mutation in mutations {
+        let input = format!(
+            r#"
+consume(require("./dep.js").UIBase);
+{mutation}
+consume(require("./dep.js").UIBase);
+"#
+        );
+        let output = apply_unesm(&input);
+
+        assert!(
+            !output.contains("import { UIBase }")
+                && output.matches("require(\"./dep.js\").UIBase").count() >= 2,
+            "provider mutation must keep fresh member reads:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn toplevel_require_named_member_does_not_reuse_local_across_provider_member_write() {
+    let input = r#"
+var UIBase = require("./dep.js").UIBase;
+require("./dep.js").UIBase = replacement;
+consume(require("./dep.js").UIBase);
+"#;
+    let expected = r#"
+import { UIBase } from "./dep.js";
+require("./dep.js").UIBase = replacement;
+consume(require("./dep.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
 fn toplevel_require_named_member_sibling_import_does_not_recover_default_arg() {
     let input = r#"
 import { keep } from "./keep.js";


### PR DESCRIPTION
## Summary
- `try_classify_cjs_require` already turns `var foo = require("bar").baz` into a named import via NamedProp. `has_hoistable_require` / `hoist_embedded_requires` never walked a top-level Call's **direct** `require("mod").Name` argument, so that producer shape stayed as `require(`.
- This PR only admits that proven shape: hoist `const Name = require("src").Name` immediately before the statement and replace the argument with ident `Name`, then reuse NamedProp. The hoist pass is all-or-nothing; other UnEsm paths still run. `.default` arguments stay out of scope.
- Does not invent aliases. Name collisions, `eval`, and reserved keys fail closed for this pass. Does not recover `__extends`, dummy→`export let`, or UnEs6Class.

Related: leftover from #206. Independent of #220 / SystemJS. Does not recover `.default` args, `__extends`, or dummy→`export let`.

Please feel free to take it from here if that is easier.
Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
(function (base) {
  use(base);
})(require("./UIBase.js").UIBase);
```

`wakaru --unpack` today: leftover `require("./UIBase.js").UIBase`. After this change: `import { UIBase } from "./UIBase.js"` and the argument is the ident `UIBase`.

Covered by `toplevel_iife_require_named_member_arg_to_named_import`, `toplevel_require_named_member_default_arg_is_out_of_scope`, `toplevel_require_named_member_fails_closed_on_unresolved_reference`, and existing `property_require_to_named_import`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test un_esm_rule`
