### PR TITLE
fix(rules): keep for-init sequence prefixes after earlier var inits

### DIFF
--- a/crates/core/src/rules/simplify_sequence.rs
+++ b/crates/core/src/rules/simplify_sequence.rs
@@ -4,15 +4,15 @@ use swc_core::atoms::Atom;
 use swc_core::common::{Mark, SyntaxContext, DUMMY_SP};
 use swc_core::ecma::ast::{
     ArrowExpr, AssignExpr, AssignTarget, BinaryOp, BlockStmt, Callee, ClassExpr, Constructor, Decl,
-    Expr, ExprStmt, FnExpr, ForHead, ForInStmt, ForOfStmt, ForStmt, Function, GetterProp, Id,
-    Ident, IfStmt, ImportSpecifier, Invalid, Lit, MemberExpr, MemberProp, ModuleDecl, ModuleItem,
-    NewExpr, ParenExpr, Pat, ReturnStmt, SeqExpr, SetterProp, SimpleAssignTarget, Stmt, SwitchStmt,
-    ThrowStmt, UnaryExpr, UnaryOp, VarDecl, VarDeclKind, VarDeclOrExpr, VarDeclarator, YieldExpr,
+    Expr, ExprStmt, FnExpr, ForHead, ForInStmt, ForOfStmt, ForStmt, Function, GetterProp, Ident,
+    IfStmt, ImportSpecifier, Invalid, Lit, MemberExpr, ModuleDecl, ModuleItem, NewExpr, ParenExpr,
+    Pat, ReturnStmt, SeqExpr, SetterProp, SimpleAssignTarget, Stmt, SwitchStmt, ThrowStmt,
+    UnaryExpr, UnaryOp, VarDecl, VarDeclKind, VarDeclOrExpr, VarDeclarator, YieldExpr,
 };
-use swc_core::ecma::utils::{find_pat_ids, ExprCtx, ExprExt};
+use swc_core::ecma::utils::{ExprCtx, ExprExt};
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
-use super::decl_utils::BindingId;
+use super::decl_utils::{binding_id, BindingId};
 use super::RewriteLevel;
 
 use crate::js_names::is_stable_builtin_alias_root;
@@ -955,14 +955,15 @@ fn can_split_standalone_for_init_expr(expr: &Expr) -> bool {
     }
 }
 
-/// Extract sequence prefixes from each declarator's init, without splitting
-/// the var decl into individual declarations (needed for for-loop scope).
+/// Extract sequence prefixes from a for-loop declaration while preserving
+/// declarator evaluation order and lexical scope.
 ///
-/// Walk left to right. A comma prefix that reads an earlier binding in this
-/// same list must not run before that binding's initializer:
+/// Walk left to right without moving a comma prefix ahead of earlier
+/// initializer effects:
 /// - `var`: flush already-collected declarators as statements, then the prefix.
