### PR TITLE
fix(rules): recover discarded numeric index holes in UnForOf

### DIFF
--- a/crates/core/src/rules/un_for_of.rs
+++ b/crates/core/src/rules/un_for_of.rs
@@ -15,6 +15,7 @@ use swc_core::ecma::visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 use crate::analysis::binding_uses::BindingUseIndex;
 use crate::facts::{ModuleFactsMap, TypeScriptHelperKind};
 
+use super::eval_utils::{js_source_mentions_binding, module_has_with_stmt, DirectEvalAnalyzer};
 use super::helper_matcher::{binding_key, static_member_prop_name, BindingKey};
 use super::transpiler_helper_utils::{
     tslib_member_ts_helper_kind, tslib_require_ts_helper_kind, LocalHelperContext, TsHelperKind,
@@ -114,6 +115,11 @@ struct ForOfHelperContext {
     closure_jscomp_namespaces: HashSet<BindingKey>,
     binding_uses: BindingUseIndex,
     unresolved_mark: Option<Mark>,
+    /// Module-wide `with` / unknown direct `eval`, plus known eval sources.
+    /// Used when dropping a function-scoped (`var`) for-of left.
+    module_has_with: bool,
+    unknown_direct_eval: bool,
+    known_direct_eval_sources: Vec<String>,
 }
 
 impl ForOfHelperContext {
@@ -129,6 +135,8 @@ impl ForOfHelperContext {
             .unwrap_or_default();
         let mut values_helpers = local_helpers.ts_helpers_of_kind(TsHelperKind::Values);
         values_helpers.extend(cross_module_values.direct);
+        let mut eval = DirectEvalAnalyzer::default();
+        module.visit_with(&mut eval);
         Self {
             values_helpers,
             tslib_namespaces: local_helpers.tslib_namespaces().clone(),
@@ -136,7 +144,21 @@ impl ForOfHelperContext {
             closure_jscomp_namespaces: collect_closure_jscomp_namespaces(module),
             binding_uses: BindingUseIndex::collect(module),
             unresolved_mark,
+            module_has_with: module_has_with_stmt(module),
+            unknown_direct_eval: eval.unknown_direct_eval,
+            known_direct_eval_sources: eval.known_direct_eval_sources,
         }
+    }
+
+    /// A `var` for-of left is visible to `with` and direct `eval` anywhere
+    /// in the module. Known eval sources only block when they mention `name`.
+    fn dynamic_scope_can_observe_name(&self, name: &Atom) -> bool {
+        self.module_has_with
+            || self.unknown_direct_eval
+            || self
+                .known_direct_eval_sources
+                .iter()
+                .any(|source| js_source_mentions_binding(source, name))
     }
 
     fn is_ts_values_callee(&self, callee: &Callee) -> bool {
@@ -455,7 +477,7 @@ impl UnForOf<'_> {
                 if self.found {
                     return;
                 }
-                if matches!(stmt, Stmt::For(_) | Stmt::Try(_)) {
+                if matches!(stmt, Stmt::For(_) | Stmt::ForOf(_) | Stmt::Try(_)) {
                     self.found = true;
                     return;
                 }
@@ -509,6 +531,9 @@ impl VisitMut for UnForOf<'_> {
         if let Some(for_of) = try_convert_for_of(stmt, &self.helper_context) {
             *stmt = Stmt::ForOf(for_of);
         }
+        if let Stmt::ForOf(for_of) = stmt {
+            try_fold_for_of_entry_slots(for_of, &self.helper_context);
+        }
     }
 }
 
@@ -555,20 +580,20 @@ fn process_stmt_vec(stmts: &mut Vec<Stmt>, helper_context: &ForOfHelperContext) 
             continue;
         }
 
-        if let Some(rewrite) = try_convert_swc_iterator_sequence(&old[i..]) {
+        if let Some(rewrite) = try_convert_swc_iterator_sequence(&old[i..], helper_context) {
             stmts.push(Stmt::ForOf(rewrite.for_of));
             i += rewrite.consumed_stmts;
             continue;
         }
 
-        if let Some(rewrite) = try_convert_iterator_helper_sequence(&old[i..]) {
+        if let Some(rewrite) = try_convert_iterator_helper_sequence(&old[i..], helper_context) {
             stmts.extend(rewrite.preserved_stmts);
             stmts.push(Stmt::ForOf(rewrite.for_of));
             i += rewrite.consumed_stmts;
             continue;
         }
 
-        if let Some(rewrite) = try_convert_loose_iterator_sequence(&old[i..]) {
+        if let Some(rewrite) = try_convert_loose_iterator_sequence(&old[i..], helper_context) {
             stmts.push(Stmt::ForOf(rewrite.for_of));
             i += rewrite.consumed_stmts;
             continue;
@@ -623,6 +648,7 @@ fn try_convert_closure_iterator_sequence(
         result_decl.init.as_deref()?,
         init.iterable,
         stmts[0].span(),
+        helper_context,
     )?;
     Some(SequenceRewrite {
         consumed_stmts: 2,
@@ -661,6 +687,7 @@ fn try_convert_closure_iterator_for_stmt(
         result_decl.init.as_deref()?,
         iterable,
         stmts[0].span(),
+        helper_context,
     )?;
     Some(SequenceRewrite {
         consumed_stmts: 1,
@@ -677,6 +704,7 @@ fn build_closure_iterator_for_of(
     result_init: &Expr,
     iterable: Box<Expr>,
     span: Span,
+    helper_context: &ForOfHelperContext,
 ) -> Option<ForOfStmt> {
     if !is_iterator_next_call(result_init, iterator_ident)
         || !is_not_done_test(for_stmt.test.as_deref()?, result_ident)
@@ -702,7 +730,13 @@ fn build_closure_iterator_for_of(
             stmts: vec![body.clone()],
         },
     };
-    build_helper_for_of(loop_body, iterable, result_ident.clone(), span)
+    build_helper_for_of(
+        loop_body,
+        iterable,
+        result_ident.clone(),
+        span,
+        helper_context,
+    )
 }
 
 fn extract_closure_iterator_init(
@@ -760,8 +794,11 @@ fn extract_closure_make_iterator_arg(
     Some(arg.expr.clone())
 }
 
-fn try_convert_iterator_helper_sequence(stmts: &[Stmt]) -> Option<SequenceRewrite> {
-    if let Some(rewrite) = try_convert_iterator_helper_decl_first_sequence(stmts) {
+fn try_convert_iterator_helper_sequence(
+    stmts: &[Stmt],
+    helper_context: &ForOfHelperContext,
+) -> Option<SequenceRewrite> {
+    if let Some(rewrite) = try_convert_iterator_helper_decl_first_sequence(stmts, helper_context) {
         return Some(rewrite);
     }
 
@@ -799,7 +836,13 @@ fn try_convert_iterator_helper_sequence(stmts: &[Stmt]) -> Option<SequenceRewrit
         return None;
     }
 
-    let for_of = build_helper_for_of(helper_loop, iterable, item_ident, stmts[0].span())?;
+    let for_of = build_helper_for_of(
+        helper_loop,
+        iterable,
+        item_ident,
+        stmts[0].span(),
+        helper_context,
+    )?;
     Some(SequenceRewrite {
         consumed_stmts,
         preserved_stmts,
@@ -807,7 +850,10 @@ fn try_convert_iterator_helper_sequence(stmts: &[Stmt]) -> Option<SequenceRewrit
     })
 }
 
-fn try_convert_iterator_helper_decl_first_sequence(stmts: &[Stmt]) -> Option<SequenceRewrite> {
+fn try_convert_iterator_helper_decl_first_sequence(
+    stmts: &[Stmt],
+    helper_context: &ForOfHelperContext,
+) -> Option<SequenceRewrite> {
     let helper_decl = stmt_as_single_var_decl(stmts.first()?)?;
     let helper_ident = pat_as_ident(&helper_decl.decls[0].name)?.id.clone();
     let iterable = extract_single_call_arg(helper_decl.decls[0].init.as_ref()?)?;
@@ -821,7 +867,13 @@ fn try_convert_iterator_helper_decl_first_sequence(stmts: &[Stmt]) -> Option<Seq
         return None;
     }
 
-    let for_of = build_helper_for_of(helper_loop, iterable, item_ident, stmts[0].span())?;
+    let for_of = build_helper_for_of(
+        helper_loop,
+        iterable,
+        item_ident,
+        stmts[0].span(),
+        helper_context,
+    )?;
     Some(SequenceRewrite {
         consumed_stmts: 3,
         preserved_stmts: Vec::new(),
@@ -829,7 +881,10 @@ fn try_convert_iterator_helper_decl_first_sequence(stmts: &[Stmt]) -> Option<Seq
     })
 }
 
-fn try_convert_loose_iterator_sequence(stmts: &[Stmt]) -> Option<SequenceRewrite> {
+fn try_convert_loose_iterator_sequence(
+    stmts: &[Stmt],
+    helper_context: &ForOfHelperContext,
+) -> Option<SequenceRewrite> {
     let item_ident = empty_single_var_ident(stmts.first()?)?;
     let Stmt::For(for_stmt) = stmts.get(1)? else {
         return None;
@@ -857,7 +912,13 @@ fn try_convert_loose_iterator_sequence(stmts: &[Stmt]) -> Option<SequenceRewrite
     let Stmt::Block(body) = &*for_stmt.body else {
         return None;
     };
-    let for_of = build_helper_for_of(body.clone(), iterable, item_ident, stmts[0].span())?;
+    let for_of = build_helper_for_of(
+        body.clone(),
+        iterable,
+        item_ident,
+        stmts[0].span(),
+        helper_context,
+    )?;
     Some(SequenceRewrite {
         consumed_stmts: 2,
         preserved_stmts: Vec::new(),
@@ -885,6 +946,7 @@ fn try_convert_ts_values_sequence(
         helper_loop.iterable,
         helper_loop.result_ident,
         stmts[0].span(),
+        helper_context,
     )?;
     Some(SequenceRewrite {
         consumed_stmts: 3,
@@ -893,7 +955,10 @@ fn try_convert_ts_values_sequence(
     })
 }
 
-fn try_convert_swc_iterator_sequence(stmts: &[Stmt]) -> Option<SequenceRewrite> {
+fn try_convert_swc_iterator_sequence(
+    stmts: &[Stmt],
+    helper_context: &ForOfHelperContext,
+) -> Option<SequenceRewrite> {
     let normal_ident = single_var_ident_with_bool(stmts.first()?, true)?;
     let did_error_ident = single_var_ident_with_bool(stmts.get(1)?, false)?;
     let error_ident = empty_single_var_ident(stmts.get(2)?)?;
@@ -925,6 +990,7 @@ fn try_convert_swc_iterator_sequence(stmts: &[Stmt]) -> Option<SequenceRewrite> 
         helper_loop.iterable,
         helper_loop.result_ident,
         stmts[0].span(),
+        helper_context,
     )?;
     Some(SequenceRewrite {
         consumed_stmts: 4,
@@ -1072,6 +1138,7 @@ fn build_helper_for_of(
     iterable: Box<Expr>,
     item_ident: Ident,
     span: Span,
+    helper_context: &ForOfHelperContext,
 ) -> Option<ForOfStmt> {
     let mut element = extract_iterator_value_element(&body.stmts, &item_ident);
     if element.is_none() {
@@ -1090,50 +1157,77 @@ fn build_helper_for_of(
         }
         replace_iterator_value_refs(&mut body, &item_ident);
     }
-    let (pat, bindings, kind, consumed_stmts, temp_ident) = if let Some(element) = element {
-        (
-            element.pat,
-            element.bindings,
-            element.kind,
-            element.consumed_stmts,
-            element.temp_ident,
-        )
+    let mut element = if let Some(element) = element {
+        element
     } else {
-        (
-            Pat::Ident(BindingIdent {
+        LoopElement {
+            pat: Pat::Ident(BindingIdent {
                 id: item_ident.clone(),
                 type_ann: None,
             }),
-            vec![item_ident.clone()],
-            VarDeclKind::Const,
-            0,
-            None,
-        )
+            bindings: vec![item_ident.clone()],
+            kind: VarDeclKind::Const,
+            temp_ident: None,
+            consumed_stmts: 0,
+            allow_ident_fallback: false,
+            temp_kind: VarDeclKind::Const,
+        }
     };
 
-    let mut remaining_body = body.stmts[consumed_stmts..].to_vec();
-    if consumed_stmts > 0
+    // Remaining-body uses / eval must be checked against the ArrayPat
+    // remainder before any ident fallback, so `eval("pair")` still
+    // fail-closes the whole helper.
+    if let Some(id) = element.temp_ident.clone() {
+        let remaining_after_pat = &body.stmts[element.consumed_stmts..];
+        if remaining_after_pat
+            .iter()
+            .any(|stmt| stmt_uses_ident(stmt, &id))
+            || dynamic_scope_observes_binding(remaining_after_pat, &id)
+        {
+            return None;
+        }
+        let var_temp = body
+            .stmts
+            .first()
+            .and_then(stmt_as_single_var_decl)
+            .is_some_and(|decl| decl.kind == VarDeclKind::Var);
+        if array_pat_left_is_unsound(
+            helper_context,
+            &iterable,
+            &body.stmts,
+            &id,
+            &element.pat,
+            &element.bindings,
+            var_temp,
+        ) && (!element.fallback_to_temp_ident()
+            || ident_fallback_tdz_in_iterable(&iterable, &element))
+        {
+            return None;
+        }
+    } else if matches!(element.pat, Pat::Array(_))
+        && expr_observes_lifted_names(&iterable, &element.bindings)
+    {
+        return None;
+    }
+
+    let mut remaining_body = body.stmts[element.consumed_stmts..].to_vec();
+    if element.consumed_stmts > 0
         && remaining_body
             .iter()
             .any(|stmt| stmt_uses_ident_key(stmt, &item_ident))
     {
         return None;
     }
-    if temp_ident
-        .as_ref()
-        .is_some_and(|id| remaining_body.iter().any(|stmt| stmt_uses_ident(stmt, id)))
-    {
-        return None;
-    }
 
     let body_uses = BindingUseIndex::collect_stmts(&remaining_body);
-    if writes_consumed_const(&body.stmts[..consumed_stmts], &body_uses) {
+    if writes_consumed_const(&body.stmts[..element.consumed_stmts], &body_uses) {
         return None;
     }
-    let is_reassigned = bindings
+    let is_reassigned = element
+        .bindings
         .iter()
         .any(|id| body_uses.has_direct_write(&id.to_id()));
-    let kind = if kind == VarDeclKind::Var {
+    let kind = if element.kind == VarDeclKind::Var {
         VarDeclKind::Var
     } else if is_reassigned {
         VarDeclKind::Let
@@ -1152,7 +1246,7 @@ fn build_helper_for_of(
             declare: false,
             decls: vec![VarDeclarator {
                 span: DUMMY_SP,
-                name: pat,
+                name: element.pat,
                 init: None,
                 definite: false,
             }],
@@ -1180,51 +1274,17 @@ fn extract_iterator_call_destructuring_element(
     }
 
     let temp_ident = &temp_binding.id;
-    let mut elems = Vec::new();
-    let mut bindings = Vec::new();
-    let mut kind = VarDeclKind::Const;
-    let mut consumed_stmts = 1;
-
-    for stmt in &stmts[1..] {
-        let Some(decl) = stmt_as_single_var_decl(stmt) else {
-            break;
-        };
-        let declarator = &decl.decls[0];
-        let expected_index = elems.len() as f64;
-        let Pat::Ident(binding) = &declarator.name else {
-            break;
-        };
-        let Some(init) = declarator.init.as_ref() else {
-            break;
-        };
-        if !is_numeric_index_access(init, &temp_ident.sym, expected_index) {
-            break;
-        }
-
-        elems.push(Some(Pat::Ident(BindingIdent {
-            id: binding.id.clone(),
-            type_ann: binding.type_ann.clone(),
-        })));
-        bindings.push(binding.id.clone());
-        kind = join_recovered_binding_kind(kind, decl.kind);
-        consumed_stmts += 1;
-    }
-
-    if elems.is_empty() {
-        return None;
-    }
+    let slots = consume_index_slots(&stmts[1..], temp_ident);
+    let (pat, bindings, kind, slot_consumed) = array_pat_from_index_slots(slots)?;
 
     Some(LoopElement {
-        pat: Pat::Array(ArrayPat {
-            span: DUMMY_SP,
-            elems,
-            optional: false,
-            type_ann: None,
-        }),
+        pat,
         bindings,
         kind,
         temp_ident: Some(temp_ident.clone()),
-        consumed_stmts,
+        consumed_stmts: 1 + slot_consumed,
+        allow_ident_fallback: false,
+        temp_kind: first_decl.kind,
     })
 }
 
@@ -1257,6 +1317,8 @@ fn extract_iterator_destructuring_decl_element(
         kind: first_decl.kind,
         temp_ident: None,
         consumed_stmts: 1,
+        allow_ident_fallback: false,
+        temp_kind: first_decl.kind,
     })
 }
 
@@ -1271,48 +1333,16 @@ fn extract_iterator_value_element(stmts: &[Stmt], item_ident: &Ident) -> Option<
     }
 
     let temp_ident = &binding.id;
-    let mut elems = Vec::new();
-    let mut bindings = Vec::new();
-    let mut kind = VarDeclKind::Const;
-    let mut consumed_stmts = 1;
-
-    for stmt in &stmts[1..] {
-        let Some(decl) = stmt_as_single_var_decl(stmt) else {
-            break;
-        };
-        let declarator = &decl.decls[0];
-        let expected_index = elems.len() as f64;
-        let Pat::Ident(binding) = &declarator.name else {
-            break;
-        };
-        let Some(init) = declarator.init.as_ref() else {
-            break;
-        };
-        if !is_numeric_index_access(init, &temp_ident.sym, expected_index) {
-            break;
-        }
-
-        elems.push(Some(Pat::Ident(BindingIdent {
-            id: binding.id.clone(),
-            type_ann: binding.type_ann.clone(),
-        })));
-        bindings.push(binding.id.clone());
-        kind = join_recovered_binding_kind(kind, decl.kind);
-        consumed_stmts += 1;
-    }
-
-    if !elems.is_empty() {
+    let slots = consume_index_slots(&stmts[1..], temp_ident);
+    if let Some((pat, bindings, kind, slot_consumed)) = array_pat_from_index_slots(slots) {
         return Some(LoopElement {
-            pat: Pat::Array(ArrayPat {
-                span: DUMMY_SP,
-                elems,
-                optional: false,
-                type_ann: None,
-            }),
+            pat,
             bindings,
             kind,
             temp_ident: Some(temp_ident.clone()),
-            consumed_stmts,
+            consumed_stmts: 1 + slot_consumed,
+            allow_ident_fallback: true,
+            temp_kind: first_decl.kind,
         });
     }
 
@@ -1322,6 +1352,8 @@ fn extract_iterator_value_element(stmts: &[Stmt], item_ident: &Ident) -> Option<
         kind: first_decl.kind,
         temp_ident: None,
         consumed_stmts: 1,
+        allow_ident_fallback: true,
+        temp_kind: first_decl.kind,
     })
 }
 
@@ -1817,11 +1849,11 @@ fn try_convert_for_of(stmt: &Stmt, helper_context: &ForOfHelperContext) -> Optio
     if block.stmts.is_empty() {
         return None;
     }
-    let element = extract_loop_element(&block.stmts, &access_obj, &idx_ident.sym)?;
+    let mut element = extract_loop_element(&block.stmts, &access_obj, &idx_ident.sym)?;
 
     // --- Safety: generated index/temp bindings must not be used in remaining body statements ---
-    let remaining_body = &block.stmts[element.consumed_stmts..];
-    for body_stmt in remaining_body {
+    let remaining_after_pat = &block.stmts[element.consumed_stmts..];
+    for body_stmt in remaining_after_pat {
         if stmt_uses_ident(body_stmt, idx_ident) {
             return None;
         }
@@ -1839,6 +1871,43 @@ fn try_convert_for_of(stmt: &Stmt, helper_context: &ForOfHelperContext) -> Optio
             return None;
         }
     }
+    if temp_ident
+        .as_ref()
+        .is_some_and(|id| dynamic_scope_observes_binding(remaining_after_pat, id))
+        || element
+            .temp_ident
+            .as_ref()
+            .is_some_and(|id| dynamic_scope_observes_binding(remaining_after_pat, id))
+    {
+        return None;
+    }
+    if let Some(id) = element.temp_ident.clone() {
+        let var_temp = block
+            .stmts
+            .first()
+            .and_then(stmt_as_single_var_decl)
+            .is_some_and(|decl| decl.kind == VarDeclKind::Var);
+        // Body-only liveness: a read in the for-init iterable is live for a
+        // function-scoped element temp, not an "inside" use of this loop.
+        if array_pat_left_is_unsound(
+            helper_context,
+            &iterable,
+            &block.stmts,
+            &id,
+            &element.pat,
+            &element.bindings,
+            var_temp,
+        ) && (!element.fallback_to_temp_ident()
+            || ident_fallback_tdz_in_iterable(&iterable, &element))
+        {
+            return None;
+        }
+    } else if matches!(element.pat, Pat::Array(_))
+        && expr_observes_lifted_names(&iterable, &element.bindings)
+    {
+        return None;
+    }
+    let remaining_body = &block.stmts[element.consumed_stmts..];
 
     // Analyze the remaining body after consuming the element declaration.
     // Shared write analysis includes nested targets and distinguishes shadowed bindings.
@@ -1899,6 +1968,32 @@ struct LoopElement {
     kind: VarDeclKind,
     temp_ident: Option<Ident>,
     consumed_stmts: usize,
+    /// Ident fallback is only valid when `temp` *is* the iterator value
+    /// (`step.value` / `arr[i]`). A helper-call temp (`_slicedToArray`) is a
+    /// converted array; dropping the call would change the observable value.
+    allow_ident_fallback: bool,
+    /// Kind of the original temp declaration (`const pair`), not the slot
+    /// join (`var value`). Ident fallback must restore this kind.
+    temp_kind: VarDeclKind,
+}
+
+impl LoopElement {
+    fn fallback_to_temp_ident(&mut self) -> bool {
+        if !self.allow_ident_fallback {
+            return false;
+        }
+        let Some(id) = self.temp_ident.take() else {
+            return false;
+        };
+        self.pat = Pat::Ident(BindingIdent {
+            id: id.clone(),
+            type_ann: None,
+        });
+        self.bindings = vec![id];
+        self.kind = self.temp_kind;
+        self.consumed_stmts = 1;
+        true
+    }
 }
 
 /// Recovery must not turn an existing const-write error into a valid write.
@@ -1989,58 +2084,330 @@ fn extract_loop_element(stmts: &[Stmt], access_obj: &Expr, idx_sym: &Atom) -> Op
         return None;
     }
 
-    let mut elems = Vec::new();
-    let mut bindings = Vec::new();
-    let mut kind = VarDeclKind::Const;
-    let mut consumed_stmts = 1;
-
-    for stmt in &stmts[1..] {
-        let Some(decl) = stmt_as_single_var_decl(stmt) else {
-            break;
-        };
-        let declarator = &decl.decls[0];
-        let expected_index = elems.len() as f64;
-        let Pat::Ident(binding) = &declarator.name else {
-            break;
-        };
-        let Some(init) = declarator.init.as_ref() else {
-            break;
-        };
-        if !is_numeric_index_access(init, &temp_ident.sym, expected_index) {
-            break;
-        }
-
-        elems.push(Some(Pat::Ident(BindingIdent {
-            id: binding.id.clone(),
-            type_ann: binding.type_ann.clone(),
-        })));
-        bindings.push(binding.id.clone());
-        kind = join_recovered_binding_kind(kind, decl.kind);
-        consumed_stmts += 1;
-    }
-
-    if elems.is_empty() {
+    let slots = consume_index_slots(&stmts[1..], temp_ident);
+    if let Some((pat, bindings, kind, slot_consumed)) = array_pat_from_index_slots(slots) {
         return Some(LoopElement {
-            pat: Pat::Ident(temp_binding.clone()),
-            bindings: vec![temp_binding.id.clone()],
-            kind: first_decl.kind,
-            temp_ident: None,
-            consumed_stmts,
+            pat,
+            bindings,
+            kind,
+            temp_ident: Some(temp_ident.clone()),
+            consumed_stmts: 1 + slot_consumed,
+            allow_ident_fallback: true,
+            temp_kind: first_decl.kind,
         });
     }
 
     Some(LoopElement {
-        pat: Pat::Array(ArrayPat {
+        pat: Pat::Ident(temp_binding.clone()),
+        bindings: vec![temp_binding.id.clone()],
+        kind: first_decl.kind,
+        temp_ident: None,
+        consumed_stmts: 1,
+        allow_ident_fallback: true,
+        temp_kind: first_decl.kind,
+    })
+}
+
+enum IndexSlot {
+    Binding {
+        ident: Ident,
+        type_ann: Option<Box<swc_core::ecma::ast::TsTypeAnn>>,
+        kind: VarDeclKind,
+    },
+    Hole,
+}
+
+struct ConsumedIndexSlots {
+    elems: Vec<Option<Pat>>,
+    bindings: Vec<Ident>,
+    kind: VarDeclKind,
+    consumed: usize,
+}
+
+/// Consecutive `temp[0]`, `temp[1]`, … on one binding identity.
+/// `const x = temp[i]` becomes a pattern slot; a bare `temp[i];` is a hole.
+/// Stop at the first non-slot. Holes do not invent a name.
+fn consume_index_slots(stmts: &[Stmt], temp: &Ident) -> ConsumedIndexSlots {
+    let mut elems = Vec::new();
+    let mut bindings = Vec::new();
+    let mut kind = VarDeclKind::Const;
+    let mut consumed = 0;
+
+    for stmt in stmts {
+        let expected = elems.len() as f64;
+        let Some(slot) = take_index_slot(stmt, temp, expected) else {
+            break;
+        };
+        match slot {
+            IndexSlot::Binding {
+                ident,
+                type_ann,
+                kind: slot_kind,
+            } => {
+                elems.push(Some(Pat::Ident(BindingIdent {
+                    id: ident.clone(),
+                    type_ann,
+                })));
+                bindings.push(ident);
+                kind = join_recovered_binding_kind(kind, slot_kind);
+            }
+            IndexSlot::Hole => elems.push(None),
+        }
+        consumed += 1;
+    }
+
+    ConsumedIndexSlots {
+        elems,
+        bindings,
+        kind,
+        consumed,
+    }
+}
+
+fn array_pat_from_index_slots(
+    slots: ConsumedIndexSlots,
+) -> Option<(Pat, Vec<Ident>, VarDeclKind, usize)> {
+    if slots.elems.is_empty() || slots.bindings.is_empty() {
+        return None;
+    }
+    Some((
+        Pat::Array(ArrayPat {
             span: DUMMY_SP,
-            elems,
+            elems: slots.elems,
             optional: false,
             type_ann: None,
         }),
-        bindings,
+        slots.bindings,
+        slots.kind,
+        slots.consumed,
+    ))
+}
+
+fn take_index_slot(stmt: &Stmt, temp: &Ident, expected: f64) -> Option<IndexSlot> {
+    if let Some(decl) = stmt_as_single_var_decl(stmt) {
+        let declarator = &decl.decls[0];
+        let Pat::Ident(binding) = &declarator.name else {
+            return None;
+        };
+        let init = declarator.init.as_ref()?;
+        if !is_numeric_index_access_key(init, temp, expected) {
+            return None;
+        }
+        return Some(IndexSlot::Binding {
+            ident: binding.id.clone(),
+            type_ann: binding.type_ann.clone(),
+            kind: decl.kind,
+        });
+    }
+
+    let Stmt::Expr(ExprStmt { expr, .. }) = stmt else {
+        return None;
+    };
+    if is_numeric_index_access_key(expr, temp, expected) {
+        return Some(IndexSlot::Hole);
+    }
+    None
+}
+
+/// Direct `eval` / `with` in `stmts` can observe `ident` by printed name.
+/// Unknown eval sources and any `with` fail closed; a known string blocks
+/// only when it mentions the binding (same contract as `dead_decls`).
+fn dynamic_scope_observes_binding(stmts: &[Stmt], ident: &Ident) -> bool {
+    struct WithFinder {
+        found: bool,
+    }
+    impl Visit for WithFinder {
+        fn visit_with_stmt(&mut self, _: &swc_core::ecma::ast::WithStmt) {
+            self.found = true;
+        }
+        fn visit_stmt(&mut self, stmt: &Stmt) {
+            if !self.found {
+                stmt.visit_children_with(self);
+            }
+        }
+    }
+
+    let mut withs = WithFinder { found: false };
+    for stmt in stmts {
+        stmt.visit_with(&mut withs);
+        if withs.found {
+            return true;
+        }
+    }
+
+    let mut eval = DirectEvalAnalyzer::default();
+    for stmt in stmts {
+        stmt.visit_with(&mut eval);
+    }
+    eval.unknown_direct_eval
+        || eval
+            .known_direct_eval_sources
+            .iter()
+            .any(|source| js_source_mentions_binding(source, &ident.sym))
+}
+
+/// ArrayPat left is unsound when the original temp still escapes, a `var`
+/// temp is visible to module-level eval/`with`, or lifting the recovered
+/// bindings would put those names in TDZ while the iterable runs.
+fn array_pat_left_is_unsound(
+    helper_context: &ForOfHelperContext,
+    iterable: &Expr,
+    inside: &[Stmt],
+    temp: &Ident,
+    pat: &Pat,
+    lifted: &[Ident],
+    var_temp: bool,
+) -> bool {
+    helper_context.binding_is_used_outside(inside, temp)
+        || (var_temp && helper_context.dynamic_scope_can_observe_name(&temp.sym))
+        || (matches!(pat, Pat::Array(_)) && expr_observes_lifted_names(iterable, lifted))
+}
+
+fn expr_observes_lifted_names(expr: &Expr, lifted: &[Ident]) -> bool {
+    let names: HashSet<Atom> = lifted.iter().map(|id| id.sym.clone()).collect();
+    expr_observes_printed_names(expr, &names)
+}
+
+/// Ident fallback of a lexical temp puts that name in TDZ on the iterable.
+/// Unknown eval is treated the same. `var` is hoisted, so it is not TDZ.
+fn ident_fallback_tdz_in_iterable(iterable: &Expr, element: &LoopElement) -> bool {
+    if element.kind == VarDeclKind::Var {
+        return false;
+    }
+    let Pat::Ident(binding) = &element.pat else {
+        return false;
+    };
+    let names: HashSet<Atom> = [binding.id.sym.clone()].into_iter().collect();
+    expr_observes_printed_names(iterable, &names)
+}
+
+/// Lifting body bindings into the for-of head puts those names in TDZ while
+/// the iterable runs. Fail closed if the RHS already mentions a dropped or
+/// lifted printed name, or a direct eval/`with` that could.
+fn for_of_right_observes_fold_names(right: &Expr, dropped: &Ident, lifted: &[Ident]) -> bool {
+    let mut names: HashSet<Atom> = lifted.iter().map(|id| id.sym.clone()).collect();
+    names.insert(dropped.sym.clone());
+    expr_observes_printed_names(right, &names)
+}
+
+fn expr_observes_printed_names(expr: &Expr, names: &HashSet<Atom>) -> bool {
+    if names.is_empty() {
+        return false;
+    }
+
+    struct Finder<'a> {
+        names: &'a HashSet<Atom>,
+        found: bool,
+    }
+    impl Visit for Finder<'_> {
+        fn visit_ident(&mut self, ident: &Ident) {
+            if !self.found && self.names.contains(&ident.sym) {
+                self.found = true;
+            }
+        }
+        fn visit_with_stmt(&mut self, _: &swc_core::ecma::ast::WithStmt) {
+            self.found = true;
+        }
+        fn visit_stmt(&mut self, stmt: &Stmt) {
+            if !self.found {
+                stmt.visit_children_with(self);
+            }
+        }
+    }
+
+    let mut finder = Finder {
+        names,
+        found: false,
+    };
+    expr.visit_with(&mut finder);
+    if finder.found {
+        return true;
+    }
+
+    let mut eval = DirectEvalAnalyzer::default();
+    expr.visit_with(&mut eval);
+    eval.unknown_direct_eval
+        || eval.known_direct_eval_sources.iter().any(|source| {
+            names
+                .iter()
+                .any(|name| js_source_mentions_binding(source, name))
+        })
+}
+
+fn try_fold_for_of_entry_slots(for_of: &mut ForOfStmt, helper_context: &ForOfHelperContext) {
+    let ForHead::VarDecl(decl) = &for_of.left else {
+        return;
+    };
+    if decl.decls.len() != 1 {
+        return;
+    }
+    let declarator = &decl.decls[0];
+    if declarator.init.is_some() {
+        return;
+    }
+    let Pat::Ident(binding) = &declarator.name else {
+        return;
+    };
+    let left_kind = decl.kind;
+    let temp = binding.id.clone();
+
+    let Stmt::Block(body) = &*for_of.body else {
+        return;
+    };
+    // Count only body uses as "inside". The iterable / after-loop reads of a
+    // function-scoped left binding are live and must keep the ident.
+    if helper_context.binding_is_used_outside(&body.stmts, &temp) {
+        return;
+    }
+    // `var` leaks past the loop. `with` / unknown direct eval anywhere in
+    // the module, or a known eval source that mentions the name, can still
+    // observe it after we drop the left ident.
+    if left_kind == VarDeclKind::Var && helper_context.dynamic_scope_can_observe_name(&temp.sym) {
+        return;
+    }
+    let slots = consume_index_slots(&body.stmts, &temp);
+    let Some((pat, bindings, slot_kind, consumed)) = array_pat_from_index_slots(slots) else {
+        return;
+    };
+    let remaining = body.stmts[consumed..].to_vec();
+    if remaining.iter().any(|stmt| stmt_uses_ident(stmt, &temp))
+        || dynamic_scope_observes_binding(&remaining, &temp)
+        || for_of_right_observes_fold_names(&for_of.right, &temp, &bindings)
+    {
+        return;
+    }
+
+    let body_uses = BindingUseIndex::collect_stmts(&remaining);
+    let is_reassigned = bindings
+        .iter()
+        .any(|id| body_uses.has_direct_write(&id.to_id()));
+    let kind = if slot_kind == VarDeclKind::Var {
+        VarDeclKind::Var
+    } else if is_reassigned {
+        VarDeclKind::Let
+    } else {
+        slot_kind
+    };
+
+    let body_span = body.span;
+    let body_ctxt = body.ctxt;
+    for_of.left = ForHead::VarDecl(Box::new(VarDecl {
+        span: DUMMY_SP,
+        ctxt: Default::default(),
         kind,
-        temp_ident: Some(temp_ident.clone()),
-        consumed_stmts,
-    })
+        declare: false,
+        decls: vec![VarDeclarator {
+            span: DUMMY_SP,
+            name: pat,
+            init: None,
+            definite: false,
+        }],
+    }));
+    *for_of.body = Stmt::Block(BlockStmt {
+        span: body_span,
+        ctxt: body_ctxt,
+        stmts: remaining,
+    });
 }
 
 fn stmt_as_single_var_decl(stmt: &Stmt) -> Option<&VarDecl> {
@@ -2063,11 +2430,16 @@ fn is_index_access(expr: &Expr, obj_expr: &Expr, idx_sym: &Atom) -> bool {
     is_ident(&computed.expr, idx_sym)
 }
 
-fn is_numeric_index_access(expr: &Expr, obj_sym: &Atom, index: f64) -> bool {
-    let Expr::Member(MemberExpr { obj, prop, .. }) = expr else {
+fn is_numeric_index_access_key(expr: &Expr, obj: &Ident, index: f64) -> bool {
+    let Expr::Member(MemberExpr {
+        obj: member_obj,
+        prop,
+        ..
+    }) = strip_parens(expr)
+    else {
         return false;
     };
-    if !is_ident(obj, obj_sym) {
+    if !is_ident_key(member_obj, obj) {
         return false;
     }
     let MemberProp::Computed(computed) = prop else {

--- a/crates/core/src/rules/un_for_of.rs
+++ b/crates/core/src/rules/un_for_of.rs
@@ -2109,11 +2109,7 @@ fn extract_loop_element(stmts: &[Stmt], access_obj: &Expr, idx_sym: &Atom) -> Op
 }
 
 enum IndexSlot {
-    Binding {
-        ident: Ident,
-        type_ann: Option<Box<swc_core::ecma::ast::TsTypeAnn>>,
-        kind: VarDeclKind,
-    },
+    Binding { ident: Ident, kind: VarDeclKind },
     Hole,
 }
 
@@ -2141,12 +2137,13 @@ fn consume_index_slots(stmts: &[Stmt], temp: &Ident) -> ConsumedIndexSlots {
         match slot {
             IndexSlot::Binding {
                 ident,
-                type_ann,
                 kind: slot_kind,
             } => {
                 elems.push(Some(Pat::Ident(BindingIdent {
                     id: ident.clone(),
-                    type_ann,
+                    // A declaration-level TypeScript annotation is not valid
+                    // on an individual ArrayPat element.
+                    type_ann: None,
                 })));
                 bindings.push(ident);
                 kind = join_recovered_binding_kind(kind, slot_kind);
@@ -2195,7 +2192,6 @@ fn take_index_slot(stmt: &Stmt, temp: &Ident, expected: f64) -> Option<IndexSlot
         }
         return Some(IndexSlot::Binding {
             ident: binding.id.clone(),
-            type_ann: binding.type_ann.clone(),
             kind: decl.kind,
         });
     }
@@ -2378,6 +2374,9 @@ fn try_fold_for_of_entry_slots(for_of: &mut ForOfStmt, helper_context: &ForOfHel
     }
 
     let body_uses = BindingUseIndex::collect_stmts(&remaining);
+    if writes_consumed_const(&body.stmts[..consumed], &body_uses) {
+        return;
+    }
     let is_reassigned = bindings
         .iter()
         .any(|id| body_uses.has_direct_write(&id.to_id()));

--- a/crates/core/tests/un_for_of_rule.rs
+++ b/crates/core/tests/un_for_of_rule.rs
@@ -1129,3 +1129,730 @@ for (const item of items) {
 "#;
     assert_eq_normalized(&render(input), expected);
 }
+
+// Babel loose Map/array entries: unused key DCE leaves `pair[0];` as an
+// expression statement. Recover a hole, never invent a binding name.
+// leftover of for-init sequence order (#224); does not skip intervening
+// statements between `let step` and the helper `for`.
+
+#[test]
+fn for_of_from_babel_loose_discards_unused_index_as_hole() {
+    // Terser with unused key: `const key = pair[0]` becomes `pair[0];`.
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const [, value] of entries) {
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn for_of_folds_discarded_index_from_existing_for_of_ident() {
+    let input = r#"
+for (const pair of entries) {
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const [, value] of entries) {
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fold_preserves_nested_write_mutability() {
+    let input = r#"
+for (const pair of entries) {
+  pair[0];
+  let value = pair[1];
+  out[value = next()] = true;
+}
+"#;
+    let expected = r#"
+for (let [, value] of entries) {
+  out[value = next()] = true;
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn for_of_from_sliced_to_array_discards_unused_index_as_hole() {
+    let input = r#"
+const iterator = _createForOfIteratorHelper(entries);
+let step;
+try {
+  for (iterator.s(); !(step = iterator.n()).done;) {
+    const pair = _slicedToArray(step.value, 2);
+    pair[0];
+    const value = pair[1];
+    use(value);
+  }
+} catch (err) {
+  iterator.e(err);
+} finally {
+  iterator.f();
+}
+"#;
+    let expected = r#"
+for (const [, value] of entries) {
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn for_of_from_index_form_discards_unused_index_as_hole() {
+    let input = r#"for (let i = 0; i < entries.length; i++) { const _entry = entries[i]; _entry[0]; const value = _entry[1]; use(value); }"#;
+    let expected = r#"for (const [, value] of entries) { use(value); }"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn for_of_named_key_binding_is_not_a_hole() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  const key = pair[0];
+  const value = pair[1];
+  use(key, value);
+}
+"#;
+    let expected = r#"
+for (const [key, value] of entries) {
+  use(key, value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_on_non_consecutive_first_slot() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries) {
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_on_length_between_slots() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair.length;
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries) {
+  pair.length;
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_when_temp_used_later() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0];
+  const value = pair[1];
+  use(pair, value);
+}
+"#;
+    // Slot recovery would keep `pair` live; leave the helper loop untouched.
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_on_later_reread() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0];
+  const value = pair[1];
+  use(value, pair[0]);
+}
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_on_assignment() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0] = 0;
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries) {
+  pair[0] = 0;
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_on_update() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0]++;
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries) {
+  pair[0]++;
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_on_delete() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  delete pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries) {
+  delete pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_on_call() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0]();
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries) {
+  pair[0]();
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_on_void() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  void pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries) {
+  void pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_on_comma_expr() {
+    // SimplifySequence splits the comma before UnForOf; the leftover `pair[0];`
+    // must not become a hole because `other()` sits between slots.
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0], other();
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries) {
+  pair[0];
+  other();
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fails_closed_on_shadowed_temp_between_slots() {
+    // A nested binding with the same spelling is not an outer slot.
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  {
+    const pair = other;
+    pair[0];
+  }
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries) {
+  {
+    const pair = other;
+    pair[0];
+  }
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fold_succeeds_when_remaining_shadows_temp_name() {
+    // After the slots, a nested binding with the same spelling is not a
+    // live use of the outer loop ident (sym + ctxt).
+    let input = r#"
+for (const pair of entries) {
+  pair[0];
+  const value = pair[1];
+  {
+    const pair = other;
+    use(pair);
+  }
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const [, value] of entries) {
+  {
+    const pair = other;
+    use(pair);
+  }
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fold_fails_closed_when_var_left_used_after_loop() {
+    // `var` leaks out of the for-of. Dropping `pair` would leave the later
+    // read unresolved.
+    let input = r#"
+for (var pair of entries) {
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+use(pair);
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_fold_fails_closed_when_var_left_used_in_rhs() {
+    // The iterable is not the loop body; `pair` there is a live read of the
+    // function-scoped left binding and must keep it.
+    let input = r#"
+for (var pair of entries(pair)) {
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_extract_keeps_var_temp_used_after_loop() {
+    // `var pair` inside the helper body is function-scoped. Recovering
+    // `[, value]` would drop it while the later read still observes it.
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  var pair = step.value;
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+use(pair);
+"#;
+    let expected = r#"
+for (var pair of entries) {
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+use(pair);
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_index_form_keeps_var_temp_used_after_loop() {
+    let input = r#"
+for (let i = 0; i < entries.length; i++) {
+  var _e = entries[i];
+  _e[0];
+  const value = _e[1];
+  use(value);
+}
+use(_e);
+"#;
+    let expected = r#"
+for (var _e of entries) {
+  _e[0];
+  const value = _e[1];
+  use(value);
+}
+use(_e);
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fold_fails_closed_when_lifted_binding_is_free_in_rhs() {
+    // Lifting `value` into the for-of head would put `entries(value)` in TDZ.
+    let input = r#"
+for (const pair of entries(value)) {
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_fold_fails_closed_on_eval_in_rhs_mentioning_lifted() {
+    let input = r#"
+for (const pair of eval("value")) {
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_extract_fails_closed_when_lifted_binding_is_free_in_iterable() {
+    // Helper conversion lifts `value` into the for-of head. The iterable
+    // already reads that printed name; ArrayPat would put it in TDZ.
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries(value)); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries(value)) {
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_extract_fails_closed_on_eval_in_iterable_mentioning_lifted() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(eval("value")); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of eval("value")) {
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_index_form_fails_closed_when_lifted_binding_is_free_in_iterable() {
+    let input = r#"for (let i = 0, entries_1 = items(value); i < entries_1.length; i++) { const _entry = entries_1[i]; _entry[0]; const value = _entry[1]; use(value); }"#;
+    let expected =
+        r#"for (const _entry of items(value)) { _entry[0]; const value = _entry[1]; use(value); }"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_extract_keeps_sliced_to_array_when_var_temp_used_after_loop() {
+    // Ident fallback would drop `_slicedToArray` while `pair` still escapes.
+    // Keep the helper loop so the converted array identity stays observable.
+    let input = r#"
+const iterator = _createForOfIteratorHelper(entries);
+let step;
+try {
+  for (iterator.s(); !(step = iterator.n()).done;) {
+    var pair = _slicedToArray(step.value, 2);
+    pair[0];
+    const value = pair[1];
+    use(value);
+  }
+} catch (err) {
+  iterator.e(err);
+} finally {
+  iterator.f();
+}
+use(pair);
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_extract_fails_closed_when_ident_fallback_would_tdz_temp() {
+    // ArrayPat is unsound because `value` is free in the iterable. Ident
+    // fallback would bind `pair` on the left and put `entries(pair, …)` in TDZ.
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries(pair, value)); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_index_form_fails_closed_when_ident_fallback_would_tdz_temp() {
+    let input = r#"for (let i = 0, entries_1 = items(_entry, value); i < entries_1.length; i++) { const _entry = entries_1[i]; _entry[0]; const value = _entry[1]; use(value); }"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_extract_fails_closed_on_unknown_eval_in_iterable() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(eval(code)); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0];
+  const value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_extract_ident_fallback_keeps_original_temp_kind() {
+    // Slot `var value` must not leak onto Ident fallback. The original temp is
+    // `const pair`; keep that kind when ArrayPat is unsound because of TDZ.
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries(value)); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0];
+  var value = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const pair of entries(value)) {
+  pair[0];
+  var value = pair[1];
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_index_form_keeps_var_temp_read_from_iterable() {
+    // The element temp is declared in the body. A read in the for-init
+    // iterable is not an "inside" use; dropping `_e` would leave `items(_e)`
+    // resolving to an outer binding.
+    let input = r#"for (let i = 0, entries_1 = items(_e); i < entries_1.length; i++) { var _e = entries_1[i]; _e[0]; const value = _e[1]; use(value); }"#;
+    let expected = r#"for (var _e of items(_e)) { _e[0]; const value = _e[1]; use(value); }"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fold_fails_closed_on_eval_mentioning_temp() {
+    // Direct eval can read the loop binding by name. Known source mentioning
+    // `pair` must not drop it.
+    let input = r#"
+for (const pair of entries) {
+  pair[0];
+  const value = pair[1];
+  eval("pair");
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_fold_fails_closed_on_unknown_eval() {
+    let input = r#"
+for (const pair of entries) {
+  pair[0];
+  const value = pair[1];
+  eval(code);
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_fold_fails_closed_on_with_in_body() {
+    let input = r#"
+for (const pair of entries) {
+  pair[0];
+  const value = pair[1];
+  with (obj) use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_fold_keeps_eval_that_does_not_mention_temp() {
+    let input = r#"
+for (const pair of entries) {
+  pair[0];
+  const value = pair[1];
+  eval("value");
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const [, value] of entries) {
+  eval("value");
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_extract_fails_closed_on_eval_mentioning_temp() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0];
+  const value = pair[1];
+  eval("pair");
+  use(value);
+}
+"#;
+    assert_eq_normalized(&render(input), input);
+}
+
+#[test]
+fn discarded_index_hole_does_not_emit_elision_only_pattern() {
+    let input = r#"
+let step;
+for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
+  const pair = step.value;
+  pair[0];
+  pair[1];
+  use(other);
+}
+"#;
+    let expected = r#"
+for (const pair of entries) {
+  pair[0];
+  pair[1];
+  use(other);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn loose_iterator_helper_does_not_skip_intervening_stmts() {
+    // Out of scope (separate leftover): `let step` must stay adjacent to the helper for.
+    let input = r#"
+let step;
+const acc = [];
+for (const iterator = _createForOfIteratorHelperLoose(items); !(step = iterator()).done;) {
+  const item = step.value;
+  acc.push(item);
+}
+"#;
+    let expected = r#"
+let step;
+const acc = [];
+for (const iterator = _createForOfIteratorHelperLoose(items); !(step = iterator()).done;) {
+  const item = step.value;
+  acc.push(item);
+}
+"#;
+    assert_eq_normalized(&render(input), expected);
+}

--- a/crates/core/tests/un_for_of_rule.rs
+++ b/crates/core/tests/un_for_of_rule.rs
@@ -4,7 +4,10 @@ use common::{assert_eq_normalized, render, render_pipeline_until, render_rule};
 use wakaru_core::facts::{
     ModuleFacts, ModuleFactsMap, TypeScriptHelperExportFact, TypeScriptHelperKind,
 };
-use wakaru_core::{rules::UnForOf, validate_output_modules, OutputFindingKind, RewriteLevel};
+use wakaru_core::{
+    decompile, rules::UnForOf, validate_output_modules, DecompileOptions, OutputFindingKind,
+    RewriteLevel,
+};
 
 fn apply_with_level(input: &str, level: RewriteLevel) -> String {
     render_rule(input, |mark| UnForOf::new_with_mark(mark, level))
@@ -1187,6 +1190,48 @@ for (let [, value] of entries) {
 }
 "#;
     assert_eq_normalized(&render(input), expected);
+}
+
+#[test]
+fn discarded_index_hole_fold_preserves_const_write_errors() {
+    for write in ["value = next();", "out[value = next()] = true;"] {
+        let input = format!(
+            r#"
+for (const pair of entries) {{
+  pair[0];
+  const value = pair[1];
+  {write}
+}}
+"#
+        );
+        assert_eq_normalized(&apply_with_level(&input, RewriteLevel::Standard), &input);
+    }
+}
+
+#[test]
+fn discarded_index_hole_drops_slot_type_annotation() {
+    let input = r#"
+for (const pair of entries) {
+  pair[0];
+  const value: string = pair[1];
+  use(value);
+}
+"#;
+    let expected = r#"
+for (const [, value] of entries) {
+  use(value);
+}
+"#;
+    let output = decompile(
+        input,
+        DecompileOptions {
+            filename: "fixture.ts".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("TypeScript input should decompile")
+    .code;
+    assert_eq_normalized(&output, expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `extract_iterator_value_element` / `extract_iterator_call_destructuring_element` / `extract_loop_element` only accepted consecutive `VarDecl` slots. A discarded unused index is a bare `temp[i];` (`ExprStmt`), so `elems` stayed empty and the loop left became the whole entry.
- This PR recovers one shape: consecutive numeric indexes on the same binding identity (sym + ctxt). `const x = temp[i]` stays a binding; an unread `temp[i];` becomes an ArrayPat hole. No invented ident. At least one real binding, and `temp` must be dead after consume, or the rewrite is skipped.
- Does not invent a name for discarded `[0]`. Does not relax `let step` adjacency to the helper `for`. Unrecognized slots stay fail-closed.

Related: leftover from #224. Independent of UnEsm / hygiene / converter. Does not recover intervening stmts between `let step` and the helper `for`.

Please feel free to take it from here if that is easier.
Maintainer edits are enabled; I will rebase instead of merging if I need to update the branch.

## Reproduce

Producer: Babel Loose `for-of` on a Map/array iterator, unused key DCE'd to an expression statement.

```js
let step;
for (const iterator = _createForOfIteratorHelperLoose(entries); !(step = iterator()).done;) {
  const pair = step.value;
  pair[0];
  const value = pair[1];
  use(value);
}
```

`wakaru` today: `for (const pair of entries) { pair[0]; const value = pair[1]; use(value); }`.
After this change: `for (const [, value] of entries) { use(value); }`.

The same hole is recovered from `_slicedToArray(step.value, 2)`, from the indexed `arr[i]` form, and from an already-converted `for (const pair of …)` whose body still has the leftover index statements.

Covered by `for_of_from_babel_loose_discards_unused_index_as_hole`, `for_of_folds_discarded_index_from_existing_for_of_ident`, `for_of_from_sliced_to_array_discards_unused_index_as_hole`, `for_of_from_index_form_discards_unused_index_as_hole`, `for_of_named_key_binding_is_not_a_hole`, `loose_iterator_helper_does_not_skip_intervening_stmts`, and existing `no_transform_destructuring_when_temp_used_later` / `for_of_preserves_destructuring_from_iterator_result`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p wakaru-core --test un_for_of_rule`
