### PR TITLE
fix(rules): recover proven top-level require(mod).default as default import

### DIFF
--- a/crates/core/src/rules/rename_utils.rs
+++ b/crates/core/src/rules/rename_utils.rs
@@ -52,11 +52,12 @@ pub(crate) fn collect_jsx_tag_bindings(module: &Module) -> HashSet<BindingId> {
     collector.bindings
 }
 
-/// Names used by unresolved expression references in this module.
+/// Names used by unresolved identifier references in this module.
 ///
 /// A transform that introduces a module-scoped binding with one of these
 /// names would capture the reference even though their syntax contexts differ
-/// before the transform.
+/// before the transform. Visit identifiers directly so write targets and JSX
+/// element names are covered as well as value-position expressions.
 pub(crate) fn collect_unresolved_reference_names(
     module: &Module,
     unresolved_mark: Mark,
@@ -67,13 +68,10 @@ pub(crate) fn collect_unresolved_reference_names(
     }
 
     impl Visit for Collector {
-        fn visit_expr(&mut self, expr: &Expr) {
-            if let Expr::Ident(ident) = expr {
-                if ident.ctxt.outer() == self.unresolved_mark {
-                    self.names.insert(ident.sym.clone());
-                }
+        fn visit_ident(&mut self, ident: &Ident) {
+            if ident.ctxt.outer() == self.unresolved_mark {
+                self.names.insert(ident.sym.clone());
             }
-            expr.visit_children_with(self);
         }
     }
 

--- a/crates/core/src/rules/un_esm.rs
+++ b/crates/core/src/rules/un_esm.rs
@@ -29,7 +29,9 @@ use super::eval_utils::{
     direct_eval_call_source, js_source_mentions_binding, DirectEvalAnalyzer, EvalCallSource,
 };
 use super::helper_matcher::count_binding_refs;
-use super::rename_utils::{collect_unresolved_reference_names, rename_bindings, BindingRename};
+use super::rename_utils::{
+    collect_module_names, collect_unresolved_reference_names, rename_bindings, BindingRename,
+};
 use super::RewriteLevel;
 
 pub struct UnEsm {
@@ -4563,7 +4565,7 @@ fn existing_default_import_item(item: &ModuleItem, source: &str) -> Option<Ident
     let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
         return None;
     };
-    if wtf8_to_string(&import.src.value) != source {
+    if import.type_only || wtf8_to_string(&import.src.value) != source {
         return None;
     }
     import.specifiers.iter().find_map(|spec| match spec {
@@ -6409,7 +6411,7 @@ fn collect_all_declared_names(module: &Module) -> HashSet<Atom> {
     }
 
     let mut collector = Collector {
-        names: HashSet::new(),
+        names: collect_module_names(module),
     };
     module.visit_with(&mut collector);
     collector.names

--- a/crates/core/src/rules/un_esm.rs
+++ b/crates/core/src/rules/un_esm.rs
@@ -161,15 +161,20 @@ impl VisitMut for UnEsm {
         let current_filename = self.current_filename.clone();
         let has_local_self_require =
             contains_local_self_require(module, self.unresolved_mark, current_filename.as_deref());
-        // The named-member argument pre-pass cannot prove that a self export
-        // is initialized before the call. Keep the whole CommonJS boundary;
-        // otherwise an early partial-object read becomes an ESM TDZ read.
+        // Named/default member argument pre-passes cannot prove that a self
+        // export is initialized before the call. Keep the whole CommonJS
+        // boundary; otherwise an early partial-object read becomes an ESM TDZ
+        // read.
         if has_local_self_require
-            && has_toplevel_require_named_member_self_arg(
+            && (has_toplevel_require_named_member_self_arg(
                 &module.body,
                 self.unresolved_mark,
                 current_filename.as_deref(),
-            )
+            ) || has_toplevel_require_default_member_self_arg(
+                &module.body,
+                self.unresolved_mark,
+                current_filename.as_deref(),
+            ))
         {
             return;
         }
@@ -181,6 +186,11 @@ impl VisitMut for UnEsm {
         recover_coupled_commonjs_default_binding(module, self.unresolved_mark);
         // Phase -1: hoist require() calls out of complex expressions
         hoist_embedded_requires(module, self.unresolved_mark);
+        // Parallel to the named-member pass inside hoist_embedded_requires.
+        // Must not sit behind has_hoistable_require: a file whose only
+        // hoistable shape is `require(mod).default` as a call argument would
+        // otherwise skip the pre-pass entirely.
+        hoist_toplevel_require_default_member_args(module, self.unresolved_mark);
         split_called_module_exports_assignments(module, self.unresolved_mark);
         split_chained_local_module_exports_assignments(module, self.unresolved_mark);
         // Phase 0: split compound `var s = exports.X = expr` →
@@ -4325,6 +4335,387 @@ fn prove_toplevel_require_named_member_args(
 fn apply_toplevel_require_named_member_args(
     module: &mut Module,
     plan: ToplevelRequireNamedMemberPlan,
+) {
+    let mut new_body = Vec::with_capacity(module.body.len() + plan.inserts.len());
+    for (index, mut item) in std::mem::take(&mut module.body).into_iter().enumerate() {
+        if let Some(inserts) = plan.inserts.get(&index) {
+            for insert in inserts {
+                new_body.push(make_require_var_item(
+                    insert.local.clone(),
+                    insert.init.clone(),
+                ));
+            }
+        }
+        if let Some(replacements) = plan.replacements.get(&index) {
+            if let Some(call) = toplevel_item_call_expr_mut(&mut item) {
+                for (arg_index, ident) in replacements {
+                    if let Some(arg) = call.args.get_mut(*arg_index) {
+                        *arg.expr = Expr::Ident(ident.clone());
+                    }
+                }
+            }
+        }
+        new_body.push(item);
+    }
+    module.body = new_body;
+}
+
+/// Top-level immediately-evaluated Call whose direct argument is
+/// `require("mod").default`. Hoist to `const L = require("mod").default`
+/// immediately before the statement so the existing DefaultProp classifier
+/// can emit `import L from "mod"`.
+///
+/// Independent of the named-member pass: a failed default proof must not
+/// roll back named recovery, and vice versa. This pass is all-or-nothing
+/// for `.default` arguments only.
+fn hoist_toplevel_require_default_member_args(module: &mut Module, unresolved_mark: Mark) {
+    let candidates = collect_toplevel_require_default_member_args(&module.body, unresolved_mark);
+    if candidates.is_empty() {
+        return;
+    }
+    let Some(plan) =
+        prove_toplevel_require_default_member_args(module, unresolved_mark, &candidates)
+    else {
+        return;
+    };
+    apply_toplevel_require_default_member_args(module, plan);
+}
+
+struct ToplevelRequireDefaultMemberArg {
+    item_index: usize,
+    arg_index: usize,
+    source: String,
+}
+
+struct ToplevelRequireDefaultMemberInsert {
+    local: Ident,
+    init: Box<Expr>,
+}
+
+struct ToplevelRequireDefaultMemberPlan {
+    replacements: HashMap<usize, Vec<(usize, Ident)>>,
+    inserts: HashMap<usize, Vec<ToplevelRequireDefaultMemberInsert>>,
+}
+
+fn collect_toplevel_require_default_member_args(
+    items: &[ModuleItem],
+    unresolved_mark: Mark,
+) -> Vec<ToplevelRequireDefaultMemberArg> {
+    let mut candidates = Vec::new();
+    for (item_index, item) in items.iter().enumerate() {
+        let Some(call) = toplevel_item_call_expr(item) else {
+            continue;
+        };
+        for (arg_index, arg) in call.args.iter().enumerate() {
+            if arg.spread.is_some() {
+                continue;
+            }
+            let Some(source) = match_require_default_member_expr(&arg.expr, unresolved_mark) else {
+                continue;
+            };
+            candidates.push(ToplevelRequireDefaultMemberArg {
+                item_index,
+                arg_index,
+                source,
+            });
+        }
+    }
+    candidates
+}
+
+fn has_toplevel_require_default_member_self_arg(
+    items: &[ModuleItem],
+    unresolved_mark: Mark,
+    current_filename: Option<&str>,
+) -> bool {
+    let Some(current_filename) = current_filename else {
+        return false;
+    };
+    let Some((normalized_filename, current_key)) = current_module_path_context(current_filename)
+    else {
+        return false;
+    };
+
+    collect_toplevel_require_default_member_args(items, unresolved_mark)
+        .into_iter()
+        .any(|candidate| {
+            resolve_relative_specifier(&normalized_filename, &candidate.source).as_deref()
+                == Some(&current_key)
+        })
+}
+
+/// Direct argument of a top-level Call: `require("mod").default` with a
+/// static string specifier (Ident or computed ident string). Does not share
+/// `match_require_named_member`, which must keep skipping `.default`.
+fn match_require_default_member_expr(expr: &Expr, unresolved_mark: Mark) -> Option<String> {
+    let Expr::Member(member) = strip_parens(expr) else {
+        return None;
+    };
+    match_require_default_member(member, unresolved_mark)
+}
+
+fn match_require_default_member(member: &MemberExpr, unresolved_mark: Mark) -> Option<String> {
+    let Expr::Call(call) = strip_parens(member.obj.as_ref()) else {
+        return None;
+    };
+    let source = is_require_call(call, unresolved_mark)?;
+    let prop = is_ident_prop(&member.prop)?;
+    if prop.as_ref() != "default" {
+        return None;
+    }
+    Some(source)
+}
+
+/// Collect direct mutations of `require(source).default`. Folding later
+/// default-member reads into one recovered import is unsafe when the
+/// CommonJS object can be changed through the same static edge.
+struct RequireDefaultMemberMutationCollector {
+    unresolved_mark: Mark,
+    write_target_depth: usize,
+    mutations: HashSet<String>,
+}
+
+impl RequireDefaultMemberMutationCollector {
+    fn collect(module: &Module, unresolved_mark: Mark) -> HashSet<String> {
+        let mut collector = Self {
+            unresolved_mark,
+            write_target_depth: 0,
+            mutations: HashSet::new(),
+        };
+        module.visit_with(&mut collector);
+        collector.mutations
+    }
+}
+
+impl Visit for RequireDefaultMemberMutationCollector {
+    fn visit_member_expr(&mut self, member: &MemberExpr) {
+        if self.write_target_depth > 0 {
+            if let Some(source) = match_require_default_member(member, self.unresolved_mark) {
+                self.mutations.insert(source);
+            }
+        }
+        member.visit_children_with(self);
+    }
+
+    fn visit_assign_expr(&mut self, assignment: &AssignExpr) {
+        self.write_target_depth += 1;
+        assignment.left.visit_with(self);
+        self.write_target_depth -= 1;
+        assignment.right.visit_with(self);
+    }
+
+    fn visit_update_expr(&mut self, update: &swc_core::ecma::ast::UpdateExpr) {
+        self.write_target_depth += 1;
+        update.arg.visit_with(self);
+        self.write_target_depth -= 1;
+    }
+
+    fn visit_unary_expr(&mut self, unary: &swc_core::ecma::ast::UnaryExpr) {
+        if unary.op == UnaryOp::Delete {
+            self.write_target_depth += 1;
+            unary.arg.visit_with(self);
+            self.write_target_depth -= 1;
+        } else {
+            unary.visit_children_with(self);
+        }
+    }
+
+    fn visit_for_in_stmt(&mut self, stmt: &ForInStmt) {
+        self.write_target_depth += 1;
+        stmt.left.visit_with(self);
+        self.write_target_depth -= 1;
+        stmt.right.visit_with(self);
+        stmt.body.visit_with(self);
+    }
+
+    fn visit_for_of_stmt(&mut self, stmt: &swc_core::ecma::ast::ForOfStmt) {
+        self.write_target_depth += 1;
+        stmt.left.visit_with(self);
+        self.write_target_depth -= 1;
+        stmt.right.visit_with(self);
+        stmt.body.visit_with(self);
+    }
+}
+
+fn existing_require_default_prop_item(
+    item: &ModuleItem,
+    source: &str,
+    unresolved_mark: Mark,
+) -> Option<Ident> {
+    let ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) = item else {
+        return None;
+    };
+    if var.decls.len() != 1 {
+        return None;
+    }
+    let decl = &var.decls[0];
+    let Pat::Ident(binding) = &decl.name else {
+        return None;
+    };
+    let init = decl.init.as_deref()?;
+    match match_require_default_member_expr(init, unresolved_mark) {
+        Some(ref existing_source) if existing_source == source => Some(binding.id.clone()),
+        _ => None,
+    }
+}
+
+fn existing_default_import_item(item: &ModuleItem, source: &str) -> Option<Ident> {
+    let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
+        return None;
+    };
+    if wtf8_to_string(&import.src.value) != source {
+        return None;
+    }
+    import.specifiers.iter().find_map(|spec| match spec {
+        ImportSpecifier::Default(default) => Some(default.local.clone()),
+        _ => None,
+    })
+}
+
+/// Reuse a DefaultProp local or an existing default import only when it is
+/// declared *before* the call and never written. A later
+/// `var L = require(src).default` is not a stable identity for an earlier
+/// argument; a mutated local is not the original member read.
+fn reusable_require_default_local(
+    items: &[ModuleItem],
+    source: &str,
+    before_item_index: usize,
+    unresolved_mark: Mark,
+    uses: &BindingUseIndex,
+) -> Option<Ident> {
+    let mut reusable = None;
+    for (index, item) in items.iter().enumerate() {
+        if index >= before_item_index {
+            break;
+        }
+        let ident = existing_require_default_prop_item(item, source, unresolved_mark)
+            .or_else(|| existing_default_import_item(item, source));
+        let Some(ident) = ident else {
+            continue;
+        };
+        if uses.has_direct_write(&binding_id(&ident)) {
+            // A mutated earlier DefaultProp is not reusable, but a later
+            // stable binding of the same source still is.
+            continue;
+        }
+        reusable = Some(ident);
+    }
+    reusable
+}
+
+fn candidate_default_member_init(
+    items: &[ModuleItem],
+    candidate: &ToplevelRequireDefaultMemberArg,
+) -> Option<Box<Expr>> {
+    let call = toplevel_item_call_expr(&items[candidate.item_index])?;
+    let arg = call.args.get(candidate.arg_index)?;
+    Some(Box::new(strip_parens(arg.expr.as_ref()).clone()))
+}
+
+fn specifier_basename(source: &str) -> Option<Atom> {
+    let last = source.rsplit('/').next().unwrap_or(source);
+    let stem = last.strip_suffix(".js").unwrap_or(last);
+    if stem.is_empty() {
+        return None;
+    }
+    if !is_valid_identifier_name(stem) || is_reserved_binding_name(stem) {
+        return None;
+    }
+    Some(Atom::from(stem))
+}
+
+fn direct_eval_mentions_name(analyzer: &DirectEvalAnalyzer, name: &Atom) -> bool {
+    analyzer
+        .known_direct_eval_sources
+        .iter()
+        .any(|source| js_source_mentions_binding(source, name))
+}
+
+fn prove_toplevel_require_default_member_args(
+    module: &Module,
+    unresolved_mark: Mark,
+    candidates: &[ToplevelRequireDefaultMemberArg],
+) -> Option<ToplevelRequireDefaultMemberPlan> {
+    let mut eval_analyzer = DirectEvalAnalyzer::default();
+    module.visit_with(&mut eval_analyzer);
+    if eval_analyzer.unknown_direct_eval {
+        return None;
+    }
+
+    let declared_names = collect_all_declared_names(module);
+    let unresolved_reference_names = collect_unresolved_reference_names(module, unresolved_mark);
+    let uses = BindingUseIndex::collect(module);
+    let provider_member_mutations =
+        RequireDefaultMemberMutationCollector::collect(module, unresolved_mark);
+    let mut used_names = declared_names;
+    used_names.extend(unresolved_reference_names);
+    let mut claimed_local_by_source: HashMap<String, Ident> = HashMap::new();
+    let mut plan = ToplevelRequireDefaultMemberPlan {
+        replacements: HashMap::new(),
+        inserts: HashMap::new(),
+    };
+    let default_prefix = Atom::from("default");
+
+    for candidate in candidates {
+        if provider_member_mutations.contains(&candidate.source) {
+            return None;
+        }
+
+        let local = if let Some(existing) = claimed_local_by_source.get(&candidate.source) {
+            existing.clone()
+        } else if let Some(existing) = reusable_require_default_local(
+            &module.body,
+            &candidate.source,
+            candidate.item_index,
+            unresolved_mark,
+            &uses,
+        ) {
+            claimed_local_by_source.insert(candidate.source.clone(), existing.clone());
+            existing
+        } else {
+            let basename = specifier_basename(&candidate.source);
+            let local_name = if let Some(ref name) = basename {
+                if !used_names.contains(name) && !direct_eval_mentions_name(&eval_analyzer, name) {
+                    used_names.insert(name.clone());
+                    name.clone()
+                } else {
+                    let synthetic = fresh_prefixed_name(&default_prefix, &mut used_names);
+                    if direct_eval_mentions_name(&eval_analyzer, &synthetic) {
+                        return None;
+                    }
+                    synthetic
+                }
+            } else {
+                let synthetic = fresh_prefixed_name(&default_prefix, &mut used_names);
+                if direct_eval_mentions_name(&eval_analyzer, &synthetic) {
+                    return None;
+                }
+                synthetic
+            };
+            let local = make_ident(local_name);
+            claimed_local_by_source.insert(candidate.source.clone(), local.clone());
+            let init = candidate_default_member_init(&module.body, candidate)?;
+            plan.inserts.entry(candidate.item_index).or_default().push(
+                ToplevelRequireDefaultMemberInsert {
+                    local: local.clone(),
+                    init,
+                },
+            );
+            local
+        };
+
+        plan.replacements
+            .entry(candidate.item_index)
+            .or_default()
+            .push((candidate.arg_index, local));
+    }
+
+    Some(plan)
+}
+
+fn apply_toplevel_require_default_member_args(
+    module: &mut Module,
+    plan: ToplevelRequireDefaultMemberPlan,
 ) {
     let mut new_body = Vec::with_capacity(module.body.len() + plan.inserts.len());
     for (index, mut item) in std::mem::take(&mut module.body).into_iter().enumerate() {

--- a/crates/core/tests/un_esm_rule.rs
+++ b/crates/core/tests/un_esm_rule.rs
@@ -3157,6 +3157,38 @@ observe(UIBase);
 }
 
 #[test]
+fn toplevel_require_named_member_fails_closed_on_unresolved_assignment_target() {
+    let input = r#"
+UIBase = globalValue;
+var keep = require("./keep.js");
+consume(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+UIBase = globalValue;
+consume(require("./UIBase.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_fails_closed_on_unresolved_jsx_tag() {
+    let input = r#"
+render(<UIBase />);
+var keep = require("./keep.js");
+consume(require("./UIBase.js").UIBase);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+render(<UIBase />);
+consume(require("./UIBase.js").UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
 fn toplevel_require_named_member_fails_closed_on_two_sources_one_local() {
     let input = r#"
 var keep = require("./keep.js");
@@ -3432,6 +3464,33 @@ import UIBase from "./UIBase.js";
 }
 
 #[test]
+fn toplevel_require_default_member_promotes_type_only_import_for_runtime_value() {
+    let input = r#"
+import type UIBase from "./UIBase.js";
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let output = wakaru_core::decompile(
+        input,
+        wakaru_core::DecompileOptions {
+            filename: "fixture.ts".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("TypeScript input should decompile")
+    .code;
+    let expected = r#"
+import UIBase from "./UIBase.js";
+((base) => {
+  use(base);
+})(UIBase);
+"#;
+
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
 fn toplevel_require_default_member_arg_reuses_existing_default_import_through_full_pipeline() {
     let input = r#"
 import UIBase from "./UIBase.js";
@@ -3565,6 +3624,36 @@ observe(UIBase);
 (function (base) {
   use(base);
 })(_default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_falls_back_for_unresolved_assignment_target() {
+    let input = r#"
+UIBase = globalValue;
+consume(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import _default from "./UIBase.js";
+UIBase = globalValue;
+consume(_default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_falls_back_for_named_default_declaration() {
+    let input = r#"
+export default function UIBase() {}
+consume(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import _default from "./UIBase.js";
+export default function UIBase() {}
+consume(_default);
 "#;
     let output = apply_unesm(input);
     assert_eq_normalized(&output, expected);

--- a/crates/core/tests/un_esm_rule.rs
+++ b/crates/core/tests/un_esm_rule.rs
@@ -2766,12 +2766,8 @@ module.exports.default = module.exports;
 // Producer: a CJS compiler emits a static `require(mod).Name` as a direct
 // argument of an immediately-evaluated top-level call (typically an IIFE).
 // UnEsm already converts `var x = require("mod").Name` via NamedProp; this
-// shape never reached that classifier. `.default` args stay out of scope.
+// shape never reached that classifier. `.default` args use a parallel pass.
 // ---------------------------------------------------------------------------
-
-fn leftover_require_named_member(output: &str) -> bool {
-    output.contains("require(") && output.contains(".UIBase")
-}
 
 fn apply_unesm(input: &str) -> String {
     render_pipeline_until(input, "UnEsm")
@@ -2942,7 +2938,7 @@ var keep = require("./keep.js");
 }
 
 #[test]
-fn toplevel_require_named_member_default_arg_is_out_of_scope() {
+fn toplevel_iife_require_default_member_arg_to_default_import() {
     let input = r#"
 var keep = require("./keep.js");
 (function (base) {
@@ -2951,12 +2947,17 @@ var keep = require("./keep.js");
 "#;
     let expected = r#"
 import keep from "./keep.js";
+import UIBase from "./UIBase.js";
 (function (base) {
   use(base);
-})(require("./UIBase.js").default);
+})(UIBase);
 "#;
     let output = apply_unesm(input);
     assert_eq_normalized(&output, expected);
+    assert!(
+        !output.contains("require("),
+        "the hoisted default member must become an import:\n{output}"
+    );
 }
 
 #[test]
@@ -3342,7 +3343,7 @@ consume(require("./dep.js").UIBase);
 }
 
 #[test]
-fn toplevel_require_named_member_sibling_import_does_not_recover_default_arg() {
+fn toplevel_require_default_member_sibling_named_import_does_not_block_recovery() {
     let input = r#"
 import { keep } from "./keep.js";
 (function (base) {
@@ -3351,14 +3352,597 @@ import { keep } from "./keep.js";
 "#;
     let expected = r#"
 import { keep } from "./keep.js";
+import UIBase from "./UIBase.js";
+(function (base) {
+  use(base);
+})(UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_var_init_iife_require_default_member_arg_to_default_import() {
+    let input = r#"
+var Child = (function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import UIBase from "./UIBase.js";
+var Child = function (base) {
+  use(base);
+}(UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_iife_computed_require_default_member_arg_to_default_import() {
+    let input = r#"
+(function (base) {
+  use(base);
+})(require("./UIBase.js")["default"]);
+"#;
+    let expected = r#"
+import UIBase from "./UIBase.js";
+(function (base) {
+  use(base);
+})(UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_arg_reuses_existing_default_prop() {
+    let input = r#"
+var UIBase = require("./UIBase.js").default;
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import UIBase from "./UIBase.js";
+(function (base) {
+  use(base);
+})(UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_arg_reuses_existing_default_import() {
+    let input = r#"
+import UIBase from "./UIBase.js";
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import UIBase from "./UIBase.js";
+(function (base) {
+  use(base);
+})(UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_arg_reuses_existing_default_import_through_full_pipeline() {
+    let input = r#"
+import UIBase from "./UIBase.js";
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import UIBase from "./UIBase.js";
+((base) => {
+  use(base);
+})(UIBase);
+"#;
+    let output = render_pipeline(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_arg_reuses_existing_default_prop_through_full_pipeline() {
+    let input = r#"
+var UIBase = require("./UIBase.js").default;
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import UIBase from "./UIBase.js";
+((base) => {
+  use(base);
+})(UIBase);
+"#;
+    let output = render_pipeline(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_iife_require_default_member_arg_keeps_import_through_full_pipeline() {
+    let input = r#"
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import UIBase from "./UIBase.js";
+((base) => {
+  use(base);
+})(UIBase);
+"#;
+    let output = render_pipeline(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_shares_local_across_same_source_args() {
+    let input = r#"
+(function (first) {
+  use(first);
+})(require("./UIBase.js").default);
+(function (second) {
+  use(second);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import UIBase from "./UIBase.js";
+(function (first) {
+  use(first);
+})(UIBase);
+(function (second) {
+  use(second);
+})(UIBase);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_falls_back_when_basename_matches_import() {
+    let input = r#"
+import { UIBase } from "./other.js";
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import { UIBase } from "./other.js";
+import keep from "./keep.js";
+import _default from "./UIBase.js";
+(function (base) {
+  use(base);
+})(_default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_falls_back_when_basename_matches_let() {
+    let input = r#"
+let UIBase = 0;
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+import _default from "./UIBase.js";
+let UIBase = 0;
+(function (base) {
+  use(base);
+})(_default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_falls_back_when_basename_is_unresolved() {
+    let input = r#"
+observe(UIBase);
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+import _default from "./UIBase.js";
+observe(UIBase);
+(function (base) {
+  use(base);
+})(_default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_ternary_arg_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+f(cond ? require("./UIBase.js").default : other);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+f(cond ? require("./UIBase.js").default : other);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_inside_then_callback_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+then(function () {
+  return require("./UIBase.js").default;
+});
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+then(function () {
+  return require("./UIBase.js").default;
+});
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_inside_function_body_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+function wrap() {
+  (function (base) {
+    use(base);
+  })(require("./UIBase.js").default);
+}
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+function wrap() {
+  (function (base) {
+    use(base);
+  })(require("./UIBase.js").default);
+}
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_dynamic_require_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require(dyn).default);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})(require(dyn).default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_spread_arg_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+f(...require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+f(...require("./UIBase.js").default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_local_require_binding_is_left_alone() {
+    let input = r#"
+function require(x) {
+  return x;
+}
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, input);
+}
+
+#[test]
+fn toplevel_require_default_member_comma_expr_arg_is_left_alone() {
+    let input = r#"
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})((0, require("./UIBase.js").default));
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})((0, require("./UIBase.js").default));
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_fails_closed_on_unknown_eval() {
+    let input = r#"
+eval(source);
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+eval(source);
 (function (base) {
   use(base);
 })(require("./UIBase.js").default);
 "#;
     let output = apply_unesm(input);
     assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_falls_back_when_eval_mentions_basename() {
+    let input = r#"
+eval("UIBase");
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+import _default from "./UIBase.js";
+eval("UIBase");
+(function (base) {
+  use(base);
+})(_default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_fails_closed_on_eval_of_synthetic_name() {
+    let input = r#"
+import { UIBase } from "./other.js";
+eval("_default");
+var keep = require("./keep.js");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let expected = r#"
+import { UIBase } from "./other.js";
+import keep from "./keep.js";
+eval("_default");
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_early_self_read_keeps_commonjs_boundary() {
+    let input = r#"
+consume(require("./module-1.js").default);
+exports.default = 1;
+"#;
+    let output = render_pipeline_until_with_filename(input, "UnEsm", "module-1.js");
+
+    assert_eq_normalized(&output, input);
     assert!(
-        leftover_require_named_member(&output) || output.contains(".default"),
-        "a sibling named import must not recover an out-of-scope .default arg:\n{output}"
+        !output.contains("import ") && !output.contains("export "),
+        "a direct default self-read must not cross only part of its CommonJS boundary:\n{output}"
     );
+}
+
+#[test]
+fn toplevel_require_default_member_fails_closed_on_provider_member_write() {
+    let input = r#"
+consume(require("./dep.js").default);
+require("./dep.js").default = replacement;
+consume(require("./dep.js").default);
+"#;
+    let output = apply_unesm(input);
+
+    assert_eq_normalized(&output, input);
+}
+
+#[test]
+fn toplevel_require_default_member_fails_closed_on_other_provider_member_mutations() {
+    let mutations = [
+        r#"require("./dep.js").default += replacement;"#,
+        r#"require("./dep.js").default++;"#,
+        r#"delete require("./dep.js").default;"#,
+        r#"for (require("./dep.js").default in values) {}"#,
+        r#"for (require("./dep.js").default of values) {}"#,
+    ];
+
+    for mutation in mutations {
+        let input = format!(
+            r#"
+consume(require("./dep.js").default);
+{mutation}
+consume(require("./dep.js").default);
+"#
+        );
+        let output = apply_unesm(&input);
+
+        assert!(
+            !output.contains("import ")
+                && output.matches("require(\"./dep.js\").default").count() >= 2,
+            "provider mutation must keep fresh default member reads:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn toplevel_require_default_member_does_not_reuse_later_default_prop() {
+    let input = r#"
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+var UIBase = require("./UIBase.js").default;
+var keep = require("./keep.js");
+"#;
+    let expected = r#"
+import _default from "./UIBase.js";
+import UIBase from "./UIBase.js";
+import keep from "./keep.js";
+(function (base) {
+  use(base);
+})(_default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_does_not_reuse_mutated_default_prop() {
+    let input = r#"
+var UIBase = require("./UIBase.js").default;
+UIBase = other;
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+var keep = require("./keep.js");
+"#;
+    let expected = r#"
+import _UIBase from "./UIBase.js";
+import _default from "./UIBase.js";
+import keep from "./keep.js";
+var UIBase = _UIBase;
+UIBase = other;
+(function (base) {
+  use(base);
+})(_default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_skips_written_binding_and_reuses_later_stable() {
+    // Basename UIBase is taken and eval mentions `_default`, so recovery is
+    // only possible by reusing the later unwritten DefaultProp.
+    let input = r#"
+import { UIBase } from "./other.js";
+eval("_default");
+var keep = require("./keep.js");
+var poisoned = require("./UIBase.js").default;
+poisoned = other;
+var helper = require("./UIBase.js").default;
+(function (base) {
+  use(base);
+})(require("./UIBase.js").default);
+"#;
+    let output = apply_unesm(input);
+    assert!(
+        output.contains("import keep from \"./keep.js\"")
+            && output.contains("import helper from \"./UIBase.js\"")
+            && output.contains("})(helper)")
+            && !output.contains("require(\"./UIBase.js\").default"),
+        "a later unwritten DefaultProp must still be reusable after a mutated one:\n{output}"
+    );
+}
+
+#[test]
+fn toplevel_require_default_member_does_not_reuse_local_across_provider_member_write() {
+    let input = r#"
+var UIBase = require("./dep.js").default;
+require("./dep.js").default = replacement;
+consume(require("./dep.js").default);
+"#;
+    let expected = r#"
+import UIBase from "./dep.js";
+require("./dep.js").default = replacement;
+consume(require("./dep.js").default);
+"#;
+    let output = apply_unesm(input);
+
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_named_member_failure_does_not_block_default_member() {
+    let input = r#"
+import { A } from "./other.js";
+var keep = require("./keep.js");
+(function (a) {
+  use(a);
+})(require("./A.js").A);
+(function (b) {
+  use(b);
+})(require("./B.js").default);
+"#;
+    let expected = r#"
+import { A } from "./other.js";
+import keep from "./keep.js";
+import B from "./B.js";
+(function (a) {
+  use(a);
+})(require("./A.js").A);
+(function (b) {
+  use(b);
+})(B);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn toplevel_require_default_member_failure_does_not_block_named_member() {
+    let input = r#"
+var keep = require("./keep.js");
+require("./B.js").default = replacement;
+(function (a) {
+  use(a);
+})(require("./A.js").A);
+(function (b) {
+  use(b);
+})(require("./B.js").default);
+"#;
+    let expected = r#"
+import keep from "./keep.js";
+import { A } from "./A.js";
+require("./B.js").default = replacement;
+(function (a) {
+  use(a);
+})(A);
+(function (b) {
+  use(b);
+})(require("./B.js").default);
+"#;
+    let output = apply_unesm(input);
+    assert_eq_normalized(&output, expected);
 }


### PR DESCRIPTION
## Summary
- `try_classify_cjs_require` already turns `var foo = require("./keep.js").default` into a default import via DefaultProp. #221 recovers top-level Call arguments of `require("mod").Name`, but `match_require_named_member` must keep skipping `.default` because that pass binds the local to the property name and `default` is reserved.
- This PR only admits the leftover proven shape: hoist `const L = require("src").default` immediately before the statement and replace the argument with ident `L`, then reuse DefaultProp. `L` reuses a prior unwritten DefaultProp / default import, else the specifier basename (`./UIBase.js` → `UIBase`), else `_default`. Basename collisions fall back to `_default` instead of failing the whole pass. The default pass is all-or-nothing and independent of named-member recovery.
- Unknown `eval`, early self-require, and provider mutation of `.default` (`=`, `+=`, `++`, `delete`, for-in/of) fail-closed for this pass. Does not recover value-position `.inst`, ClassExtends, `__extends`, or dummy→`export let`.

Related: leftover from #221. Independent of SystemJS / UnEnum. Does not recover value-position `.inst` or ClassExtends.

Please feel free to take it from here if that is easier.
Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

```js
(function (base) {
  use(base);
})(require("./UIBase.js").default);
```

`wakaru --unpack` today: leftover `require("./UIBase.js").default`. After this change: `import UIBase from "./UIBase.js"` and the argument is the ident `UIBase`.

Covered by `toplevel_iife_require_default_member_arg_to_default_import`, `toplevel_require_default_member_falls_back_when_basename_matches_import`, `toplevel_require_named_member_failure_does_not_block_default_member`, and existing `default_property_require`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test un_esm_rule`