-/// - `let` / `const`: cannot hoist those declarators out of the `for`; leave
-///   that init unsplit (fail-closed).
+/// - `let` / `const`: cannot hoist those declarators out of the `for`, so a
+///   later declarator's prefix stays unsplit. A first prefix may lift only when
+///   it does not reference any lexical binding in the whole header (TDZ).
 fn extract_var_decl_prefix(
     var: Box<VarDecl>,
     span: swc_core::common::Span,
@@ -974,14 +975,25 @@ fn extract_var_decl_prefix(
     let is_var = kind == VarDeclKind::Var;
     let mut prefix = Vec::new();
     let mut new_decls = Vec::new();
-    // Names bound by earlier declarators in this list. Not cleared on flush:
-    // later prefixes still see those names as already initialized in source order.
-    let mut bound_so_far: HashSet<Atom> = HashSet::new();
+    let mut header_bindings = HashSet::new();
+    if !is_var {
+        for decl in &var.decls {
+            collect_binding_ids_from_pat(&decl.name, &mut header_bindings);
+        }
+    }
+    let mut future_header_names: HashSet<Atom> =
+        header_bindings.iter().map(|(sym, _)| sym.clone()).collect();
 
     for decl in var.decls {
+        if !is_var {
+            let mut current_bindings = HashSet::new();
+            collect_binding_ids_from_pat(&decl.name, &mut current_bindings);
+            for (sym, _) in current_bindings {
+                future_header_names.remove(&sym);
+            }
+        }
         if let Some(init) = decl.init {
             if level == RewriteLevel::Minimal && sequence_blocks_decl_name_inference(&init) {
-                collect_pat_bound_names(&decl.name, &mut bound_so_far);
                 new_decls.push(VarDeclarator {
                     span: decl.span,
                     name: decl.name,
@@ -993,9 +1005,14 @@ fn extract_var_decl_prefix(
             let (pre, last) = split_expr_seq(init);
             let keep_unsplit = !pre.is_empty()
                 && (seq_prefix_has_string_lit(&pre)
-                    || (!is_var && seq_prefix_refs_bound_names(&pre, &bound_so_far)));
+                    || (!is_var
+                        && (!new_decls.is_empty()
+                            || seq_prefix_refs_lexical_header(
+                                &pre,
+                                &header_bindings,
+                                &future_header_names,
+                            ))));
             if keep_unsplit {
-                collect_pat_bound_names(&decl.name, &mut bound_so_far);
                 new_decls.push(VarDeclarator {
                     span: decl.span,
                     name: decl.name,
@@ -1004,13 +1021,12 @@ fn extract_var_decl_prefix(
                 });
                 continue;
             }
-            if !pre.is_empty() && is_var && seq_prefix_refs_bound_names(&pre, &bound_so_far) {
+            if !pre.is_empty() && is_var {
                 flush_var_declarators(&mut prefix, &mut new_decls, var_span, ctxt, kind);
             }
             for p in pre {
                 prefix.push(Stmt::Expr(ExprStmt { span, expr: p }));
             }
-            collect_pat_bound_names(&decl.name, &mut bound_so_far);
             new_decls.push(VarDeclarator {
                 span: decl.span,
                 name: decl.name,
@@ -1018,7 +1034,6 @@ fn extract_var_decl_prefix(
                 definite: decl.definite,
             });
         } else {
-            collect_pat_bound_names(&decl.name, &mut bound_so_far);
             new_decls.push(decl);
         }
     }
@@ -1032,11 +1047,6 @@ fn extract_var_decl_prefix(
     });
 
     (prefix, new_var)
-}
-
-fn collect_pat_bound_names(pat: &Pat, names: &mut HashSet<Atom>) {
-    let ids: Vec<Id> = find_pat_ids(pat);
-    names.extend(ids.into_iter().map(|(sym, _)| sym));
 }
 
 fn flush_var_declarators(
@@ -1075,33 +1085,46 @@ fn seq_prefix_has_string_lit(prefix: &[Box<Expr>]) -> bool {
         .any(|expr| matches!(strip_parens(expr), Expr::Lit(Lit::Str(_))))
 }
 
-fn seq_prefix_refs_bound_names(prefix: &[Box<Expr>], bound: &HashSet<Atom>) -> bool {
-    prefix.iter().any(|expr| expr_refs_bound_names(expr, bound))
+fn seq_prefix_refs_lexical_header(
+    prefix: &[Box<Expr>],
+    bindings: &HashSet<BindingId>,
+    future_names: &HashSet<Atom>,
+) -> bool {
+    prefix
+        .iter()
+        .any(|expr| expr_refs_lexical_header(expr, bindings, future_names))
 }
 
-fn expr_refs_bound_names(expr: &Expr, bound: &HashSet<Atom>) -> bool {
-    if bound.is_empty() {
+fn expr_refs_lexical_header(
+    expr: &Expr,
+    bindings: &HashSet<BindingId>,
+    future_names: &HashSet<Atom>,
+) -> bool {
+    if bindings.is_empty() && future_names.is_empty() {
         return false;
     }
     struct Finder<'a> {
-        bound: &'a HashSet<Atom>,
+        bindings: &'a HashSet<BindingId>,
+        future_names: &'a HashSet<Atom>,
         hit: bool,
     }
     impl Visit for Finder<'_> {
         fn visit_ident(&mut self, ident: &Ident) {
-            if self.bound.contains(&ident.sym) {
+            // SWC resolves a read before a later same-list lexical declarator
+            // to an outer binding context, even though JavaScript evaluates it
+            // against that declarator's TDZ. Use names only for those future
+            // bindings; current and earlier bindings still require exact IDs.
+            if self.bindings.contains(&binding_id(ident)) || self.future_names.contains(&ident.sym)
+            {
                 self.hit = true;
             }
         }
-
-        fn visit_member_prop(&mut self, prop: &MemberProp) {
-            // `obj.ident` is a property name, not a binding read.
-            if let MemberProp::Computed(computed) = prop {
-                computed.visit_with(self);
-            }
-        }
     }
-    let mut finder = Finder { bound, hit: false };
+    let mut finder = Finder {
+        bindings,
+        future_names,
+        hit: false,
+    };
     expr.visit_with(&mut finder);
     finder.hit
 }

--- a/crates/core/src/rules/simplify_sequence.rs
+++ b/crates/core/src/rules/simplify_sequence.rs
@@ -1,14 +1,15 @@
 use std::collections::HashSet;
 
+use swc_core::atoms::Atom;
 use swc_core::common::{Mark, SyntaxContext, DUMMY_SP};
 use swc_core::ecma::ast::{
     ArrowExpr, AssignExpr, AssignTarget, BinaryOp, BlockStmt, Callee, ClassExpr, Constructor, Decl,
-    Expr, ExprStmt, FnExpr, ForHead, ForInStmt, ForOfStmt, ForStmt, Function, GetterProp, IfStmt,
-    ImportSpecifier, Invalid, Lit, MemberExpr, ModuleDecl, ModuleItem, NewExpr, ParenExpr, Pat,
-    ReturnStmt, SeqExpr, SetterProp, SimpleAssignTarget, Stmt, SwitchStmt, ThrowStmt, UnaryExpr,
-    UnaryOp, VarDecl, VarDeclKind, VarDeclOrExpr, VarDeclarator, YieldExpr,
+    Expr, ExprStmt, FnExpr, ForHead, ForInStmt, ForOfStmt, ForStmt, Function, GetterProp, Id,
+    Ident, IfStmt, ImportSpecifier, Invalid, Lit, MemberExpr, MemberProp, ModuleDecl, ModuleItem,
+    NewExpr, ParenExpr, Pat, ReturnStmt, SeqExpr, SetterProp, SimpleAssignTarget, Stmt, SwitchStmt,
+    ThrowStmt, UnaryExpr, UnaryOp, VarDecl, VarDeclKind, VarDeclOrExpr, VarDeclarator, YieldExpr,
 };
-use swc_core::ecma::utils::{ExprCtx, ExprExt};
+use swc_core::ecma::utils::{find_pat_ids, ExprCtx, ExprExt};
 use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use super::decl_utils::BindingId;
@@ -956,6 +957,12 @@ fn can_split_standalone_for_init_expr(expr: &Expr) -> bool {
 
 /// Extract sequence prefixes from each declarator's init, without splitting
 /// the var decl into individual declarations (needed for for-loop scope).
+///
+/// Walk left to right. A comma prefix that reads an earlier binding in this
+/// same list must not run before that binding's initializer:
+/// - `var`: flush already-collected declarators as statements, then the prefix.
+/// - `let` / `const`: cannot hoist those declarators out of the `for`; leave
+///   that init unsplit (fail-closed).
 fn extract_var_decl_prefix(
     var: Box<VarDecl>,
     span: swc_core::common::Span,
@@ -964,12 +971,17 @@ fn extract_var_decl_prefix(
     let kind = var.kind;
     let ctxt = var.ctxt;
     let var_span = var.span;
+    let is_var = kind == VarDeclKind::Var;
     let mut prefix = Vec::new();
     let mut new_decls = Vec::new();
+    // Names bound by earlier declarators in this list. Not cleared on flush:
+    // later prefixes still see those names as already initialized in source order.
+    let mut bound_so_far: HashSet<Atom> = HashSet::new();
 
     for decl in var.decls {
         if let Some(init) = decl.init {
             if level == RewriteLevel::Minimal && sequence_blocks_decl_name_inference(&init) {
+                collect_pat_bound_names(&decl.name, &mut bound_so_far);
                 new_decls.push(VarDeclarator {
                     span: decl.span,
                     name: decl.name,
@@ -979,9 +991,26 @@ fn extract_var_decl_prefix(
                 continue;
             }
             let (pre, last) = split_expr_seq(init);
+            let keep_unsplit = !pre.is_empty()
+                && (seq_prefix_has_string_lit(&pre)
+                    || (!is_var && seq_prefix_refs_bound_names(&pre, &bound_so_far)));
+            if keep_unsplit {
+                collect_pat_bound_names(&decl.name, &mut bound_so_far);
+                new_decls.push(VarDeclarator {
+                    span: decl.span,
+                    name: decl.name,
+                    init: Some(rejoin_seq(pre, last)),
+                    definite: decl.definite,
+                });
+                continue;
+            }
+            if !pre.is_empty() && is_var && seq_prefix_refs_bound_names(&pre, &bound_so_far) {
+                flush_var_declarators(&mut prefix, &mut new_decls, var_span, ctxt, kind);
+            }
             for p in pre {
                 prefix.push(Stmt::Expr(ExprStmt { span, expr: p }));
             }
+            collect_pat_bound_names(&decl.name, &mut bound_so_far);
             new_decls.push(VarDeclarator {
                 span: decl.span,
                 name: decl.name,
@@ -989,6 +1018,7 @@ fn extract_var_decl_prefix(
                 definite: decl.definite,
             });
         } else {
+            collect_pat_bound_names(&decl.name, &mut bound_so_far);
             new_decls.push(decl);
         }
     }
@@ -1002,6 +1032,78 @@ fn extract_var_decl_prefix(
     });
 
     (prefix, new_var)
+}
+
+fn collect_pat_bound_names(pat: &Pat, names: &mut HashSet<Atom>) {
+    let ids: Vec<Id> = find_pat_ids(pat);
+    names.extend(ids.into_iter().map(|(sym, _)| sym));
+}
+
+fn flush_var_declarators(
+    prefix: &mut Vec<Stmt>,
+    new_decls: &mut Vec<VarDeclarator>,
+    span: swc_core::common::Span,
+    ctxt: SyntaxContext,
+    kind: VarDeclKind,
+) {
+    if new_decls.is_empty() {
+        return;
+    }
+    prefix.push(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+        span,
+        ctxt,
+        kind,
+        declare: false,
+        decls: std::mem::take(new_decls),
+    }))));
+}
+
+fn rejoin_seq(mut prefix: Vec<Box<Expr>>, last: Box<Expr>) -> Box<Expr> {
+    if prefix.is_empty() {
+        return last;
+    }
+    prefix.push(last);
+    Box::new(Expr::Seq(SeqExpr {
+        span: DUMMY_SP,
+        exprs: prefix,
+    }))
+}
+
+fn seq_prefix_has_string_lit(prefix: &[Box<Expr>]) -> bool {
+    prefix
+        .iter()
+        .any(|expr| matches!(strip_parens(expr), Expr::Lit(Lit::Str(_))))
+}
+
+fn seq_prefix_refs_bound_names(prefix: &[Box<Expr>], bound: &HashSet<Atom>) -> bool {
+    prefix.iter().any(|expr| expr_refs_bound_names(expr, bound))
+}
+
+fn expr_refs_bound_names(expr: &Expr, bound: &HashSet<Atom>) -> bool {
+    if bound.is_empty() {
+        return false;
+    }
+    struct Finder<'a> {
+        bound: &'a HashSet<Atom>,
+        hit: bool,
+    }
+    impl Visit for Finder<'_> {
+        fn visit_ident(&mut self, ident: &Ident) {
+            if self.bound.contains(&ident.sym) {
+                self.hit = true;
+            }
+        }
+
+        fn visit_member_prop(&mut self, prop: &MemberProp) {
+            // `obj.ident` is a property name, not a binding read.
+            if let MemberProp::Computed(computed) = prop {
+                computed.visit_with(self);
+            }
+        }
+    }
+    let mut finder = Finder { bound, hit: false };
+    expr.visit_with(&mut finder);
+    finder.hit
 }
 
 fn sequence_blocks_decl_name_inference(expr: &Expr) -> bool {

--- a/crates/core/tests/simplify_sequence_rule.rs
+++ b/crates/core/tests/simplify_sequence_rule.rs
@@ -921,17 +921,36 @@ function walk(n, helper) {
 }
 
 #[test]
-fn for_var_init_independent_sequence_prefix_still_lifts() {
-    // Independent prefixes must still lift; this is not a blanket fail-closed.
+fn for_var_init_independent_sequence_prefix_keeps_prior_initializer_order() {
+    // A call can observe any earlier `var` through effects or a closure even
+    // when its argument AST does not directly reference that binding.
     let input = r#"
-for (var i = 0, j = (foo(), 1); i < n; i++) {}
+function run(log) {
+  for (var a = log("init"), b = (log("prefix"), 1); false;);
+}
 "#;
     let expected = r#"
-foo();
-for (var i = 0, j = 1; i < n; i++) {}
+function run(log) {
+  var a = log("init");
+  log("prefix");
+  for (var b = 1; false;);
+}
 "#;
     let output = apply(input);
     assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn for_let_init_independent_later_prefix_keeps_prior_initializer_order() {
+    // A lexical declarator cannot be flushed out of the loop, so keep the
+    // later sequence intact rather than moving its effects before `a`.
+    let input = r#"
+function run(log) {
+  for (let a = log("init"), b = (log("prefix"), 1); false;);
+}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, input);
 }
 
 #[test]
@@ -955,6 +974,40 @@ for (const r = n.value, s = (r[0], r[1]); false; ) {}
 }
 
 #[test]
+fn for_let_init_sequence_prefix_self_reference_stays_in_tdz() {
+    let input = r#"
+let x = 0;
+for (let x = (x, 1); false;);
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, input);
+}
+
+#[test]
+fn for_const_init_sequence_prefix_later_reference_stays_in_tdz() {
+    let input = r#"
+const later = 0;
+for (const x = (later, 1), later = 2; false;);
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, input);
+}
+
+#[test]
+fn for_let_init_shadowed_header_name_does_not_trigger_tdz_guard() {
+    // Resolver identity distinguishes the IIFE parameter from the loop binding.
+    let input = r#"
+for (let x = ((function(x) { use(x); })(0), 1); false;);
+"#;
+    let expected = r#"
+(function(x) { use(x); })(0);
+for (let x = 1; false;);
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
 fn for_var_init_function_iife_prefix_keeps_expression_context() {
     // Lifted function-callee IIFE must stay an expression, not `function(){}()`.
     let input = r#"
@@ -964,8 +1017,9 @@ function run() {
 "#;
     let expected = r#"
 function run() {
+  var x = 0;
   (function() {})();
-  for (var x = 0, y = 1; false;);
+  for (var y = 1; false;);
 }
 "#;
     let output = apply(input);
@@ -982,8 +1036,9 @@ function run(k, h) {
 "#;
     let expected = r#"
 function run(k, h) {
+  var x = 0;
   ({ [k()]: h })[k()]();
-  for (var x = 0, y = 1; false;);
+  for (var y = 1; false;);
 }
 "#;
     let output = apply(input);

--- a/crates/core/tests/simplify_sequence_rule.rs
+++ b/crates/core/tests/simplify_sequence_rule.rs
@@ -897,3 +897,107 @@ a.b = c;
     let output = apply(input);
     assert_eq_normalized(&output, expected);
 }
+
+// Babel loose `for-of` packs Map entry unpack into the inner for-init:
+// `for (var a, r = n.value, s = (r[0], r[1]), l = helper(s); !(a = l()).done;)`
+// Sequence prefixes must not run before earlier declarators in the same list.
+
+#[test]
+fn for_var_init_sequence_prefix_does_not_read_earlier_declarator_before_init() {
+    let input = r#"
+function walk(n, helper) {
+  for (var a, r = n.value, s = (r[0], r[1]), l = helper(s); !(a = l()).done;);
+}
+"#;
+    let expected = r#"
+function walk(n, helper) {
+  var a, r = n.value;
+  r[0];
+  for (var s = r[1], l = helper(s); !(a = l()).done;);
+}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn for_var_init_independent_sequence_prefix_still_lifts() {
+    // Independent prefixes must still lift; this is not a blanket fail-closed.
+    let input = r#"
+for (var i = 0, j = (foo(), 1); i < n; i++) {}
+"#;
+    let expected = r#"
+foo();
+for (var i = 0, j = 1; i < n; i++) {}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn for_let_init_sequence_prefix_that_reads_earlier_decl_stays_unsplit() {
+    // Lexical for-init bindings cannot be hoisted out of the loop.
+    let input = r#"
+for (let r = n.value, s = (r[0], r[1]); r < 10; r++) {}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, input);
+}
+
+#[test]
+fn for_const_init_sequence_prefix_that_reads_earlier_decl_stays_unsplit() {
+    // Same fail-closed as `let`: do not pull const declarators out of the `for`.
+    let input = r#"
+for (const r = n.value, s = (r[0], r[1]); false; ) {}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, input);
+}
+
+#[test]
+fn for_var_init_function_iife_prefix_keeps_expression_context() {
+    // Lifted function-callee IIFE must stay an expression, not `function(){}()`.
+    let input = r#"
+function run() {
+  for (var x = 0, y = ((function () {})(), 1); false;);
+}
+"#;
+    let expected = r#"
+function run() {
+  (function() {})();
+  for (var x = 0, y = 1; false;);
+}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn for_var_init_object_headed_prefix_keeps_expression_context() {
+    // Lifted object-headed call chains must keep expression context.
+    let input = r#"
+function run(k, h) {
+  for (var x = 0, y = ({ [k()]: h }[k()](), 1); false;);
+}
+"#;
+    let expected = r#"
+function run(k, h) {
+  ({ [k()]: h })[k()]();
+  for (var x = 0, y = 1; false;);
+}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, expected);
+}
+
+#[test]
+fn for_var_init_string_prefix_does_not_become_directive() {
+    // A leading string statement can become a directive; leave this init unsplit.
+    let input = r#"
+function run() {
+  for (var x = ("use strict", 1); false;);
+}
+"#;
+    let output = apply(input);
+    assert_eq_normalized(&output, input);
+}


### PR DESCRIPTION
## Summary
- `extract_var_decl_prefix` lifted every comma prefix in a for-init `var` list in front of the whole `for`, so a later declarator could read an earlier binding before its initializer ran.
- This PR walks that list left to right: if a `var` init's sequence prefix reads an earlier same-list name, flush already-collected `var` declarators, then the prefix, then keep the remaining for-init. `let`/`const` fail-closed and leave that init unsplit. Independent prefixes still lift.
- Does not invent export/import or name a discarded index-0 unpack. Unrecognized lexical dependence stays fail-closed.

Related: leftover of sequence-lift class (#218). Independent of UnForOf / hygiene. Does not recover nested helper→for-of.

Please feel free to take it from here if that is easier.
Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

Producer: Babel Loose `for-of` over a Map iterator (the discarded key lives in the inner for-init comma list).

```js
function walk(n, helper) {
  for (var a, r = n.value, s = (r[0], r[1]), l = helper(s); !(a = l()).done;);
}
```

`wakaru` today: `r[0]` runs before `var r = n.value` (ESM strict `TypeError` on the first non-empty iteration).
After this change: `var a, r = n.value;` then `r[0];` then `for (var s = r[1], l = helper(s); …)`.

Covered by `for_var_init_sequence_prefix_does_not_read_earlier_declarator_before_init`, `for_var_init_independent_sequence_prefix_still_lifts`, `for_let_init_sequence_prefix_that_reads_earlier_decl_stays_unsplit`, `for_const_init_sequence_prefix_that_reads_earlier_decl_stays_unsplit`, `for_var_init_function_iife_prefix_keeps_expression_context`, `for_var_init_object_headed_prefix_keeps_expression_context`, `for_var_init_string_prefix_does_not_become_directive`, and existing `splits_for_init_keeps_assignment_as_init` / `splits_for_init_sequence_with_var_decl` / `does_not_split_directive_like_for_initializer`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test simplify_sequence_rule`
